### PR TITLE
Return err object

### DIFF
--- a/api/handler/default.go
+++ b/api/handler/default.go
@@ -86,8 +86,7 @@ func (m ArcDefaultHandler) POSTTransaction(ctx echo.Context, params api.POSTTran
 
 	transactionOptions, err := getTransactionOptions(params)
 	if err != nil {
-		e := api.ErrBadRequest
-		e.ExtraInfo = ptr.To(err.Error())
+		e := api.NewErrorFields(api.ErrStatusBadRequest, err.Error())
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(e.Status, e)
@@ -95,8 +94,7 @@ func (m ArcDefaultHandler) POSTTransaction(ctx echo.Context, params api.POSTTran
 
 	body, err := io.ReadAll(ctx.Request().Body)
 	if err != nil {
-		e := api.ErrBadRequest
-		e.ExtraInfo = ptr.To(err.Error())
+		e := api.NewErrorFields(api.ErrStatusBadRequest, err.Error())
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(e.Status, e)
@@ -107,8 +105,7 @@ func (m ArcDefaultHandler) POSTTransaction(ctx echo.Context, params api.POSTTran
 	switch contentType {
 	case "text/plain":
 		if transaction, err = bt.NewTxFromString(string(body)); err != nil {
-			e := api.ErrBadRequest
-			e.ExtraInfo = ptr.To(err.Error())
+			e := api.NewErrorFields(api.ErrStatusBadRequest, err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(e.Status, e)
@@ -117,8 +114,7 @@ func (m ArcDefaultHandler) POSTTransaction(ctx echo.Context, params api.POSTTran
 		var txHex string
 		var txBody api.POSTTransactionJSONRequestBody
 		if err = json.Unmarshal(body, &txBody); err != nil {
-			e := api.ErrBadRequest
-			e.ExtraInfo = ptr.To(err.Error())
+			e := api.NewErrorFields(api.ErrStatusBadRequest, err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(e.Status, e)
@@ -126,23 +122,20 @@ func (m ArcDefaultHandler) POSTTransaction(ctx echo.Context, params api.POSTTran
 		txHex = txBody.RawTx
 
 		if transaction, err = bt.NewTxFromString(txHex); err != nil {
-			e := api.ErrBadRequest
-			e.ExtraInfo = ptr.To(err.Error())
+			e := api.NewErrorFields(api.ErrStatusBadRequest, err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(e.Status, e)
 		}
 	case "application/octet-stream":
 		if transaction, err = bt.NewTxFromBytes(body); err != nil {
-			e := api.ErrBadRequest
-			e.ExtraInfo = ptr.To(err.Error())
+			e := api.NewErrorFields(api.ErrStatusBadRequest, err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(e.Status, e)
 		}
 	default:
-		e := api.ErrBadRequest
-		e.ExtraInfo = ptr.To(fmt.Sprintf("given content-type %s does not match any of the allowed content-types", contentType))
+		e := api.NewErrorFields(api.ErrStatusBadRequest, fmt.Sprintf("given content-type %s does not match any of the allowed content-types", contentType))
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(e.Status, e)
@@ -177,23 +170,20 @@ func (m ArcDefaultHandler) GETTransactionStatus(ctx echo.Context, id string) err
 	tx, err := m.getTransactionStatus(tracingCtx, id)
 	if err != nil {
 		if errors.Is(err, transactionHandler.ErrTransactionNotFound) {
-			e := api.ErrNotFound
-			e.Detail = err.Error()
+			e := api.NewErrorFields(api.ErrStatusNotFound, err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(e.Status, e)
 		}
 
-		e := api.ErrGeneric
-		e.ExtraInfo = ptr.To(err.Error())
+		e := api.NewErrorFields(api.ErrStatusGeneric, err.Error())
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(e.Status, e)
 	}
 
 	if tx == nil {
-		e := api.ErrNotFound
-		e.ExtraInfo = ptr.To("failed to find transaction")
+		e := api.NewErrorFields(api.ErrStatusNotFound, "failed to find transaction")
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(e.Status, e)
@@ -217,8 +207,7 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 	// set the globals for all transactions in this request
 	transactionOptions, err := getTransactionsOptions(params)
 	if err != nil {
-		e := api.ErrBadRequest
-		e.ExtraInfo = ptr.To(err.Error())
+		e := api.NewErrorFields(api.ErrStatusBadRequest, err.Error())
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(e.Status, e)
@@ -250,8 +239,7 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 	case "application/json":
 		body, err := io.ReadAll(ctx.Request().Body)
 		if err != nil {
-			e := api.ErrBadRequest
-			e.ExtraInfo = ptr.To(err.Error())
+			e := api.NewErrorFields(api.ErrStatusBadRequest, err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(e.Status, e)
@@ -259,8 +247,7 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 
 		var txBody api.POSTTransactionsJSONBody
 		if err = json.Unmarshal(body, &txBody); err != nil {
-			e := api.ErrBadRequest
-			e.ExtraInfo = ptr.To(err.Error())
+			e := api.NewErrorFields(api.ErrStatusBadRequest, err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(e.Status, e)
@@ -271,8 +258,7 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 		for index, tx := range txBody {
 			transaction, err := bt.NewTxFromString(tx.RawTx)
 			if err != nil {
-				e := api.ErrBadRequest
-				e.ExtraInfo = ptr.To(err.Error())
+				e := api.NewErrorFields(api.ErrStatusBadRequest, err.Error())
 				transactions[index] = e
 				return ctx.JSON(e.Status, e)
 			}
@@ -302,8 +288,7 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 			btTx, err := transactionReaderFn(reader)
 			if err != nil {
 				if !errors.Is(err, io.EOF) {
-					e := api.ErrBadRequest
-					e.ExtraInfo = ptr.To(err.Error())
+					e := api.NewErrorFields(api.ErrStatusBadRequest, err.Error())
 					span.SetTag(string(ext.Error), true)
 					span.LogFields(log.Error(err))
 					return ctx.JSON(e.Status, e)
@@ -314,8 +299,7 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 			if btTx == nil {
 				if isFirstTransaction {
 					// no transactions found in the request body
-					e := api.ErrBadRequest
-					e.ExtraInfo = ptr.To("no transactions found in the request body")
+					e := api.NewErrorFields(api.ErrStatusBadRequest, "no transactions found in the request body")
 					span.SetTag(string(ext.Error), true)
 					span.LogFields(log.Error(err))
 					return ctx.JSON(e.Status, e)
@@ -331,8 +315,7 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 		}
 
 	default:
-		e := api.ErrBadRequest
-		e.ExtraInfo = ptr.To(fmt.Sprintf("given content-type %s does not match any of the allowed content-types", contentType))
+		e := api.NewErrorFields(api.ErrStatusBadRequest, fmt.Sprintf("given content-type %s does not match any of the allowed content-types", contentType))
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(e.Status, e)
@@ -341,8 +324,7 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 	// process all transactions
 	status, transactions, err = m.processTransactions(tracingCtx, transactionInputs, transactionOptions)
 	if err != nil {
-		e := api.ErrGeneric
-		e.ExtraInfo = ptr.To(fmt.Sprintf("failed to process transactions: %v", err))
+		e := api.NewErrorFields(api.ErrStatusGeneric, fmt.Errorf("failed to process transactions: %v", err).Error())
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(e.Status, e)
@@ -562,12 +544,16 @@ func (m ArcDefaultHandler) getTransactionStatus(ctx context.Context, id string) 
 }
 
 func (ArcDefaultHandler) handleError(_ context.Context, transaction *bt.Tx, submitErr error) (api.StatusCode, *api.ErrorFields) {
+	if submitErr == nil {
+		return api.StatusOK, nil
+	}
+
 	status := api.ErrStatusGeneric
 
-	var arcErr *validator.Error
-	ok := errors.As(submitErr, &arcErr)
+	var validatorErr *validator.Error
+	ok := errors.As(submitErr, &validatorErr)
 	if ok {
-		status = arcErr.ArcErrorStatus
+		status = validatorErr.ArcErrorStatus
 	}
 
 	if errors.Is(submitErr, transactionHandler.ErrParentTransactionNotFound) {
@@ -575,18 +561,10 @@ func (ArcDefaultHandler) handleError(_ context.Context, transaction *bt.Tx, subm
 	}
 
 	// enrich the response with the error details
-	arcError := api.ErrByStatus[status]
-	if arcError == nil {
-		arcError = &api.ErrGeneric
-	}
+	arcError := api.NewErrorFields(status, submitErr.Error())
 
 	if transaction != nil {
-		txID := transaction.TxID()
-		arcError.Txid = &txID
-	}
-	if submitErr != nil {
-		extraInfo := submitErr.Error()
-		arcError.ExtraInfo = &extraInfo
+		arcError.Txid = ptr.To(transaction.TxID())
 	}
 
 	return status, arcError

--- a/api/handler/default.go
+++ b/api/handler/default.go
@@ -86,9 +86,8 @@ func (m ArcDefaultHandler) POSTTransaction(ctx echo.Context, params api.POSTTran
 
 	transactionOptions, err := getTransactionOptions(params)
 	if err != nil {
-		errStr := err.Error()
 		e := api.ErrBadRequest
-		e.ExtraInfo = &errStr
+		e.ExtraInfo = ptr.To(err.Error())
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(int(api.ErrStatusBadRequest), e)
@@ -96,9 +95,8 @@ func (m ArcDefaultHandler) POSTTransaction(ctx echo.Context, params api.POSTTran
 
 	body, err := io.ReadAll(ctx.Request().Body)
 	if err != nil {
-		errStr := err.Error()
 		e := api.ErrBadRequest
-		e.ExtraInfo = &errStr
+		e.ExtraInfo = ptr.To(err.Error())
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(http.StatusBadRequest, e)
@@ -109,9 +107,8 @@ func (m ArcDefaultHandler) POSTTransaction(ctx echo.Context, params api.POSTTran
 	switch contentType {
 	case "text/plain":
 		if transaction, err = bt.NewTxFromString(string(body)); err != nil {
-			errStr := err.Error()
 			e := api.ErrBadRequest
-			e.ExtraInfo = &errStr
+			e.ExtraInfo = ptr.To(err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(int(api.ErrStatusBadRequest), e)
@@ -120,9 +117,8 @@ func (m ArcDefaultHandler) POSTTransaction(ctx echo.Context, params api.POSTTran
 		var txHex string
 		var txBody api.POSTTransactionJSONRequestBody
 		if err = json.Unmarshal(body, &txBody); err != nil {
-			errStr := err.Error()
 			e := api.ErrBadRequest
-			e.ExtraInfo = &errStr
+			e.ExtraInfo = ptr.To(err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(int(api.ErrStatusBadRequest), e)
@@ -130,18 +126,16 @@ func (m ArcDefaultHandler) POSTTransaction(ctx echo.Context, params api.POSTTran
 		txHex = txBody.RawTx
 
 		if transaction, err = bt.NewTxFromString(txHex); err != nil {
-			errStr := err.Error()
 			e := api.ErrBadRequest
-			e.ExtraInfo = &errStr
+			e.ExtraInfo = ptr.To(err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(int(api.ErrStatusBadRequest), e)
 		}
 	case "application/octet-stream":
 		if transaction, err = bt.NewTxFromBytes(body); err != nil {
-			errStr := err.Error()
 			e := api.ErrBadRequest
-			e.ExtraInfo = &errStr
+			e.ExtraInfo = ptr.To(err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(e.Status, e)
@@ -190,9 +184,8 @@ func (m ArcDefaultHandler) GETTransactionStatus(ctx echo.Context, id string) err
 			return echo.NewHTTPError(http.StatusNotFound, e)
 		}
 
-		errStr := err.Error()
 		e := api.ErrGeneric
-		e.ExtraInfo = &errStr
+		e.ExtraInfo = ptr.To(err.Error())
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(int(api.ErrStatusGeneric), e)
@@ -220,9 +213,8 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 	// set the globals for all transactions in this request
 	transactionOptions, err := getTransactionsOptions(params)
 	if err != nil {
-		errStr := err.Error()
 		e := api.ErrBadRequest
-		e.ExtraInfo = &errStr
+		e.ExtraInfo = ptr.To(err.Error())
 		span.SetTag(string(ext.Error), true)
 		span.LogFields(log.Error(err))
 		return ctx.JSON(e.Status, e)
@@ -251,9 +243,8 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 	case "application/json":
 		body, err := io.ReadAll(ctx.Request().Body)
 		if err != nil {
-			errStr := err.Error()
 			e := api.ErrBadRequest
-			e.ExtraInfo = &errStr
+			e.ExtraInfo = ptr.To(err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(e.Status, e)
@@ -261,9 +252,8 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 
 		var txBody api.POSTTransactionsJSONBody
 		if err = json.Unmarshal(body, &txBody); err != nil {
-			errStr := err.Error()
 			e := api.ErrBadRequest
-			e.ExtraInfo = &errStr
+			e.ExtraInfo = ptr.To(err.Error())
 			span.SetTag(string(ext.Error), true)
 			span.LogFields(log.Error(err))
 			return ctx.JSON(e.Status, e)
@@ -274,9 +264,8 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 		for index, tx := range txBody {
 			transaction, err := bt.NewTxFromString(tx.RawTx)
 			if err != nil {
-				errStr := err.Error()
 				e := api.ErrBadRequest
-				e.ExtraInfo = &errStr
+				e.ExtraInfo = ptr.To(err.Error())
 				transactions[index] = e
 				return ctx.JSON(e.Status, e)
 			}
@@ -326,8 +315,7 @@ func (m ArcDefaultHandler) POSTTransactions(ctx echo.Context, params api.POSTTra
 			if err != nil {
 				if !errors.Is(err, io.EOF) {
 					e := api.ErrBadRequest
-					errStr := err.Error()
-					e.ExtraInfo = &errStr
+					e.ExtraInfo = ptr.To(err.Error())
 					span.SetTag(string(ext.Error), true)
 					span.LogFields(log.Error(err))
 					return ctx.JSON(e.Status, e)

--- a/api/handler/default.go
+++ b/api/handler/default.go
@@ -554,9 +554,7 @@ func (ArcDefaultHandler) handleError(_ context.Context, transaction *bt.Tx, subm
 	ok := errors.As(submitErr, &validatorErr)
 	if ok {
 		status = validatorErr.ArcErrorStatus
-	}
-
-	if errors.Is(submitErr, transactionHandler.ErrParentTransactionNotFound) {
+	} else if errors.Is(submitErr, transactionHandler.ErrParentTransactionNotFound) {
 		status = api.ErrStatusTxFormat
 	}
 

--- a/api/handler/default_test.go
+++ b/api/handler/default_test.go
@@ -673,6 +673,20 @@ func Test_handleError(t *testing.T) {
 			expectedArcErr: nil,
 		},
 		{
+			name:        "generic error",
+			submitError: errors.New("some error"),
+
+			expectedStatus: api.ErrStatusGeneric,
+			expectedArcErr: &api.ErrorFields{
+				Detail:    "Transaction could not be processed",
+				ExtraInfo: ptr.To("some error"),
+				Title:     "Generic error",
+				Type:      "https://arc.bitcoinsv.com/errors/409",
+				Txid:      ptr.To("a147cc3c71cc13b29f18273cf50ffeb59fc9758152e2b33e21a8092f0b049118"),
+				Status:    409,
+			},
+		},
+		{
 			name: "validator error",
 			submitError: &validator.Error{
 				ArcErrorStatus: api.ErrStatusBadRequest,
@@ -687,6 +701,20 @@ func Test_handleError(t *testing.T) {
 				Type:      "https://arc.bitcoinsv.com/errors/400",
 				Txid:      ptr.To("a147cc3c71cc13b29f18273cf50ffeb59fc9758152e2b33e21a8092f0b049118"),
 				Status:    400,
+			},
+		},
+		{
+			name:        "parent not found error",
+			submitError: transactionHandler.ErrParentTransactionNotFound,
+
+			expectedStatus: api.ErrStatusTxFormat,
+			expectedArcErr: &api.ErrorFields{
+				Detail:    "Transaction is not in extended format, missing input scripts",
+				ExtraInfo: ptr.To("parent transaction not found"),
+				Title:     "Not extended format",
+				Type:      "https://arc.bitcoinsv.com/errors/460",
+				Txid:      ptr.To("a147cc3c71cc13b29f18273cf50ffeb59fc9758152e2b33e21a8092f0b049118"),
+				Status:    460,
 			},
 		},
 	}

--- a/api/status.go
+++ b/api/status.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"strconv"
+
+	"k8s.io/utils/ptr"
 )
 
 const ArcDocServerUrl = "https://arc.bitcoinsv.com"
@@ -10,10 +12,7 @@ type StatusCode int
 
 const (
 	StatusOK StatusCode = 200
-)
 
-// custom (http) status code
-const (
 	ErrStatusBadRequest       StatusCode = 400
 	ErrStatusNotFound         StatusCode = 404
 	ErrStatusGeneric          StatusCode = 409
@@ -28,103 +27,70 @@ const (
 	ErrStatusFrozenConsensus  StatusCode = 482
 )
 
-var (
-	ErrBadRequest = ErrorFields{
-		Detail: "The request seems to be malformed and cannot be processed",
-		Status: int(ErrStatusBadRequest),
-		Title:  "Bad request",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusBadRequest)),
+func NewErrorFields(status StatusCode, extraInfo string) *ErrorFields {
+	errFields := ErrorFields{
+		Status: int(status),
 	}
 
-	ErrNotFound = ErrorFields{
-		Detail: "The requested resource could not be found",
-		Status: int(ErrStatusNotFound),
-		Title:  "Not found",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusNotFound)),
+	if extraInfo != "" {
+		errFields.ExtraInfo = ptr.To(extraInfo)
 	}
 
-	ErrGeneric = ErrorFields{
-		Detail: "Transaction could not be processed",
-		Status: int(ErrStatusGeneric),
-		Title:  "Generic error",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusGeneric)),
+	switch status {
+	case ErrStatusBadRequest:
+		errFields.Detail = "The request seems to be malformed and cannot be processed"
+		errFields.Title = "Bad request"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusBadRequest))
+	case ErrStatusNotFound:
+		errFields.Detail = "The requested resource could not be found"
+		errFields.Title = "Not found"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusNotFound))
+	case ErrStatusGeneric:
+		errFields.Detail = "Transaction could not be processed"
+		errFields.Title = "Generic error"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusGeneric))
+	case ErrStatusTxFormat:
+		errFields.Detail = "Transaction is not in extended format, missing input scripts"
+		errFields.Title = "Not extended format"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusTxFormat))
+	case ErrStatusConflict:
+		errFields.Detail = "Transaction is valid, but there is a conflicting tx in the block template"
+		errFields.Title = "Conflicting tx found"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusConflict))
+	case ErrStatusUnlockingScripts:
+		errFields.Detail = "Transaction is malformed and cannot be processed"
+		errFields.Title = "Malformed transaction"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusUnlockingScripts))
+	case ErrStatusInputs:
+		errFields.Detail = "Transaction is invalid because the inputs are non-existent or spent"
+		errFields.Title = "Invalid inputs"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusInputs))
+	case ErrStatusOutputs:
+		errFields.Detail = "Transaction is invalid because the outputs are non-existent or invalid"
+		errFields.Title = "Invalid outputs"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusOutputs))
+	case ErrStatusMalformed:
+		errFields.Detail = "Transaction is malformed and cannot be processed"
+		errFields.Title = "Malformed transaction"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusMalformed))
+	case ErrStatusFees:
+		errFields.Detail = "Fees are too low"
+		errFields.Title = "Fee too low"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusFees))
+	case ErrStatusFrozenPolicy:
+		errFields.Detail = "Input Frozen (blacklist manager policy blacklisted)"
+		errFields.Title = "Input Frozen"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusFrozenPolicy))
+	case ErrStatusFrozenConsensus:
+		errFields.Detail = "Input Frozen (blacklist manager consensus blacklisted)"
+		errFields.Title = "Input Frozen"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusFrozenConsensus))
+	default:
+		errFields.Status = int(ErrStatusGeneric)
+		errFields.Detail = "Transaction could not be processed"
+		errFields.Title = "Generic error"
+		errFields.Type = ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusGeneric))
 	}
 
-	ErrTxFormat = ErrorFields{
-		Detail: "Transaction is not in extended format, missing input scripts",
-		Status: int(ErrStatusTxFormat),
-		Title:  "Not extended format",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusTxFormat)),
-	}
-
-	ErrConflict = ErrorFields{
-		Detail: "Transaction is valid, but there is a conflicting tx in the block template",
-		Status: int(ErrStatusConflict),
-		Title:  "Conflicting tx found",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusConflict)),
-	}
-
-	ErrUnlockingScripts = ErrorFields{
-		Detail: "Transaction is malformed and cannot be processed",
-		Status: int(ErrStatusUnlockingScripts),
-		Title:  "Malformed transaction",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusUnlockingScripts)),
-	}
-
-	ErrInputs = ErrorFields{
-		Detail: "Transaction is invalid because the inputs are non-existent or spent",
-		Status: int(ErrStatusInputs),
-		Title:  "Invalid inputs",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusInputs)),
-	}
-
-	ErrOutputs = ErrorFields{
-		Detail: "Transaction is invalid because the outputs are non-existent or invalid",
-		Status: int(ErrStatusOutputs),
-		Title:  "Invalid outputs",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusOutputs)),
-	}
-
-	ErrMalformed = ErrorFields{
-		Detail: "Transaction is malformed and cannot be processed",
-		Status: int(ErrStatusMalformed),
-		Title:  "Malformed transaction",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusMalformed)),
-	}
-
-	ErrFees = ErrorFields{
-		Detail: "Fees are too low",
-		Status: int(ErrStatusFees),
-		Title:  "Fee too low",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusFees)),
-	}
-
-	ErrFrozenPolicy = ErrorFields{
-		Detail: "Input Frozen (blacklist manager policy blacklisted)",
-		Status: int(ErrStatusFrozenPolicy),
-		Title:  "Input Frozen",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusFrozenPolicy)),
-	}
-
-	ErrFrozenConsensus = ErrorFields{
-		Detail: "Input Frozen (blacklist manager consensus blacklisted)",
-		Status: int(ErrStatusFrozenConsensus),
-		Title:  "Input Frozen",
-		Type:   ArcDocServerUrl + "/errors/" + strconv.Itoa(int(ErrStatusFrozenConsensus)),
-	}
-)
-
-var ErrByStatus = map[StatusCode]*ErrorFields{
-	ErrStatusBadRequest:       &ErrBadRequest,
-	ErrStatusNotFound:         &ErrNotFound,
-	ErrStatusGeneric:          &ErrGeneric,
-	ErrStatusTxFormat:         &ErrTxFormat,
-	ErrStatusUnlockingScripts: &ErrUnlockingScripts,
-	ErrStatusInputs:           &ErrInputs,
-	ErrStatusOutputs:          &ErrOutputs,
-	ErrStatusMalformed:        &ErrMalformed,
-	ErrStatusFees:             &ErrFees,
-	ErrStatusConflict:         &ErrConflict,
-	ErrStatusFrozenPolicy:     &ErrFrozenPolicy,
-	ErrStatusFrozenConsensus:  &ErrFrozenConsensus,
+	return &errFields
 }

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewErrorFields(t *testing.T) {
+	tt := []struct {
+		name   string
+		status StatusCode
+
+		expectedStatus StatusCode
+	}{
+		{
+			name:   "ErrStatusBadRequest",
+			status: ErrStatusBadRequest,
+
+			expectedStatus: ErrStatusBadRequest,
+		},
+		{
+			name:   "ErrStatusNotFound",
+			status: ErrStatusNotFound,
+
+			expectedStatus: ErrStatusNotFound,
+		},
+		{
+			name:   "ErrStatusGeneric",
+			status: ErrStatusGeneric,
+
+			expectedStatus: ErrStatusGeneric,
+		},
+		{
+			name:   "ErrStatusTxFormat",
+			status: ErrStatusTxFormat,
+
+			expectedStatus: ErrStatusTxFormat,
+		},
+		{
+			name:   "ErrStatusUnlockingScripts",
+			status: ErrStatusUnlockingScripts,
+
+			expectedStatus: ErrStatusUnlockingScripts,
+		},
+		{
+			name:   "ErrStatusInputs",
+			status: ErrStatusInputs,
+
+			expectedStatus: ErrStatusInputs,
+		},
+		{
+			name:   "ErrStatusOutputs",
+			status: ErrStatusOutputs,
+
+			expectedStatus: ErrStatusOutputs,
+		},
+		{
+			name:   "ErrStatusMalformed",
+			status: ErrStatusMalformed,
+
+			expectedStatus: ErrStatusMalformed,
+		},
+		{
+			name:   "ErrStatusFees",
+			status: ErrStatusFees,
+
+			expectedStatus: ErrStatusFees,
+		},
+		{
+			name:   "ErrStatusConflict",
+			status: ErrStatusConflict,
+
+			expectedStatus: ErrStatusConflict,
+		},
+		{
+			name:   "ErrStatusFrozenPolicy",
+			status: ErrStatusFrozenPolicy,
+
+			expectedStatus: ErrStatusFrozenPolicy,
+		},
+		{
+			name:   "ErrStatusFrozenConsensus",
+			status: ErrStatusFrozenConsensus,
+
+			expectedStatus: ErrStatusFrozenConsensus,
+		},
+		{
+			name:   "non existent status",
+			status: 1000,
+
+			expectedStatus: ErrStatusGeneric,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+
+			errFields := NewErrorFields(tc.status, "some extra info")
+
+			require.Equal(t, int(tc.expectedStatus), errFields.Status)
+			require.Equal(t, "some extra info", *errFields.ExtraInfo)
+
+		})
+	}
+}

--- a/api/transactionHandler/interface.go
+++ b/api/transactionHandler/interface.go
@@ -25,12 +25,12 @@ type TransactionHandler interface {
 
 // TransactionStatus defines model for TransactionStatus.
 type TransactionStatus struct {
-	TxID        string `json:"tx_id"`
-	MerklePath  string `json:"merkle_path"`
-	BlockHash   string `json:"blockHash,omitempty"`
-	BlockHeight uint64 `json:"blockHeight,omitempty"`
-	Status      string `json:"status"`
-	TxStatus    string `json:"txStatus"`
-	ExtraInfo   string `json:"extraInfo,omitempty"`
-	Timestamp   int64  `json:"timestamp"`
+	TxID        string
+	MerklePath  string
+	BlockHash   string
+	BlockHeight uint64
+	Status      string
+	TxStatus    string
+	ExtraInfo   string
+	Timestamp   int64
 }

--- a/api/transactionHandler/interface.go
+++ b/api/transactionHandler/interface.go
@@ -30,7 +30,6 @@ type TransactionStatus struct {
 	BlockHash   string
 	BlockHeight uint64
 	Status      string
-	TxStatus    string
 	ExtraInfo   string
 	Timestamp   int64
 }


### PR DESCRIPTION
- ensure that each transaction api endpoint always returns either a transaction status or a full ErrorFields object
- reduce code duplication of calling `m.processTransactions(tracingCtx, transactionInputs, transactionOptions)` in POSTTransactions() function
- refactor `handleError()` function. returned error was always `nil`
- refactor ErrorField statuses: Remove global variables and replace with constructor
- add unit test coverage for `handleError()`
- remove unused json tags from `TransactionStatus` type