### PR TITLE
add retry policy for transactions that are not seen on the network fo…

### DIFF
--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -204,25 +204,21 @@ func (p *Processor) processExpiredSeenTransactions() {
 func (p *Processor) processExpiredTransactions() {
 	// filterFunc returns true if the transaction has not been seen on the network
 	filterFunc := func(p *processor_response.ProcessorResponse) bool {
-		return p.GetStatus() < metamorph_api.Status_SEEN_ON_NETWORK && time.Since(p.Start) > 60*time.Second
+		return p.GetStatus() < metamorph_api.Status_SEEN_ON_NETWORK && time.Since(p.Start) > UnseenTransactionRebroadcastingInterval*time.Second
 	}
 
 	// Resend transactions that have not been seen on the network every 60 seconds
 	// The Items() method will return a copy of the map, so we can iterate over it without locking
-	for range time.NewTicker(60 * time.Second).C {
+	for range time.NewTicker(UnseenTransactionRebroadcastingInterval * time.Second).C {
 		expiredTransactionItems := p.processorResponseMap.Items(filterFunc)
 		if len(expiredTransactionItems) > 0 {
 			p.logger.Infof("Resending %d expired transactions", len(expiredTransactionItems))
 			for txID, item := range expiredTransactionItems {
 				startTime := time.Now()
 				retries := item.GetRetries()
-				p.logger.Debugf("Resending expired tx: %s (%d retries)", txID, retries)
-				if retries >= 3 {
-					continue
-				} else if retries >= 2 {
-					p.logger.Debugf("Transaction %s has been retried 4 times, not resending", txID)
-					continue
-				} else if retries >= 1 {
+				item.IncrementRetry()
+
+				if retries >= MaxRetries {
 					// retried announcing 2 times, now sending GETDATA to peers to see if they have it
 					p.logger.Debugf("Re-getting expired tx: %s", txID)
 					p.pm.RequestTransaction(item.Hash)
@@ -242,8 +238,6 @@ func (p *Processor) processExpiredTransactions() {
 				}
 
 				p.retries.AddDuration(time.Since(startTime))
-
-				item.IncrementRetry()
 			}
 		}
 	}

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -219,7 +219,7 @@ func (p *Processor) processExpiredTransactions() {
 				item.IncrementRetry()
 
 				if retries > MaxRetries {
-					// Ssending GETDATA to peers to see if they have it
+					// Sending GETDATA to peers to see if they have it
 					p.logger.Debugf("Re-getting expired tx: %s", txID)
 					p.pm.RequestTransaction(item.Hash)
 					item.AddLog(

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -69,6 +69,14 @@ type Processor struct {
 	retries            *stat.AtomicStat
 }
 
+const (
+	// number of times we will retry broacasting transaction if we haven't seen it on the network
+	MaxRetries = 15
+	// length of interval for checking transactions if they are seen on the network
+	// if not we resend them again for a few times
+	UnseenTransactionRebroadcastingInterval = 180
+)
+
 func NewProcessor(s store.MetamorphStore, pm p2p.PeerManagerI, metamorphAddress string,
 	cbChannel chan *callbacker_api.Callback, btc blocktx.ClientI) *Processor {
 	if s == nil {

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -204,7 +204,7 @@ func (p *Processor) processExpiredSeenTransactions() {
 func (p *Processor) processExpiredTransactions() {
 	// filterFunc returns true if the transaction has not been seen on the network
 	filterFunc := func(p *processor_response.ProcessorResponse) bool {
-		return p.GetStatus() < metamorph_api.Status_SEEN_ON_NETWORK && time.Since(p.Start) > UnseenTransactionRebroadcastingInterval*time.Second
+		return p.GetStatus() < metamorph_api.Status_SEEN_ON_NETWORK && time.Since(p.Start) > UnseenTransactionRebroadcastingInterval * time.Second
 	}
 
 	// Resend transactions that have not been seen on the network every 60 seconds
@@ -218,8 +218,8 @@ func (p *Processor) processExpiredTransactions() {
 				retries := item.GetRetries()
 				item.IncrementRetry()
 
-				if retries >= MaxRetries {
-					// retried announcing 2 times, now sending GETDATA to peers to see if they have it
+				if retries > MaxRetries {
+					// Ssending GETDATA to peers to see if they have it
 					p.logger.Debugf("Re-getting expired tx: %s", txID)
 					p.pm.RequestTransaction(item.Hash)
 					item.AddLog(

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -74,7 +74,7 @@ const (
 	MaxRetries = 15
 	// length of interval for checking transactions if they are seen on the network
 	// if not we resend them again for a few times
-	UnseenTransactionRebroadcastingInterval = 180
+	UnseenTransactionRebroadcastingInterval = 60
 )
 
 func NewProcessor(s store.MetamorphStore, pm p2p.PeerManagerI, metamorphAddress string,

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -70,7 +70,7 @@ type Processor struct {
 }
 
 const (
-	// number of times we will retry broacasting transaction if we haven't seen it on the network
+	// number of times we will retry announcing transaction if we haven't seen it on the network
 	MaxRetries = 15
 	// length of interval for checking transactions if they are seen on the network
 	// if not we resend them again for a few times


### PR DESCRIPTION
We fix retry policy for the transactions that are broadcasted but never seen on the network. In that case we broadcast those transactions periodically for a few (15 now) times.  