### PR TITLE
Validate callback url in API and in metamorph

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -30,7 +30,7 @@ jobs:
         continue-on-error: true
         uses: securego/gosec@master
         with:
-          args: -exclude-dir=testdata -fmt=sonarqube -out gosec-report.json ./...
+          args: -exclude-dir=testdata -exclude-dir=test -exclude-dir=blocktx/store/sql -exclude-generated -fmt=sonarqube -out gosec-report.json ./...
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/api/handler/default_test.go
+++ b/api/handler/default_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"k8s.io/utils/ptr"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -135,10 +136,10 @@ func TestPOSTTransaction(t *testing.T) { //nolint:funlen
 		req.Header.Set(echo.HeaderContentType, echo.MIMETextPlain)
 
 		options := api.POSTTransactionParams{
-			XCallbackUrl:   api.StringToPointer("callback.example.com"),
-			XCallbackToken: api.StringToPointer("test-token"),
-			XWaitForStatus: api.IntToPointer(4),
-			XMerkleProof:   api.StringToPointer("true"),
+			XCallbackUrl:   ptr.To("callback.example.com"),
+			XCallbackToken: ptr.To("test-token"),
+			XWaitForStatus: ptr.To(4),
+			XMerkleProof:   ptr.To("true"),
 		}
 
 		err = defaultHandler.POSTTransaction(ctx, options)
@@ -304,10 +305,10 @@ func TestPOSTTransactions(t *testing.T) { //nolint:funlen
 		req.Header.Set(echo.HeaderContentType, echo.MIMETextPlain)
 
 		options := api.POSTTransactionsParams{
-			XCallbackUrl:   api.StringToPointer("callback.example.com"),
-			XCallbackToken: api.StringToPointer("test-token"),
-			XWaitForStatus: api.IntToPointer(4),
-			XMerkleProof:   api.StringToPointer("true"),
+			XCallbackUrl:   ptr.To("callback.example.com"),
+			XCallbackToken: ptr.To("test-token"),
+			XWaitForStatus: ptr.To(4),
+			XMerkleProof:   ptr.To("true"),
 		}
 
 		err = defaultHandler.POSTTransactions(ctx, options)
@@ -560,8 +561,8 @@ func TestGetTransactionOptions(t *testing.T) {
 		{
 			name: "valid callback url",
 			params: api.POSTTransactionParams{
-				XCallbackUrl:   api.StringToPointer("http://api.callme.com"),
-				XCallbackToken: api.StringToPointer("1234"),
+				XCallbackUrl:   ptr.To("http://api.callme.com"),
+				XCallbackToken: ptr.To("1234"),
 			},
 
 			expectedOptions: &api.TransactionOptions{
@@ -572,7 +573,7 @@ func TestGetTransactionOptions(t *testing.T) {
 		{
 			name: "invalid callback url",
 			params: api.POSTTransactionParams{
-				XCallbackUrl: api.StringToPointer("api.callme.com"),
+				XCallbackUrl: ptr.To("api.callme.com"),
 			},
 
 			expectedErrorStr: "invalid callback URL",
@@ -580,7 +581,7 @@ func TestGetTransactionOptions(t *testing.T) {
 		{
 			name: "merkle proof - true",
 			params: api.POSTTransactionParams{
-				XMerkleProof: api.StringToPointer("true"),
+				XMerkleProof: ptr.To("true"),
 			},
 
 			expectedOptions: &api.TransactionOptions{
@@ -590,7 +591,7 @@ func TestGetTransactionOptions(t *testing.T) {
 		{
 			name: "merkle proof - 1",
 			params: api.POSTTransactionParams{
-				XMerkleProof: api.StringToPointer("1"),
+				XMerkleProof: ptr.To("1"),
 			},
 
 			expectedOptions: &api.TransactionOptions{
@@ -600,7 +601,7 @@ func TestGetTransactionOptions(t *testing.T) {
 		{
 			name: "wait for status - 1",
 			params: api.POSTTransactionParams{
-				XWaitForStatus: api.IntToPointer(1),
+				XWaitForStatus: ptr.To(1),
 			},
 
 			expectedOptions: &api.TransactionOptions{},
@@ -608,7 +609,7 @@ func TestGetTransactionOptions(t *testing.T) {
 		{
 			name: "wait for status - 2",
 			params: api.POSTTransactionParams{
-				XWaitForStatus: api.IntToPointer(2),
+				XWaitForStatus: ptr.To(2),
 			},
 
 			expectedOptions: &api.TransactionOptions{
@@ -618,7 +619,7 @@ func TestGetTransactionOptions(t *testing.T) {
 		{
 			name: "wait for status - 6",
 			params: api.POSTTransactionParams{
-				XWaitForStatus: api.IntToPointer(6),
+				XWaitForStatus: ptr.To(6),
 			},
 
 			expectedOptions: &api.TransactionOptions{
@@ -628,7 +629,7 @@ func TestGetTransactionOptions(t *testing.T) {
 		{
 			name: "wait for status - 7",
 			params: api.POSTTransactionParams{
-				XWaitForStatus: api.IntToPointer(7),
+				XWaitForStatus: ptr.To(7),
 			},
 
 			expectedOptions: &api.TransactionOptions{},

--- a/api/handler/default_test.go
+++ b/api/handler/default_test.go
@@ -142,6 +142,7 @@ func TestPOSTTransaction(t *testing.T) { //nolint:funlen
 		}
 
 		err = defaultHandler.POSTTransaction(ctx, options)
+		require.NoError(t, err)
 		assert.Equal(t, api.ErrBadRequest.Status, rec.Code)
 
 		b := rec.Body.Bytes()
@@ -310,6 +311,7 @@ func TestPOSTTransactions(t *testing.T) { //nolint:funlen
 		}
 
 		err = defaultHandler.POSTTransactions(ctx, options)
+		require.NoError(t, err)
 		assert.Equal(t, api.ErrBadRequest.Status, rec.Code)
 
 		b := rec.Body.Bytes()

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -25,3 +25,11 @@ func FeesToBtFeeQuote(minMiningFee float64) *bt.FeeQuote {
 
 	return btFeeQuote
 }
+
+func StringToPointer(input string) *string {
+	return &input
+}
+
+func IntToPointer(input int) *int {
+	return &input
+}

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -25,11 +25,3 @@ func FeesToBtFeeQuote(minMiningFee float64) *bt.FeeQuote {
 
 	return btFeeQuote
 }
-
-func StringToPointer(input string) *string {
-	return &input
-}
-
-func IntToPointer(input int) *int {
-	return &input
-}

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	google.golang.org/grpc v1.55.0
 	google.golang.org/protobuf v1.30.0
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	modernc.org/sqlite v1.20.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -886,6 +886,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 lukechampine.com/uint128 v1.2.0 h1:mBi/5l91vocEN8otkC5bDLhi2KdCticRiwbdB0O+rjI=
 lukechampine.com/uint128 v1.2.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 modernc.org/cc/v3 v3.40.0 h1:P3g79IUS/93SYhtoeaHW+kRCIrYaxJ27MFPv+7kaTOw=

--- a/metamorph/Server.go
+++ b/metamorph/Server.go
@@ -134,6 +134,10 @@ func (s *Server) PutTransaction(ctx context.Context, req *metamorph_api.Transact
 		gocore.NewStat("PutTransaction").AddTime(start)
 	}()
 
+	if _, err := url.ParseRequestURI(req.CallbackUrl); req.CallbackUrl != "" && err != nil {
+		return nil, fmt.Errorf("invalid URL [%w]", err)
+	}
+
 	next, status, hash, transactionStatus, err := s.putTransactionInit(ctx, req, start)
 	if err != nil {
 		// if we have an error, we will return immediately
@@ -224,6 +228,10 @@ func (s *Server) PutTransactions(ctx context.Context, req *metamorph_api.Transac
 	// if not we store the transaction data and set the transaction status in response array to - STORED
 	requests := make([]*store.StoreData, 0, len(req.Transactions))
 	for ind, req := range req.Transactions {
+		if _, err := url.ParseRequestURI(req.CallbackUrl); req.CallbackUrl != "" && err != nil {
+			return nil, fmt.Errorf("invalid URL [%w]", err)
+		}
+
 		_, status, hash, transactionStatus, err := s.putTransactionInit(ctx, req, start)
 		if err != nil {
 			// if we have an error, we will return immediately

--- a/metamorph/Server_test.go
+++ b/metamorph/Server_test.go
@@ -239,3 +239,40 @@ func TestServer_GetTransactionStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCallbackURL(t *testing.T) {
+	tt := []struct {
+		name        string
+		callbackURL string
+
+		expectedErrorStr string
+	}{
+		{
+			name:        "empty callback URL",
+			callbackURL: "",
+		},
+		{
+			name:        "valid callback URL",
+			callbackURL: "http://api.callback.com",
+		},
+		{
+			name:        "invalid callback URL",
+			callbackURL: "api.callback.com",
+
+			expectedErrorStr: "invalid URL [parse \"api.callback.com\": invalid URI for request]",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCallbackURL(tc.callbackURL)
+
+			if tc.expectedErrorStr != "" || err != nil {
+				require.ErrorContains(t, err, tc.expectedErrorStr)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/metamorph/Server_test.go
+++ b/metamorph/Server_test.go
@@ -89,6 +89,17 @@ func TestPutTransaction(t *testing.T) {
 		assert.True(t, txStatus.TimedOut)
 	})
 
+	t.Run("invalid request", func(t *testing.T) {
+		server := NewServer(nil, nil, nil, nil, source)
+
+		txRequest := &metamorph_api.TransactionRequest{
+			CallbackUrl: "api.callback.com",
+		}
+
+		_, err := server.PutTransaction(context.Background(), txRequest)
+		assert.ErrorContains(t, err, "invalid URL [parse \"api.callback.com\": invalid URI for request]")
+	})
+
 	t.Run("PutTransaction - SEEN to network", func(t *testing.T) {
 		s, err := sql.New("sqlite_memory")
 		require.NoError(t, err)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.projectName=ARC
 sonar.projectVersion=0.1
 
 sonar.sources=.
-sonar.exclusions=**/*_test.go,doc/**/*,examples/**/*,testdata/**/*
+sonar.exclusions=**/*_test.go,doc/**/*,examples/**/*,testdata/**/*,**/test/**/*
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
- Validate the callback URL in both API and metamorph
- This ensures that the user will be informed about his callback URL being invalid
- Otherwise the user could never understand why the callback URL has not been called if the transaction was mined