### PR TITLE
If Merkle path not found still return transaction status

### DIFF
--- a/api/handler/load.go
+++ b/api/handler/load.go
@@ -43,7 +43,7 @@ func LoadArcHandler(e *echo.Echo, logger utils.Logger) error {
 		return fmt.Errorf("grpcMessageSize not found in config")
 	}
 
-	txHandler, err := transactionHandler.NewMetamorph(addresses, bTx, grpcMessageSize)
+	txHandler, err := transactionHandler.NewMetamorph(addresses, bTx, grpcMessageSize, logger)
 	if err != nil {
 		return err
 	}

--- a/blocktx/Client.go
+++ b/blocktx/Client.go
@@ -89,7 +89,7 @@ func (btc *Client) LocateTransaction(ctx context.Context, transaction *blocktx_a
 func (btc *Client) GetTransactionMerklePath(ctx context.Context, hash *blocktx_api.Transaction) (string, error) {
 	merklePath, err := btc.client.GetTransactionMerklePath(ctx, hash)
 	if err != nil {
-		return "", ErrTransactionNotFound
+		return "", err
 	}
 
 	return merklePath.MerklePath, nil

--- a/cmd/txstatus/main.go
+++ b/cmd/txstatus/main.go
@@ -49,7 +49,7 @@ func main() {
 	if grpcMessageSize == 0 {
 		panic("Missing grpcMessageSize")
 	}
-	txHandler, err := transactionHandler.NewMetamorph(addresses, bTx, grpcMessageSize)
+	txHandler, err := transactionHandler.NewMetamorph(addresses, bTx, grpcMessageSize, logger)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/custom/main.go
+++ b/examples/custom/main.go
@@ -71,7 +71,7 @@ func main() {
 	blockTxClient := blocktx.NewClient(logger, "localhost:8021")
 	grpcMessageSize := viper.GetInt("grpcMessageSize")
 	// add a single metamorph, with the BlockTx client we want to use
-	txHandler, err := transactionHandler.NewMetamorph("localhost:8011", blockTxClient, grpcMessageSize)
+	txHandler, err := transactionHandler.NewMetamorph("localhost:8011", blockTxClient, grpcMessageSize, logger)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- If Merkle path not found still return transaction status
- log error
- Return `err` not `ErrTransactionNotFound` in `GetTransactionMerklePath()` blocktx client, as blocktx itself makes this distinction already