### PR TITLE
Enforce code generation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,6 +29,18 @@ jobs:
     - name: Run go vet
       run: go vet ./...
 
+    - name: Install code generation tools
+      run: make install_gen
+
+    - name: Check go format
+      run: gofmt -s -w . && git diff --exit-code
+
+    - name: Check go generate
+      run: make gen_go && git diff --exit-code
+
+    - name: Check generate api
+      run: make api && git diff --exit-code
+
     - name: Install staticcheck
       run: go install honnef.co/go/tools/cmd/staticcheck@latest
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ lint:
 run:
 	sh run.sh
 
+.PHONY: gen_go
+gen_go:
+	go generate ./...
+
 .PHONY: gen
 gen:
 	protoc \
@@ -69,11 +73,13 @@ install:
 	# arch -arm64 brew install golangci-lint
 	brew install pre-commit
 	pre-commit install
-	go install honnef.co/go/tools/cmd/staticcheck@latest
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-	# GO111MODULE=off go get -u github.com/mwitkow/go-proto-validators/protoc-gen-govalidators
-	go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.11.0
+
+.PHONY: install_gen
+install_gen:
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
+	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
+	go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.15.0
+	go install github.com/matryer/moq@v0.3.2
 
 .PHONY: docs
 docs:

--- a/api/test/transactionHandler_mock.go
+++ b/api/test/transactionHandler_mock.go
@@ -16,28 +16,28 @@ var _ transactionHandler.TransactionHandler = &TransactionHandlerMock{}
 
 // TransactionHandlerMock is a mock implementation of transactionHandler.TransactionHandler.
 //
-// 	func TestSomethingThatUsesTransactionHandler(t *testing.T) {
+//	func TestSomethingThatUsesTransactionHandler(t *testing.T) {
 //
-// 		// make and configure a mocked transactionHandler.TransactionHandler
-// 		mockedTransactionHandler := &TransactionHandlerMock{
-// 			GetTransactionFunc: func(ctx context.Context, txID string) ([]byte, error) {
-// 				panic("mock out the GetTransaction method")
-// 			},
-// 			GetTransactionStatusFunc: func(ctx context.Context, txID string) (*transactionHandler.TransactionStatus, error) {
-// 				panic("mock out the GetTransactionStatus method")
-// 			},
-// 			SubmitTransactionFunc: func(ctx context.Context, tx []byte, options *arc.TransactionOptions) (*transactionHandler.TransactionStatus, error) {
-// 				panic("mock out the SubmitTransaction method")
-// 			},
-// 			SubmitTransactionsFunc: func(ctx context.Context, tx [][]byte, options *arc.TransactionOptions) ([]*transactionHandler.TransactionStatus, error) {
-// 				panic("mock out the SubmitTransactions method")
-// 			},
-// 		}
+//		// make and configure a mocked transactionHandler.TransactionHandler
+//		mockedTransactionHandler := &TransactionHandlerMock{
+//			GetTransactionFunc: func(ctx context.Context, txID string) ([]byte, error) {
+//				panic("mock out the GetTransaction method")
+//			},
+//			GetTransactionStatusFunc: func(ctx context.Context, txID string) (*transactionHandler.TransactionStatus, error) {
+//				panic("mock out the GetTransactionStatus method")
+//			},
+//			SubmitTransactionFunc: func(ctx context.Context, tx []byte, options *arc.TransactionOptions) (*transactionHandler.TransactionStatus, error) {
+//				panic("mock out the SubmitTransaction method")
+//			},
+//			SubmitTransactionsFunc: func(ctx context.Context, tx [][]byte, options *arc.TransactionOptions) ([]*transactionHandler.TransactionStatus, error) {
+//				panic("mock out the SubmitTransactions method")
+//			},
+//		}
 //
-// 		// use mockedTransactionHandler in code that requires transactionHandler.TransactionHandler
-// 		// and then make assertions.
+//		// use mockedTransactionHandler in code that requires transactionHandler.TransactionHandler
+//		// and then make assertions.
 //
