### PR TITLE
Fix for submitting mined transactions

### DIFF
--- a/metamorph/server.go
+++ b/metamorph/server.go
@@ -405,8 +405,7 @@ func (s *Server) putTransactionInit(ctx context.Context, req *metamorph_api.Tran
 		// submitting the same transaction through arc endpoint we have problem.
 		// The transaction doesn't exist in metamorph so the call after this line
 		// (updating tx status to MINED) will fail as there is no transaction to update.
-		// In that case we take the transaction from blocktx (where we parsed it from network)
-		// and store it first in metamorph database. BPAAS-1150
+		// In that case we take the transaction and store it first in metamorph database.
 		if err := s.store.Set(ctx, hash[:], &store.StoreData{
 			Hash:          &hash,
 			Status:        status,

--- a/metamorph/server.go
+++ b/metamorph/server.go
@@ -414,7 +414,7 @@ func (s *Server) putTransactionInit(ctx context.Context, req *metamorph_api.Tran
 			MerkleProof:   req.MerkleProof,
 			RawTx:         req.RawTx,
 		}); err != nil {
-			s.logger.Warn("Transaction already exists in db", slog.String("warn", err.Error()))
+			s.logger.Error("Failed to store transaction", slog.String("hash", hash.String()), slog.String("err", err.Error()))
 		}
 
 		// If the transaction was mined, we should mark it as such


### PR DESCRIPTION
Insert transaction first to update it's status to mined.