### PR TITLE
Add index on inserted_at field

### DIFF
--- a/database/migrations/blocktx/postgres/000007_inserted_at_index.down.sql
+++ b/database/migrations/blocktx/postgres/000007_inserted_at_index.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX ux_blocks_inserted_at;
+DROP INDEX ux_transactions_inserted_at;
+DROP INDEX ux_block_transactions_map_inserted_at;

--- a/database/migrations/blocktx/postgres/000007_inserted_at_index.up.sql
+++ b/database/migrations/blocktx/postgres/000007_inserted_at_index.up.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX IF NOT EXISTS ux_blocks_inserted_at ON blocks (inserted_at);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_transactions_inserted_at ON transactions (inserted_at);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_block_transactions_map_inserted_at ON block_transactions_map (inserted_at);


### PR DESCRIPTION
- Add index on inserted_at field
- This index will increase speed of clearing data in the background worker when there are millions of rows
  - https://github.com/bitcoin-sv/arc/blob/f43dd6c46005b0a9b139e1fd191a05c779656371/background_worker/jobs/clear_block_transactions_map.go#L21
  - https://github.com/bitcoin-sv/arc/blob/f43dd6c46005b0a9b139e1fd191a05c779656371/background_worker/jobs/clear_blocks.go#L28
  - https://github.com/bitcoin-sv/arc/blob/f43dd6c46005b0a9b139e1fd191a05c779656371/background_worker/jobs/clear_transactions.go#L22