### PR TITLE
Rearrange github workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ name: Go
 
 on:
   push:
-    branches: ["fix/staticchecks"]
+    branches: ["main"]
   pull_request:
     branches: ["main"]
 
@@ -13,12 +13,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: './go.mod'
+          go-version-file: "./go.mod"
 
       - name: Verify dependencies
         run: go mod verify
@@ -41,15 +42,6 @@ jobs:
       - name: Check generate api
         run: make api && git diff --exit-code
 
-      - uses: dominikh/staticcheck-action@v1.2.0
-        with:
-          version: "2023.1.6"
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.54
-
       - name: Run tests
         run: go test -race -vet=off ./...
 
@@ -62,6 +54,7 @@ jobs:
           name: arc-build
           path: ./build
           retention-days: 1
+
   e2e:
     name: e2e
     needs: build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ name: Go
 
 on:
   push:
-    branches: ["main"]
+    branches: ["fix/staticchecks"]
   pull_request:
     branches: ["main"]
 
@@ -41,17 +41,14 @@ jobs:
       - name: Check generate api
         run: make api && git diff --exit-code
 
-      - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-      - name: Run staticcheck
-        run: staticcheck ./...
+      - uses: dominikh/staticcheck-action@v1.2.0
+        with:
+          version: "2023.1.6"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
-          args: --skip-dirs p2p/wire
+          version: v1.54
 
       - name: Run tests
         run: go test -race -vet=off ./...

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,22 +4,23 @@ on:
     branches:
       - main
   pull_request:
-    types: [ opened, synchronize, reopened ]
-  workflow_dispatch: { }
+    types: [opened, synchronize, reopened]
+  workflow_dispatch: {}
 
 jobs:
   analyze:
     name: Static analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out the repo
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: './go.mod'
+          go-version-file: "./go.mod"
 
       - name: Run unit Tests
         continue-on-error: true
@@ -37,3 +38,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  staticcheck:
+    name: Static check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: staticcheck
+        uses: dominikh/staticcheck-action@v1.3.0
+        with:
+          version: "2023.1.6"
+
+  lint:
+    name: Golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -24,8 +24,9 @@ jobs:
   build:
     runs-on: [ubuntu-latest]
     steps:
-      - name: Perform Checkout
-        uses: actions/checkout@v3
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
       - name: Deploy Files
         run: |
           git push --force origin `git subtree split --prefix doc main`:gh-pages

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ clean_gen:
 coverage:
 	rm -f ./cov.out
 	go test -coverprofile=./cov.out ./...
+
 .PHONY: clean
 clean:
 	rm -f ./arc_*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ build_release:
 test:
 	go test -race -count=1 ./...
 
+.PHONY: install_lint
+install_lint:
+	go install honnef.co/go/tools/cmd/staticcheck@latest
+
 .PHONY: lint
 lint:
 	golangci-lint run -v ./...

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/oapi-codegen/runtime v1.0.0
 	github.com/opentracing-contrib/echo v0.0.0-20190807091611-5fe2e1308f06
 	github.com/opentracing/opentracing-go v1.2.0
-	github.com/ordishs/go-bitcoin v1.0.79
+	github.com/ordishs/go-bitcoin v1.0.85
 	github.com/ordishs/go-utils v1.0.34
 	github.com/ordishs/gocore v1.0.35
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -363,6 +363,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/ordishs/go-bitcoin v1.0.79 h1:36U67J7+5nm5RX9j81tqRabYdQi6lYXBiTc8sVwnpsw=
 github.com/ordishs/go-bitcoin v1.0.79/go.mod h1:7gXD2G745ETJK4OU4xXl0UBIOAc80615hBJRjPqKhWY=
+github.com/ordishs/go-bitcoin v1.0.85 h1:VGLqcOP2ubFzDp8RxnjqUgMsf0Pv84mRYsjubcLdp4c=
+github.com/ordishs/go-bitcoin v1.0.85/go.mod h1:O3lqD8unDlwLXTmQTT4F5x/Gl3xgP4IgMQDFxTmi9V4=
 github.com/ordishs/go-utils v1.0.34 h1:0jHT5KfRuPdysFg+aZqUcSXJXtgGAkK+YOjhcPe8reQ=
 github.com/ordishs/go-utils v1.0.34/go.mod h1:k9G7Bbv2GwoOn9fwZx70yM5jwwIymkv+90FUKLudtyc=
 github.com/ordishs/gocore v1.0.35 h1:dasWlk2xEjibXCWRltlw74nkwqzJVxo2ZB3Fvl2u4IE=

--- a/test/go.mod
+++ b/test/go.mod
@@ -2,14 +2,12 @@ module github.com/bitcoin-sv/arc
 
 go 1.19
 
-replace github.com/ordishs/go-bitcoin v1.0.83 => github.com/boecklim/go-bitcoin v1.0.85
-
 require (
 	github.com/bitcoinsv/bsvd v0.0.0-20190609155523-4c29707f7173
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/libsv/go-bk v0.1.6
 	github.com/libsv/go-bt/v2 v2.1.1
-	github.com/ordishs/go-bitcoin v1.0.83
+	github.com/ordishs/go-bitcoin v1.0.85
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -83,6 +83,9 @@ github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/ordishs/go-bitcoin v1.0.83/go.mod h1:O3lqD8unDlwLXTmQTT4F5x/Gl3xgP4IgMQDFxTmi9V4=
+github.com/ordishs/go-bitcoin v1.0.85 h1:VGLqcOP2ubFzDp8RxnjqUgMsf0Pv84mRYsjubcLdp4c=
+github.com/ordishs/go-bitcoin v1.0.85/go.mod h1:O3lqD8unDlwLXTmQTT4F5x/Gl3xgP4IgMQDFxTmi9V4=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION
- move both golanci-lint step and staticcheck step into static analysis workflow into separate parallel jobs
  - staticcheck cannot run in the same job as actions/setup-go because it causes errors
  - golangci lint and staticcheck cannot be in the same job because it cause errors
