### PR TITLE
Coverage table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ settings_local.conf
 cov.out
 gosec-report.json
 .scannerwork
+gotest.out
+report.xml

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,9 @@ clean_gen:
 
 coverage:
 	rm -f ./cov.out
-	go test -coverprofile=./cov.out ./...
+	go test -coverprofile=./cov.out -covermode=atomic ./... 2>&1 > gotest.out
+	cat gotest.out | go-junit-report -set-exit-code > report.xml
+	goverreport -coverprofile cov.out -packages -sort block
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,17 @@ clean_gen:
 	rm -f ./blocktx/blocktx_api/*.pb.go
 	rm -f ./callbacker/callbacker_api/*.pb.go
 
+.PHONY: coverage
 coverage:
 	rm -f ./cov.out
 	go test -coverprofile=./cov.out -covermode=atomic ./... 2>&1 > gotest.out
 	cat gotest.out | go-junit-report -set-exit-code > report.xml
 	goverreport -coverprofile cov.out -packages -sort block
+
+.PHONY: install_coverage
+install_coverage:
+	go install github.com/mcubik/goverreport@latest
+	go install github.com/jstemmer/go-junit-report/v2@latest
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Show the coverage in a tabular way. It also shows a total coverage.
Example

```
+--------------------------------------------------------+--------+---------+-------+---------+---------------+--------------+
|                        Package                         | Blocks | Missing | Stmts | Missing | Block cover % | Stmt cover % |
+--------------------------------------------------------+--------+---------+-------+---------+---------------+--------------+
| github.com/bitcoin-sv/arc/api                          |    381 |     359 |   631 |     576 |          5.77 |         8.72 |
| github.com/bitcoin-sv/arc/blocktx                      |    227 |     176 |   380 |     287 |         22.47 |        24.47 |
| github.com/bitcoin-sv/arc/metamorph/processor_response |     50 |      35 |    88 |      54 |         30.00 |        38.64 |
| github.com/bitcoin-sv/arc/metamorph                    |    487 |     314 |   987 |     651 |         35.52 |        34.04 |
| github.com/bitcoin-sv/arc/blocktx/store/sql            |    231 |     144 |   389 |     225 |         37.66 |        42.16 |
| github.com/bitcoin-sv/arc/lib/keyset                   |     33 |      20 |    51 |      27 |         39.39 |        47.06 |
| github.com/bitcoin-sv/arc/callbacker                   |     63 |      37 |   104 |      56 |         41.27 |        46.15 |
| github.com/bitcoin-sv/arc/metamorph/store              |    113 |      51 |   135 |      52 |         54.87 |        61.48 |
| github.com/bitcoin-sv/arc/api/handler                  |    221 |      78 |   445 |     139 |         64.71 |        68.76 |
| github.com/bitcoin-sv/arc/validator/default            |    103 |      35 |   127 |      35 |         66.02 |        72.44 |
| github.com/bitcoin-sv/arc/metamorph/store/sql          |    137 |      46 |   268 |      90 |         66.42 |        66.42 |
| github.com/bitcoin-sv/arc/asynccaller                  |     38 |      12 |    64 |      16 |         68.42 |        75.00 |
| github.com/bitcoin-sv/arc/callbacker/store/badgerhold  |     37 |      11 |    60 |      14 |         70.27 |        76.67 |
| github.com/bitcoin-sv/arc/metamorph/store/badger       |     92 |      20 |   184 |      45 |         78.26 |        75.54 |
| github.com/bitcoin-sv/arc/api/dictionary               |     16 |       1 |    37 |       1 |         93.75 |        97.30 |
| github.com/bitcoin-sv/arc/lib/fees                     |      1 |       0 |    12 |       0 |        100.00 |       100.00 |
+--------------------------------------------------------+--------+---------+-------+---------+---------------+--------------+
|                                                  Total |   2230 |    1339 |  3962 |    2268 |         39.96 |        42.76 |
+--------------------------------------------------------+--------+---------+-------+---------+---------------+--------------+

```