### PR TITLE
Get transaction Merkle path in Metamorph, not in api

### DIFF
--- a/api/transactionHandler/metamorph.go
+++ b/api/transactionHandler/metamorph.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bitcoin-sv/arc/metamorph/metamorph_api"
 	"github.com/bitcoin-sv/arc/tracing"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/libsv/go-p2p/chaincfg/chainhash"
 	"github.com/ordishs/go-utils"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
@@ -102,25 +101,9 @@ func (m *Metamorph) GetTransactionStatus(ctx context.Context, txID string) (stat
 		return nil, ErrTransactionNotFound
 	}
 
-	hash, err := chainhash.NewHashFromStr(txID)
-	if err != nil {
-		return nil, err
-	}
-
-	merklePath, err := m.blockTxClient.GetTransactionMerklePath(ctx, &blocktx_api.Transaction{Hash: hash[:]})
-	if err != nil {
-		if errors.Is(err, blocktx.ErrTransactionNotFoundForMerklePath) {
-			if tx.Status == metamorph_api.Status_MINED {
-				m.logger.Errorf("Merkle path not found for mined transaction %s: %v", hash.String(), err)
-			}
-		} else {
-			m.logger.Errorf("failed to get Merkle path for transaction %s: %v", hash.String(), err)
-		}
-	}
-
 	return &TransactionStatus{
 		TxID:        txID,
-		MerklePath:  merklePath,
+		MerklePath:  tx.MerklePath,
 		Status:      tx.Status.String(),
 		BlockHash:   tx.BlockHash,
 		BlockHeight: tx.BlockHeight,

--- a/metamorph/server.go
+++ b/metamorph/server.go
@@ -558,7 +558,18 @@ func (s *Server) GetTransactionStatus(ctx context.Context, req *metamorph_api.Tr
 		return nil, err
 	}
 
-	status := &metamorph_api.TransactionStatus{
+	merklePath, err := s.btc.GetTransactionMerklePath(ctx, &blocktx_api.Transaction{Hash: hash[:]})
+	if err != nil {
+		if errors.Is(err, blocktx.ErrTransactionNotFoundForMerklePath) {
+			if data.Status == metamorph_api.Status_MINED {
+				s.logger.Error("Merkle path not found for mined transaction", slog.String("hash", hash.String()), slog.String("err", err.Error()))
+			}
+		} else {
+			s.logger.Error("failed to get Merkle path for transaction", slog.String("hash", hash.String()), slog.String("err", err.Error()))
+		}
+	}
+
+	return &metamorph_api.TransactionStatus{
 		Txid:         data.Hash.String(),
 		AnnouncedAt:  announcedAt,
 		StoredAt:     storedAt,
@@ -567,22 +578,8 @@ func (s *Server) GetTransactionStatus(ctx context.Context, req *metamorph_api.Tr
 		BlockHeight:  data.BlockHeight,
 		BlockHash:    blockHash,
 		RejectReason: data.RejectReason,
-	}
-
-	merklePath, err := s.btc.GetTransactionMerklePath(ctx, &blocktx_api.Transaction{Hash: hash[:]})
-	if err != nil {
-		if errors.Is(err, blocktx.ErrTransactionNotFoundForMerklePath) {
-			if status.Status == metamorph_api.Status_MINED {
-				s.logger.Error("Merkle path not found for mined transaction", slog.String("hash", hash.String()), slog.String("err", err.Error()))
-			}
-		} else {
-			s.logger.Error("failed to get Merkle path for transaction", slog.String("hash", hash.String()), slog.String("err", err.Error()))
-		}
-	}
-
-	status.MerklePath = merklePath
-
-	return status, nil
+		MerklePath:   merklePath,
+	}, nil
 }
 
 func (s *Server) getTransactionData(ctx context.Context, req *metamorph_api.TransactionStatusRequest) (*store.StoreData, *timestamppb.Timestamp, *timestamppb.Timestamp, *timestamppb.Timestamp, error) {


### PR DESCRIPTION
- Remove direct dependency of API to blocktx
- Get transaction Merkle path in Metamorph, not in api