### PR TITLE
remove incorrect block hash query

### DIFF
--- a/blocktx/store/sql/RegisterTransaction.go
+++ b/blocktx/store/sql/RegisterTransaction.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bitcoin-sv/arc/blocktx/blocktx_api"
 	"github.com/lib/pq"
-	"github.com/libsv/go-p2p/chaincfg/chainhash"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
@@ -86,34 +85,13 @@ func (s *SQL) RegisterTransaction(ctx context.Context, transaction *blocktx_api.
 			return "", nil, 0, err
 		}
 
-		rows, err := result.RowsAffected()
+		_, err = result.RowsAffected()
 		if err != nil {
 			if spanErr != nil {
 				spanErr.SetTag(string(ext.Error), true)
 				spanErr.LogFields(log.Error(err))
 			}
 			return "", nil, 0, err
-		}
-
-		if rows == 1 {
-			// We successfully updated the source and which means it had already been mined
-			// so we return the block hash and height
-			var blockHash chainhash.Hash
-			var blockHeight uint64
-
-			if spanErr != nil {
-				spanErr.SetTag("already_mined", true)
-			}
-			if err := s.db.QueryRowContext(ctx, queryGetBlockHashHeightForTransactionHash, transaction.Hash).Scan(&blockHash, &blockHeight); err != nil {
-				if spanErr != nil {
-					spanErr.SetTag(string(ext.Error), true)
-					spanErr.LogFields(log.Error(err))
-				}
-				return "", nil, 0, err
-			}
-
-			return transaction.Source, blockHash[:], blockHeight, nil
-
 		}
 
 		var source string


### PR DESCRIPTION
We had error in blocktx (issue BPAAS-934) because we incorrectly assumed that the block hash would be present at the point of query. Removed the assumption and query. 