### PR TITLE
Break outer loop in blocktx client Start function so that next attemp…

### DIFF
--- a/blocktx/client.go
+++ b/blocktx/client.go
@@ -82,6 +82,7 @@ func (btc *Client) Start(minedBlockChan chan *blocktx_api.Block) {
 			btc.shutdownComplete <- struct{}{}
 		}()
 
+	getBlocksLoop:
 		for {
 			select {
 			case <-btc.getBlocksTicker.C:
@@ -102,7 +103,7 @@ func (btc *Client) Start(minedBlockChan chan *blocktx_api.Block) {
 						block, err = stream.Recv()
 						if err != nil {
 							btc.logger.Error("Failed to receive block", slog.String("err", err.Error()))
-							break
+							break getBlocksLoop
 						}
 						btc.logger.Info("Block", slog.String("hash", utils.ReverseAndHexEncodeSlice(block.Hash)))
 						utils.SafeSend(minedBlockChan, block)


### PR DESCRIPTION
- If receiving a block fails, blocktx client can get into a failing loop
- Break outer loop in blocktx client Start function so that next attempt is done at next tick