-// 	}
+//	}
 type TransactionHandlerMock struct {
 	// GetTransactionFunc mocks the GetTransaction method.
 	GetTransactionFunc func(ctx context.Context, txID string) ([]byte, error)
@@ -112,7 +112,8 @@ func (mock *TransactionHandlerMock) GetTransaction(ctx context.Context, txID str
 
 // GetTransactionCalls gets all the calls that were made to GetTransaction.
 // Check the length with:
-//     len(mockedTransactionHandler.GetTransactionCalls())
+//
+//	len(mockedTransactionHandler.GetTransactionCalls())
 func (mock *TransactionHandlerMock) GetTransactionCalls() []struct {
 	Ctx  context.Context
 	TxID string
@@ -147,7 +148,8 @@ func (mock *TransactionHandlerMock) GetTransactionStatus(ctx context.Context, tx
 
 // GetTransactionStatusCalls gets all the calls that were made to GetTransactionStatus.
 // Check the length with:
-//     len(mockedTransactionHandler.GetTransactionStatusCalls())
+//
+//	len(mockedTransactionHandler.GetTransactionStatusCalls())
 func (mock *TransactionHandlerMock) GetTransactionStatusCalls() []struct {
 	Ctx  context.Context
 	TxID string
@@ -184,7 +186,8 @@ func (mock *TransactionHandlerMock) SubmitTransaction(ctx context.Context, tx []
 
 // SubmitTransactionCalls gets all the calls that were made to SubmitTransaction.
 // Check the length with:
-//     len(mockedTransactionHandler.SubmitTransactionCalls())
+//
+//	len(mockedTransactionHandler.SubmitTransactionCalls())
 func (mock *TransactionHandlerMock) SubmitTransactionCalls() []struct {
 	Ctx     context.Context
 	Tx      []byte
@@ -223,7 +226,8 @@ func (mock *TransactionHandlerMock) SubmitTransactions(ctx context.Context, tx [
 
 // SubmitTransactionsCalls gets all the calls that were made to SubmitTransactions.
 // Check the length with:
-//     len(mockedTransactionHandler.SubmitTransactionsCalls())
+//
+//	len(mockedTransactionHandler.SubmitTransactionsCalls())
 func (mock *TransactionHandlerMock) SubmitTransactionsCalls() []struct {
 	Ctx     context.Context
 	Tx      [][]byte

--- a/callbacker/test/utils.go
+++ b/callbacker/test/utils.go
@@ -206,9 +206,8 @@ func getNewWalletAddress(t *testing.T) (address, privateKey string) {
 		return
 	}
 
-
 	//scripthash
-	
+
 	fmt.Println("Result: " + out.String())
 	require.NoError(t, err)
 	address = strings.TrimSpace(out.String())

--- a/metamorph/blocktx/mock/mock.go
+++ b/metamorph/blocktx/mock/mock.go
@@ -17,40 +17,43 @@ var _ blocktx.ClientI = &ClientIMock{}
 
 // ClientIMock is a mock implementation of blocktx.ClientI.
 //
-// 	func TestSomethingThatUsesClientI(t *testing.T) {
+//	func TestSomethingThatUsesClientI(t *testing.T) {
 //
-// 		// make and configure a mocked blocktx.ClientI
-// 		mockedClientI := &ClientIMock{
-// 			GetBlockFunc: func(ctx context.Context, blockHash *chainhash.Hash) (*blocktx_api.Block, error) {
-// 				panic("mock out the GetBlock method")
-// 			},
-// 			GetLastProcessedBlockFunc: func(ctx context.Context) (*blocktx_api.Block, error) {
-// 				panic("mock out the GetLastProcessedBlock method")
-// 			},
-// 			GetMinedTransactionsForBlockFunc: func(ctx context.Context, blockAndSource *blocktx_api.BlockAndSource) (*blocktx_api.MinedTransactions, error) {
-// 				panic("mock out the GetMinedTransactionsForBlock method")
-// 			},
-// 			GetTransactionBlockFunc: func(ctx context.Context, transaction *blocktx_api.Transaction) (*blocktx_api.RegisterTransactionResponse, error) {
-// 				panic("mock out the GetTransactionBlock method")
-// 			},
-// 			GetTransactionBlocksFunc: func(ctx context.Context, transaction *blocktx_api.Transactions) (*blocktx_api.TransactionBlocks, error) {
-// 				panic("mock out the GetTransactionBlocks method")
-// 			},
-// 			LocateTransactionFunc: func(ctx context.Context, transaction *blocktx_api.Transaction) (string, error) {
-// 				panic("mock out the LocateTransaction method")
-// 			},
-// 			RegisterTransactionFunc: func(ctx context.Context, transaction *blocktx_api.TransactionAndSource) (*blocktx_api.RegisterTransactionResponse, error) {
-// 				panic("mock out the RegisterTransaction method")
-// 			},
-// 			StartFunc: func(minedBlockChan chan *blocktx_api.Block)  {
-// 				panic("mock out the Start method")
-// 			},
-// 		}
+//		// make and configure a mocked blocktx.ClientI
+//		mockedClientI := &ClientIMock{
+//			GetBlockFunc: func(ctx context.Context, blockHash *chainhash.Hash) (*blocktx_api.Block, error) {
+//				panic("mock out the GetBlock method")
+//			},
+//			GetLastProcessedBlockFunc: func(ctx context.Context) (*blocktx_api.Block, error) {
+//				panic("mock out the GetLastProcessedBlock method")
+//			},
+//			GetMinedTransactionsForBlockFunc: func(ctx context.Context, blockAndSource *blocktx_api.BlockAndSource) (*blocktx_api.MinedTransactions, error) {
+//				panic("mock out the GetMinedTransactionsForBlock method")
+//			},
+//			GetTransactionBlockFunc: func(ctx context.Context, transaction *blocktx_api.Transaction) (*blocktx_api.RegisterTransactionResponse, error) {
+//				panic("mock out the GetTransactionBlock method")
+//			},
+//			GetTransactionBlocksFunc: func(ctx context.Context, transaction *blocktx_api.Transactions) (*blocktx_api.TransactionBlocks, error) {
+//				panic("mock out the GetTransactionBlocks method")
+//			},
+//			GetTransactionMerklePathFunc: func(ctx context.Context, transaction *blocktx_api.Transaction) (string, error) {
+//				panic("mock out the GetTransactionMerklePath method")
+//			},
+//			LocateTransactionFunc: func(ctx context.Context, transaction *blocktx_api.Transaction) (string, error) {
+//				panic("mock out the LocateTransaction method")
+//			},
+//			RegisterTransactionFunc: func(ctx context.Context, transaction *blocktx_api.TransactionAndSource) (*blocktx_api.RegisterTransactionResponse, error) {
+//				panic("mock out the RegisterTransaction method")
+//			},
+//			StartFunc: func(minedBlockChan chan *blocktx_api.Block)  {
+//				panic("mock out the Start method")
+//			},
+//		}
 //
-// 		// use mockedClientI in code that requires blocktx.ClientI
-// 		// and then make assertions.
+//		// use mockedClientI in code that requires blocktx.ClientI
+//		// and then make assertions.
 //
-// 	}
+//	}
 type ClientIMock struct {
 	// GetBlockFunc mocks the GetBlock method.
 	GetBlockFunc func(ctx context.Context, blockHash *chainhash.Hash) (*blocktx_api.Block, error)
@@ -67,11 +70,11 @@ type ClientIMock struct {
 	// GetTransactionBlocksFunc mocks the GetTransactionBlocks method.
 	GetTransactionBlocksFunc func(ctx context.Context, transaction *blocktx_api.Transactions) (*blocktx_api.TransactionBlocks, error)
 
+	// GetTransactionMerklePathFunc mocks the GetTransactionMerklePath method.
+	GetTransactionMerklePathFunc func(ctx context.Context, transaction *blocktx_api.Transaction) (string, error)
+
 	// LocateTransactionFunc mocks the LocateTransaction method.
 	LocateTransactionFunc func(ctx context.Context, transaction *blocktx_api.Transaction) (string, error)
-
-	// GetTransactionMerklePath returns merkle path of the transaction
-	GetTransactionMerklePathFunc func(ctx context.Context, transaction *blocktx_api.Transaction) (string, error)
 
 	// RegisterTransactionFunc mocks the RegisterTransaction method.
 	RegisterTransactionFunc func(ctx context.Context, transaction *blocktx_api.TransactionAndSource) (*blocktx_api.RegisterTransactionResponse, error)
@@ -114,6 +117,13 @@ type ClientIMock struct {
 			// Transaction is the transaction argument value.
 			Transaction *blocktx_api.Transactions
 		}
+		// GetTransactionMerklePath holds details about calls to the GetTransactionMerklePath method.
+		GetTransactionMerklePath []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Transaction is the transaction argument value.
+			Transaction *blocktx_api.Transaction
+		}
 		// LocateTransaction holds details about calls to the LocateTransaction method.
 		LocateTransaction []struct {
 			// Ctx is the ctx argument value.
@@ -139,6 +149,7 @@ type ClientIMock struct {
 	lockGetMinedTransactionsForBlock sync.RWMutex
 	lockGetTransactionBlock          sync.RWMutex
 	lockGetTransactionBlocks         sync.RWMutex
+	lockGetTransactionMerklePath     sync.RWMutex
 	lockLocateTransaction            sync.RWMutex
 	lockRegisterTransaction          sync.RWMutex
 	lockStart                        sync.RWMutex
@@ -164,7 +175,8 @@ func (mock *ClientIMock) GetBlock(ctx context.Context, blockHash *chainhash.Hash
 
 // GetBlockCalls gets all the calls that were made to GetBlock.
 // Check the length with:
-//     len(mockedClientI.GetBlockCalls())
+//
+//	len(mockedClientI.GetBlockCalls())
 func (mock *ClientIMock) GetBlockCalls() []struct {
 	Ctx       context.Context
 	BlockHash *chainhash.Hash
@@ -197,7 +209,8 @@ func (mock *ClientIMock) GetLastProcessedBlock(ctx context.Context) (*blocktx_ap
 
 // GetLastProcessedBlockCalls gets all the calls that were made to GetLastProcessedBlock.
 // Check the length with:
-//     len(mockedClientI.GetLastProcessedBlockCalls())
+//
+//	len(mockedClientI.GetLastProcessedBlockCalls())
 func (mock *ClientIMock) GetLastProcessedBlockCalls() []struct {
 	Ctx context.Context
 } {
@@ -230,7 +243,8 @@ func (mock *ClientIMock) GetMinedTransactionsForBlock(ctx context.Context, block
 
 // GetMinedTransactionsForBlockCalls gets all the calls that were made to GetMinedTransactionsForBlock.
 // Check the length with:
-//     len(mockedClientI.GetMinedTransactionsForBlockCalls())
+//
+//	len(mockedClientI.GetMinedTransactionsForBlockCalls())
 func (mock *ClientIMock) GetMinedTransactionsForBlockCalls() []struct {
 	Ctx            context.Context
 	BlockAndSource *blocktx_api.BlockAndSource
@@ -265,7 +279,8 @@ func (mock *ClientIMock) GetTransactionBlock(ctx context.Context, transaction *b
 
 // GetTransactionBlockCalls gets all the calls that were made to GetTransactionBlock.
 // Check the length with:
-//     len(mockedClientI.GetTransactionBlockCalls())
+//
+//	len(mockedClientI.GetTransactionBlockCalls())
 func (mock *ClientIMock) GetTransactionBlockCalls() []struct {
 	Ctx         context.Context
 	Transaction *blocktx_api.Transaction
@@ -300,7 +315,8 @@ func (mock *ClientIMock) GetTransactionBlocks(ctx context.Context, transaction *
 
 // GetTransactionBlocksCalls gets all the calls that were made to GetTransactionBlocks.
 // Check the length with:
-//     len(mockedClientI.GetTransactionBlocksCalls())
+//
+//	len(mockedClientI.GetTransactionBlocksCalls())
 func (mock *ClientIMock) GetTransactionBlocksCalls() []struct {
 	Ctx         context.Context
 	Transaction *blocktx_api.Transactions
@@ -312,6 +328,42 @@ func (mock *ClientIMock) GetTransactionBlocksCalls() []struct {
 	mock.lockGetTransactionBlocks.RLock()
 	calls = mock.calls.GetTransactionBlocks
 	mock.lockGetTransactionBlocks.RUnlock()
+	return calls
+}
+
+// GetTransactionMerklePath calls GetTransactionMerklePathFunc.
+func (mock *ClientIMock) GetTransactionMerklePath(ctx context.Context, transaction *blocktx_api.Transaction) (string, error) {
+	if mock.GetTransactionMerklePathFunc == nil {
+		panic("ClientIMock.GetTransactionMerklePathFunc: method is nil but ClientI.GetTransactionMerklePath was just called")
+	}
+	callInfo := struct {
+		Ctx         context.Context
+		Transaction *blocktx_api.Transaction
+	}{
+		Ctx:         ctx,
+		Transaction: transaction,
+	}
+	mock.lockGetTransactionMerklePath.Lock()
+	mock.calls.GetTransactionMerklePath = append(mock.calls.GetTransactionMerklePath, callInfo)
+	mock.lockGetTransactionMerklePath.Unlock()
+	return mock.GetTransactionMerklePathFunc(ctx, transaction)
+}
+
+// GetTransactionMerklePathCalls gets all the calls that were made to GetTransactionMerklePath.
+// Check the length with:
+//
+//	len(mockedClientI.GetTransactionMerklePathCalls())
+func (mock *ClientIMock) GetTransactionMerklePathCalls() []struct {
+	Ctx         context.Context
+	Transaction *blocktx_api.Transaction
+} {
+	var calls []struct {
+		Ctx         context.Context
+		Transaction *blocktx_api.Transaction
+	}
+	mock.lockGetTransactionMerklePath.RLock()
+	calls = mock.calls.GetTransactionMerklePath
+	mock.lockGetTransactionMerklePath.RUnlock()
 	return calls
 }
 
@@ -333,17 +385,10 @@ func (mock *ClientIMock) LocateTransaction(ctx context.Context, transaction *blo
 	return mock.LocateTransactionFunc(ctx, transaction)
 }
 
-// GetTransactionMerklePath calls GetTransactionMerklePathFunc.
-func (mock *ClientIMock) GetTransactionMerklePath(ctx context.Context, transaction *blocktx_api.Transaction) (string, error) {
-	if mock.GetTransactionMerklePathFunc == nil {
-		panic("ClientIMock.GetTransactionMerklePathFunc: method is nil but ClientI.GetTransactionMerklePath was just called")
-	}
-	return mock.GetTransactionMerklePathFunc(ctx, transaction)
-}
-
 // LocateTransactionCalls gets all the calls that were made to LocateTransaction.
 // Check the length with:
-//     len(mockedClientI.LocateTransactionCalls())
+//
+//	len(mockedClientI.LocateTransactionCalls())
 func (mock *ClientIMock) LocateTransactionCalls() []struct {
 	Ctx         context.Context
 	Transaction *blocktx_api.Transaction
@@ -378,7 +423,8 @@ func (mock *ClientIMock) RegisterTransaction(ctx context.Context, transaction *b
 
 // RegisterTransactionCalls gets all the calls that were made to RegisterTransaction.
 // Check the length with:
-//     len(mockedClientI.RegisterTransactionCalls())
+//
+//	len(mockedClientI.RegisterTransactionCalls())
 func (mock *ClientIMock) RegisterTransactionCalls() []struct {
 	Ctx         context.Context
 	Transaction *blocktx_api.TransactionAndSource
@@ -411,7 +457,8 @@ func (mock *ClientIMock) Start(minedBlockChan chan *blocktx_api.Block) {
 
 // StartCalls gets all the calls that were made to Start.
 // Check the length with:
-//     len(mockedClientI.StartCalls())
+//
+//	len(mockedClientI.StartCalls())
 func (mock *ClientIMock) StartCalls() []struct {
 	MinedBlockChan chan *blocktx_api.Block
 } {

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -438,11 +438,11 @@ func BenchmarkProcessTransaction(b *testing.B) {
 func TestProcessExpiredSeenTransactions(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 
-		exptectedNrOfUpdates := 3
+		expectedNrOfUpdates := 3
 		expectedNrOfBlockTxRequests := 1
 		expectedNumberOfTransactions := 3
 
-		storeMock := &storeMock.MetamorphStoreMock{
+		metamorphStore := &storeMock.MetamorphStoreMock{
 			UpdateMinedFunc: func(ctx context.Context, hash *chainhash.Hash, blockHash *chainhash.Hash, blockHeight uint64) error {
 				require.Condition(t, func() (success bool) {
 					oneOfHash := hash.IsEqual(testdata.TX1Hash) || hash.IsEqual(testdata.TX2Hash) || hash.IsEqual(testdata.TX3Hash)
@@ -481,7 +481,7 @@ func TestProcessExpiredSeenTransactions(t *testing.T) {
 		}
 
 		pm := p2p.NewPeerManagerMock()
-		processor := NewProcessor(storeMock, pm, "test", nil, btxMock, WithProcessExpiredSeenTxsInterval(20*time.Millisecond))
+		processor := NewProcessor(metamorphStore, pm, "test", nil, btxMock, WithProcessExpiredSeenTxsInterval(20*time.Millisecond))
 		defer processor.Shutdown()
 
 		processor.SetLogger(p2p.TestLogger{})
@@ -493,7 +493,7 @@ func TestProcessExpiredSeenTransactions(t *testing.T) {
 
 		time.Sleep(50 * time.Millisecond)
 
-		require.Equal(t, exptectedNrOfUpdates, len(storeMock.UpdateMinedCalls()))
+		require.Equal(t, expectedNrOfUpdates, len(metamorphStore.UpdateMinedCalls()))
 		require.Equal(t, expectedNrOfBlockTxRequests, len(btxMock.GetTransactionBlocksCalls()))
 	})
 }

--- a/metamorph/store/mock/mock.go
+++ b/metamorph/store/mock/mock.go
@@ -18,43 +18,43 @@ var _ store.MetamorphStore = &MetamorphStoreMock{}
 
 // MetamorphStoreMock is a mock implementation of store.MetamorphStore.
 //
-// 	func TestSomethingThatUsesMetamorphStore(t *testing.T) {
+//	func TestSomethingThatUsesMetamorphStore(t *testing.T) {
 //
-// 		// make and configure a mocked store.MetamorphStore
-// 		mockedMetamorphStore := &MetamorphStoreMock{
-// 			CloseFunc: func(ctx context.Context) error {
-// 				panic("mock out the Close method")
-// 			},
-// 			DelFunc: func(ctx context.Context, key []byte) error {
-// 				panic("mock out the Del method")
-// 			},
-// 			GetFunc: func(ctx context.Context, key []byte) (*store.StoreData, error) {
-// 				panic("mock out the Get method")
-// 			},
-// 			GetBlockProcessedFunc: func(ctx context.Context, blockHash *chainhash.Hash) (*time.Time, error) {
-// 				panic("mock out the GetBlockProcessed method")
-// 			},
-// 			GetUnminedFunc: func(contextMoqParam context.Context, callback func(s *store.StoreData)) error {
-// 				panic("mock out the GetUnmined method")
-// 			},
-// 			SetFunc: func(ctx context.Context, key []byte, value *store.StoreData) error {
-// 				panic("mock out the Set method")
-// 			},
-// 			SetBlockProcessedFunc: func(ctx context.Context, blockHash *chainhash.Hash) error {
-// 				panic("mock out the SetBlockProcessed method")
-// 			},
-// 			UpdateMinedFunc: func(ctx context.Context, hash *chainhash.Hash, blockHash *chainhash.Hash, blockHeight uint64) error {
-// 				panic("mock out the UpdateMined method")
-// 			},
-// 			UpdateStatusFunc: func(ctx context.Context, hash *chainhash.Hash, status metamorph_api.Status, rejectReason string) error {
-// 				panic("mock out the UpdateStatus method")
-// 			},
-// 		}
+//		// make and configure a mocked store.MetamorphStore
+//		mockedMetamorphStore := &MetamorphStoreMock{
+//			CloseFunc: func(ctx context.Context) error {
+//				panic("mock out the Close method")
+//			},
+//			DelFunc: func(ctx context.Context, key []byte) error {
+//				panic("mock out the Del method")
+//			},
+//			GetFunc: func(ctx context.Context, key []byte) (*store.StoreData, error) {
+//				panic("mock out the Get method")
+//			},
+//			GetBlockProcessedFunc: func(ctx context.Context, blockHash *chainhash.Hash) (*time.Time, error) {
+//				panic("mock out the GetBlockProcessed method")
+//			},
+//			GetUnminedFunc: func(contextMoqParam context.Context, callback func(s *store.StoreData)) error {
+//				panic("mock out the GetUnmined method")
+//			},
+//			SetFunc: func(ctx context.Context, key []byte, value *store.StoreData) error {
+//				panic("mock out the Set method")
+//			},
+//			SetBlockProcessedFunc: func(ctx context.Context, blockHash *chainhash.Hash) error {
+//				panic("mock out the SetBlockProcessed method")
+//			},
+//			UpdateMinedFunc: func(ctx context.Context, hash *chainhash.Hash, blockHash *chainhash.Hash, blockHeight uint64) error {
+//				panic("mock out the UpdateMined method")
+//			},
+//			UpdateStatusFunc: func(ctx context.Context, hash *chainhash.Hash, status metamorph_api.Status, rejectReason string) error {
+//				panic("mock out the UpdateStatus method")
+//			},
+//		}
 //
-// 		// use mockedMetamorphStore in code that requires store.MetamorphStore
-// 		// and then make assertions.
+//		// use mockedMetamorphStore in code that requires store.MetamorphStore
+//		// and then make assertions.
 //
-// 	}
+//	}
 type MetamorphStoreMock struct {
 	// CloseFunc mocks the Close method.
 	CloseFunc func(ctx context.Context) error
@@ -186,7 +186,8 @@ func (mock *MetamorphStoreMock) Close(ctx context.Context) error {
 
 // CloseCalls gets all the calls that were made to Close.
 // Check the length with:
-//     len(mockedMetamorphStore.CloseCalls())
+//
+//	len(mockedMetamorphStore.CloseCalls())
 func (mock *MetamorphStoreMock) CloseCalls() []struct {
 	Ctx context.Context
 } {
@@ -219,7 +220,8 @@ func (mock *MetamorphStoreMock) Del(ctx context.Context, key []byte) error {
 
 // DelCalls gets all the calls that were made to Del.
 // Check the length with:
-//     len(mockedMetamorphStore.DelCalls())
+//
+//	len(mockedMetamorphStore.DelCalls())
 func (mock *MetamorphStoreMock) DelCalls() []struct {
 	Ctx context.Context
 	Key []byte
@@ -254,7 +256,8 @@ func (mock *MetamorphStoreMock) Get(ctx context.Context, key []byte) (*store.Sto
 
 // GetCalls gets all the calls that were made to Get.
 // Check the length with:
-//     len(mockedMetamorphStore.GetCalls())
+//
+//	len(mockedMetamorphStore.GetCalls())
 func (mock *MetamorphStoreMock) GetCalls() []struct {
 	Ctx context.Context
 	Key []byte
@@ -289,7 +292,8 @@ func (mock *MetamorphStoreMock) GetBlockProcessed(ctx context.Context, blockHash
 
 // GetBlockProcessedCalls gets all the calls that were made to GetBlockProcessed.
 // Check the length with:
-//     len(mockedMetamorphStore.GetBlockProcessedCalls())
+//
+//	len(mockedMetamorphStore.GetBlockProcessedCalls())
 func (mock *MetamorphStoreMock) GetBlockProcessedCalls() []struct {
 	Ctx       context.Context
 	BlockHash *chainhash.Hash
@@ -324,7 +328,8 @@ func (mock *MetamorphStoreMock) GetUnmined(contextMoqParam context.Context, call
 
 // GetUnminedCalls gets all the calls that were made to GetUnmined.
 // Check the length with:
-//     len(mockedMetamorphStore.GetUnminedCalls())
+//
+//	len(mockedMetamorphStore.GetUnminedCalls())
 func (mock *MetamorphStoreMock) GetUnminedCalls() []struct {
 	ContextMoqParam context.Context
 	Callback        func(s *store.StoreData)
@@ -361,7 +366,8 @@ func (mock *MetamorphStoreMock) Set(ctx context.Context, key []byte, value *stor
 
 // SetCalls gets all the calls that were made to Set.
 // Check the length with:
-//     len(mockedMetamorphStore.SetCalls())
+//
+//	len(mockedMetamorphStore.SetCalls())
 func (mock *MetamorphStoreMock) SetCalls() []struct {
 	Ctx   context.Context
 	Key   []byte
@@ -398,7 +404,8 @@ func (mock *MetamorphStoreMock) SetBlockProcessed(ctx context.Context, blockHash
 
 // SetBlockProcessedCalls gets all the calls that were made to SetBlockProcessed.
 // Check the length with:
-//     len(mockedMetamorphStore.SetBlockProcessedCalls())
+//
+//	len(mockedMetamorphStore.SetBlockProcessedCalls())
 func (mock *MetamorphStoreMock) SetBlockProcessedCalls() []struct {
 	Ctx       context.Context
 	BlockHash *chainhash.Hash
@@ -437,7 +444,8 @@ func (mock *MetamorphStoreMock) UpdateMined(ctx context.Context, hash *chainhash
 
 // UpdateMinedCalls gets all the calls that were made to UpdateMined.
 // Check the length with:
-//     len(mockedMetamorphStore.UpdateMinedCalls())
+//
+//	len(mockedMetamorphStore.UpdateMinedCalls())
 func (mock *MetamorphStoreMock) UpdateMinedCalls() []struct {
 	Ctx         context.Context
 	Hash        *chainhash.Hash
@@ -480,7 +488,8 @@ func (mock *MetamorphStoreMock) UpdateStatus(ctx context.Context, hash *chainhas
 
 // UpdateStatusCalls gets all the calls that were made to UpdateStatus.
 // Check the length with:
-//     len(mockedMetamorphStore.UpdateStatusCalls())
+//
+//	len(mockedMetamorphStore.UpdateStatusCalls())
 func (mock *MetamorphStoreMock) UpdateStatusCalls() []struct {
 	Ctx          context.Context
 	Hash         *chainhash.Hash

--- a/test/utils.go
+++ b/test/utils.go
@@ -82,9 +82,8 @@ func getNewWalletAddress(t *testing.T) (address, privateKey string) {
 		return
 	}
 
-
 	//scripthash
-	
+
 	fmt.Println("Result: " + out.String())
 	require.NoError(t, err)
 	address = strings.TrimSpace(out.String())


### PR DESCRIPTION
- `make install` will install specified versions of code generation tools
- go workflow will make the pipeline fail if running code generation will alter any code. Thereby it is ensured that no generated code has been hand edited.
- update generated go code