### PR TITLE
change seen transaction expiration time from an hour to 24 hours

### DIFF
--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -103,7 +103,7 @@ func NewProcessor(s store.MetamorphStore, pm p2p.PeerManagerI, metamorphAddress 
 	logLevel, _ := gocore.Config().Get("logLevel")
 	logger := gocore.Log("proc", gocore.NewLogLevelFromString(logLevel))
 
-	mapExpiryStr, _ := gocore.Config().Get("processorCacheExpiryTime", "1h")
+	mapExpiryStr, _ := gocore.Config().Get("processorCacheExpiryTime", "24h")
 	mapExpiry, err := time.ParseDuration(mapExpiryStr)
 	if err != nil {
 		logger.Fatalf("Invalid processorCacheExpiryTime: %s", mapExpiryStr)


### PR DESCRIPTION
We noticed that transaction took almost 24 hours to confirm. In the code we remove (expire) transactions after 1 hour which means that transactions confirmed after 1 hour will not be able to change their state in database. 

Any consequent status check for the transaction return "SEEN_ON_NETWORK" and not "MINED". That's why we change expiration from 1 hour to 24.