### PR TITLE
fix: update go-bc solves BUMP related memory exhaustion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/labstack/echo/v4 v4.11.1
 	github.com/labstack/gommon v0.4.0
 	github.com/lib/pq v1.10.9
-	github.com/libsv/go-bc v0.1.24
+	github.com/libsv/go-bc v0.1.25
 	github.com/libsv/go-bk v0.1.6
 	github.com/libsv/go-bt v1.0.8
 	github.com/libsv/go-bt/v2 v2.2.5

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmt
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/libsv/go-bc v0.1.24 h1:yyI/FRmFEXizgSMK9lcalkxC81zNUzG7cU2yQ6Q9gA8=
-github.com/libsv/go-bc v0.1.24/go.mod h1:l6epTfcakN8YKId/hrpUzlu1QeT3ODF1MI3DeYhG1O8=
+github.com/libsv/go-bc v0.1.25 h1:Jsmqrari/YzVH3FuDfvSeG6nyDiOGCV0AYntaL/5TFk=
+github.com/libsv/go-bc v0.1.25/go.mod h1:l6epTfcakN8YKId/hrpUzlu1QeT3ODF1MI3DeYhG1O8=
 github.com/libsv/go-bk v0.1.6 h1:c9CiT5+64HRDbzxPl1v/oiFmbvWZTuUYqywCf+MBs/c=
 github.com/libsv/go-bk v0.1.6/go.mod h1:khJboDoH18FPUaZlzRFKzlVN84d4YfdmlDtdX4LAjQA=
 github.com/libsv/go-bt v1.0.8 h1:nWLLcnUm0dxNO3exqrL5jvAcTGkl0dsnBuQqB6+M6vQ=


### PR DESCRIPTION
When BUMPs are being created, it was encoding the whole tree for every transaction. This small update ensures that only the relevant hashes are stored and the BUMP format returned is minimal. This should Massively improve performance issues associated with large memory usage.