### PR TITLE
Format time duration as string

### DIFF
--- a/background_worker/jobs/clear_block_transactions_map.go
+++ b/background_worker/jobs/clear_block_transactions_map.go
@@ -34,6 +34,6 @@ func ClearBlockTransactionsMap(params ClearRecrodsParams) error {
 
 	timePassed := time.Since(start)
 
-	logger.Info("Successfully cleared block_transactions_map table", slog.Int64("rows", rows), slog.Duration("duration", timePassed))
+	logger.Info("Successfully cleared block_transactions_map table", slog.Int64("rows", rows), slog.String("duration", timePassed.String()))
 	return nil
 }

--- a/background_worker/jobs/clear_blocks.go
+++ b/background_worker/jobs/clear_blocks.go
@@ -42,6 +42,6 @@ func ClearBlocks(params ClearRecrodsParams) error {
 
 	timePassed := time.Since(start)
 
-	logger.Info("Successfully cleared blocks table", slog.Int64("rows", rows), slog.Duration("duration", timePassed))
+	logger.Info("Successfully cleared blocks table", slog.Int64("rows", rows), slog.String("duration", timePassed.String()))
 	return nil
 }

--- a/background_worker/jobs/clear_transactions.go
+++ b/background_worker/jobs/clear_transactions.go
@@ -34,6 +34,6 @@ func ClearTransactions(params ClearRecrodsParams) error {
 	rows, _ := res.RowsAffected()
 	timePassed := time.Since(start)
 
-	logger.Info("Successfully cleared transactions table", slog.Int64("rows", rows), slog.Duration("duration", timePassed))
+	logger.Info("Successfully cleared transactions table", slog.Int64("rows", rows), slog.String("duration", timePassed.String()))
 	return nil
 }


### PR DESCRIPTION
- Currently duration is formatted in nano seconds `"duration":1665167`
- Use more human readable format