### PR TITLE
If processedAt date of a block has not been found, do not return an error

### DIFF
--- a/metamorph/store/dynamodb/dynamodb.go
+++ b/metamorph/store/dynamodb/dynamodb.go
@@ -558,7 +558,7 @@ func (ddb *DynamoDB) GetBlockProcessed(ctx context.Context, blockHash *chainhash
 		return &processedAtTime, nil
 	}
 
-	return nil, store.ErrNotFound
+	return nil, nil
 }
 
 func (ddb *DynamoDB) SetBlockProcessed(ctx context.Context, blockHash *chainhash.Hash) error {

--- a/metamorph/store/dynamodb/dynamodb_test.go
+++ b/metamorph/store/dynamodb/dynamodb_test.go
@@ -247,8 +247,9 @@ func TestDynamoDBIntegration(t *testing.T) {
 		require.NoError(t, err)
 
 		time.Sleep(2 * time.Second) // give DynamoDB time to delete
-		_, err = repo.GetBlockProcessed(ctx, Block1Hash)
-		require.ErrorIs(t, err, store.ErrNotFound)
+		processedAt, err := repo.GetBlockProcessed(ctx, Block1Hash)
+		require.NoError(t, err)
+		require.Nil(t, processedAt)
 	})
 
 	t.Run("transactions - time to live = -1 hour", func(t *testing.T) {


### PR DESCRIPTION
- Do not return an error if the processed at date for a block is not found
- Otherwise block processing will be skipped: https://github.com/bitcoin-sv/arc/blob/17129759f70ac0ca0271c9690bfc6d32c4fc9b53/cmd/metamorph.go#L193-L196
- This reflects the same behaviour as in the badger db implementation: https://github.com/bitcoin-sv/arc/blob/58fb518a00f17514496f6a1e6d6cebe7b3330cdd/metamorph/store/badger/badger_test.go#L194-L198