### PR TITLE
Distributed ARC uses setting which has missing value for callbacker a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Please note that if you are running multiple instances of BlockTX for resilience
 ### Callbacker
 
 Callbacker is a very simple microservice that is responsible for sending callbacks to clients when a transaction has
-been accepted by the Bitcoin network. To register a callback, the client must add the `X-Callback-Url` header to the
+been accepted by the Bitcoin network. To register a callback, the client must add the `X-CallbackUrl` header to the
 request. The callbacker will then send a POST request to the URL specified in the header, with the transaction ID in
 the body. See the [API documentation](#API) for more information.
 

--- a/cmd/metamorph.go
+++ b/cmd/metamorph.go
@@ -76,7 +76,7 @@ func StartMetamorph(logger utils.Logger) (func(), error) {
 
 	pm, statusMessageCh := initPeerManager(logger, s)
 
-	callbackerAddress, ok := gocore.Config().Get("callbacker_grpcAddress", "localhost:8002")
+	callbackerAddress, ok := gocore.Config().Get("callbackerAddress", "localhost:8002")
 	if !ok {
 		logger.Fatalf("no callbacker_grpcAddress setting found")
 	}

--- a/doc/README.md
+++ b/doc/README.md
@@ -48,7 +48,7 @@ they were mined. Metamorph is responsible for storing the transaction data.
 ### Callbacker
 
 Callbacker is a very simple microservice that is responsible for sending callbacks to clients when a transaction has
-been accepted by the Bitcoin network. To register a callback, the client must add the `X-Callback-Url` header to the
+been accepted by the Bitcoin network. To register a callback, the client must add the `X-CallbackUrl` header to the
 request. The callbacker will then send a POST request to the URL specified in the header, with the transaction ID in
 the body. See the [API documentation](/arc/api.html) for more information.
 


### PR DESCRIPTION
* Distributed ARC uses setting which has missing value for callbacker address in production. Thus metamorph can't call callbacker and the callbacks are not invoked.
* Fix wrong name of header in readme

