### PR TITLE
Do not delete rejected transactions prematurely

### DIFF
--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -511,8 +511,6 @@ func (p *Processor) SendStatusForTransaction(hash *chainhash.Hash, status metamo
 					p.logger.Warn("transaction rejected", slog.String("status", status.String()), slog.String("hash", hash.String()))
 
 					p.rejected.AddDuration(source, time.Since(processorResponse.Start))
-					processorResponse.Close()
-					p.processorResponseMap.Delete(hash)
 				}
 			},
 		})


### PR DESCRIPTION
- Do not delete rejected transactions from the processor response map, as they could still get into the mempool and eventually mined
- If rejected transactions stay rejected, they'll get expired and cleaned after (currently) 24h of expiration duration: https://github.com/bitcoin-sv/arc/blob/7046640673b5f348c5a4f6746658c2313ade4c59/metamorph/processor_response_map.go#L59-L63