### PR TITLE
Exclude everything from the code coverage calculation which is in the cmd/ folder

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.projectName=ARC
 sonar.projectVersion=0.1
 
 sonar.sources=.
-sonar.exclusions=**/*_test.go,doc/**/*,examples/**/*,testdata/**/*,**/test/**/*,api/arc.go,**/*mock.go,**/*.pb.go
+sonar.exclusions=**/*_test.go,doc/**/*,examples/**/*,testdata/**/*,**/test/**/*,api/arc.go,**/*mock.go,**/*.pb.go,cmd/**/*,main.go
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
Exclude everything from the code coverage calculation which is in the cmd/ folder as it cannot be covered by unit tests