### PR TITLE
Fix the go generate instruction for mocking processor

### DIFF
--- a/metamorph/Server_test.go
+++ b/metamorph/Server_test.go
@@ -283,7 +283,7 @@ func TestValidateCallbackURL(t *testing.T) {
 	}
 }
 
-// //go:generate moq -pkg metamorph -out ./processor_mock.go . ProcessorI ==> Todo: moq has a bug for creating a mock file in the same package. Currently fixed manually --> Create issue on moq github repo
+//go:generate moq -out ./processor_mock.go . ProcessorI
 
 func TestPutTransactions(t *testing.T) {
 	hash0, err := chainhash.NewHashFromStr("9b58926ec7eed21ec2f3ca518d5fc0c6ccbf963e25c3e7ac496c99867d97599a")

--- a/metamorph/processor_mock.go
+++ b/metamorph/processor_mock.go
@@ -22,13 +22,13 @@ var _ ProcessorI = &ProcessorIMock{}
 //			GetPeersFunc: func() ([]string, []string) {
 //				panic("mock out the GetPeers method")
 //			},
-//			GetStatsFunc: func(debugItems bool) *metamorph.ProcessorStats {
+//			GetStatsFunc: func(debugItems bool) *ProcessorStats {
 //				panic("mock out the GetStats method")
 //			},
 //			LoadUnminedFunc: func()  {
 //				panic("mock out the LoadUnmined method")
 //			},
-//			ProcessTransactionFunc: func(req *metamorph.ProcessorRequest)  {
+//			ProcessTransactionFunc: func(req *ProcessorRequest)  {
 //				panic("mock out the ProcessTransaction method")
 //			},
 //			SendStatusForTransactionFunc: func(hash *chainhash.Hash, status metamorph_api.Status, id string, err error) (bool, error) {
@@ -37,7 +37,7 @@ var _ ProcessorI = &ProcessorIMock{}
 //			SendStatusMinedForTransactionFunc: func(hash *chainhash.Hash, blockHash *chainhash.Hash, blockHeight uint64) (bool, error) {
 //				panic("mock out the SendStatusMinedForTransaction method")
 //			},
-//			SetFunc: func(req *metamorph.ProcessorRequest) error {
+//			SetFunc: func(req *ProcessorRequest) error {
 //				panic("mock out the Set method")
 //			},
 //		}


### PR DESCRIPTION
- Fix the go generate instruction for mocking processor