### PR TITLE
Delete txs from storage after period of time

### DIFF
--- a/cmd/metamorph.go
+++ b/cmd/metamorph.go
@@ -145,6 +145,7 @@ func StartMetamorph(logger utils.Logger) (func(), error) {
 		metamorph.WithCacheExpiryTime(mapExpiry),
 		metamorph.WithProcessorLogger(processorLogger),
 		metamorph.WithLogFilePath(viper.GetString("metamorph.log.file")),
+		metamorph.WithDataRetentionPeriod(time.Duration(viper.GetInt("metamorph.dataRetentionPeriodDays"))*24*time.Hour),
 	)
 
 	http.HandleFunc("/pstats", metamorphProcessor.HandleStats)

--- a/config.yaml
+++ b/config.yaml
@@ -52,6 +52,7 @@ metamorph:
       awsSecretAccessKey:
       awsSessionToken:
   processorCacheExpiryTime: 24h # time after which processor cache is cleaned
+  dataRetentionPeriodDays: 14 # number of days for which data is kept in the storage before it can be deleted
   checkUtxos: false # force check each utxo for validity. If enabled ARC connects to bitcoin node using rpc for each utxo
   statsKeypress: false # enable stats keypress. If enabled pressing any key will print stats to stdout
   profilerAddr: localhost:9992 # address to start profiler server on

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -51,6 +51,7 @@ type Processor struct {
 	logger               *slog.Logger
 	logFile              string
 	mapExpiryTime        time.Duration
+	dataRetentionPeriod  time.Duration
 	now                  func() time.Time
 
 	processExpiredSeenTxsInterval time.Duration
@@ -82,8 +83,8 @@ const (
 	mapExpiryTimeDefault                    = 24 * time.Hour
 	logLevelDefault                         = slog.LevelInfo
 
-	failedToUpdateStatus = "Failed to update status"
-	txDeletionPeriod     = 336 * time.Hour // 14 days
+	failedToUpdateStatus       = "Failed to update status"
+	dataRetentionPeriodDefault = 14 * 24 * time.Hour // 14 days
 )
 
 func WithProcessExpiredSeenTxsInterval(d time.Duration) func(*Processor) {
@@ -122,6 +123,12 @@ func WithProcessExpiredTxsInterval(d time.Duration) func(*Processor) {
 	}
 }
 
+func WithDataRetentionPeriod(d time.Duration) func(*Processor) {
+	return func(p *Processor) {
+		p.dataRetentionPeriod = d
+	}
+}
+
 type Option func(f *Processor)
 
 func NewProcessor(s store.MetamorphStore, pm p2p.PeerManagerI,
@@ -139,6 +146,7 @@ func NewProcessor(s store.MetamorphStore, pm p2p.PeerManagerI,
 		cbChannel:               cbChannel,
 		pm:                      pm,
 		btc:                     btc,
+		dataRetentionPeriod:     dataRetentionPeriodDefault,
 		mapExpiryTime:           mapExpiryTimeDefault,
 		now:                     time.Now,
 		processExpiredTxsTicker: time.NewTicker(unseenTransactionRebroadcastingInterval * time.Second),
@@ -302,19 +310,29 @@ func (p *Processor) GetPeers() ([]string, []string) {
 	return peersConnected, peersDisconnected
 }
 
+func (p *Processor) deleteExpired(record *store.StoreData) (recordDeleted bool) {
+	if p.now().Sub(record.StoredAt) <= p.dataRetentionPeriod {
+		return recordDeleted
+	}
+
+	p.logger.Info("deleting transaction from storage", slog.String("hash", record.Hash.String()), slog.String("status", metamorph_api.Status_name[int32(record.Status)]))
+
+	err := p.store.Del(context.Background(), record.RawTx)
+	if err != nil {
+		p.logger.Error("failed to delete transaction", slog.String("hash", record.Hash.String()), slog.String("err", err.Error()))
+		return recordDeleted
+	}
+	recordDeleted = true
+
+	return recordDeleted
+}
+
 func (p *Processor) LoadUnmined() {
 	span, spanCtx := opentracing.StartSpanFromContext(context.Background(), "Processor:LoadUnmined")
 	defer span.Finish()
 
 	err := p.store.GetUnmined(spanCtx, func(record *store.StoreData) {
-
-		if p.now().Sub(record.StoredAt) > txDeletionPeriod {
-			p.logger.Info("deleting transaction from storage", slog.String("hash", record.Hash.String()), slog.String("status", metamorph_api.Status_name[int32(record.Status)]))
-
-			err := p.store.Del(context.Background(), record.RawTx)
-			if err != nil {
-				p.logger.Error("failed to delete transaction", slog.String("hash", record.Hash.String()), slog.String("err", err.Error()))
-			}
+		if p.deleteExpired(record) {
 			return
 		}
 

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -101,6 +101,7 @@ func TestLoadUnmined(t *testing.T) {
 		getTransactionBlockErr error
 		delErr                 error
 
+		expectedDeletions         int
 		expectedItemTxHashesFinal []*chainhash.Hash
 	}{
 		{
@@ -190,6 +191,7 @@ func TestLoadUnmined(t *testing.T) {
 				},
 			},
 
+			expectedDeletions:         1,
 			expectedItemTxHashesFinal: []*chainhash.Hash{},
 		},
 		{
@@ -204,7 +206,8 @@ func TestLoadUnmined(t *testing.T) {
 			},
 			delErr: errors.New("failed to delete hash"),
 
-			expectedItemTxHashesFinal: []*chainhash.Hash{},
+			expectedDeletions:         1,
+			expectedItemTxHashesFinal: []*chainhash.Hash{testdata.TX2Hash},
 		},
 	}
 
@@ -265,6 +268,7 @@ func TestLoadUnmined(t *testing.T) {
 				WithNow(func() time.Time {
 					return storedAt.Add(1 * time.Hour)
 				}),
+				WithDataRetentionPeriod(time.Hour*24),
 			)
 			require.NoError(t, err)
 			defer processor.Shutdown()
@@ -280,6 +284,7 @@ func TestLoadUnmined(t *testing.T) {
 				allItemHashes = append(allItemHashes, item.Hash)
 			}
 
+			require.Equal(t, tc.expectedDeletions, len(mtmStore.DelCalls()))
 			require.ElementsMatch(t, tc.expectedItemTxHashesFinal, allItemHashes)
 		})
 	}


### PR DESCRIPTION
On loading unmined transactions delete those from storage which have been stored more than 2 weeks earlier