### PR TITLE
Do not check for expiry when getting hash from memory

### DIFF
--- a/metamorph/processor_response_map.go
+++ b/metamorph/processor_response_map.go
@@ -114,10 +114,6 @@ func (m *ProcessorResponseMap) Get(hash *chainhash.Hash) (*processor_response.Pr
 		return nil, false
 	}
 
-	if m.now().Sub(processorResponse.Start) > m.Expiry {
-		return nil, false
-	}
-
 	return processorResponse, true
 }
 

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -186,20 +186,6 @@ func TestLoadUnmined(t *testing.T) {
 
 			expectedItemTxHashesFinal: []*chainhash.Hash{testdata.TX2Hash},
 		},
-		{
-			name: "delete expired - deletion fails",
-			storedData: []*store.StoreData{
-				{
-					StoredAt:    storedAt.Add(-400 * time.Hour),
-					AnnouncedAt: storedAt.Add(1 * time.Second),
-					Hash:        testdata.TX2Hash,
-					Status:      metamorph_api.Status_SEEN_ON_NETWORK,
-				},
-			},
-			delErr: errors.New("failed to delete hash"),
-
-			expectedItemTxHashesFinal: []*chainhash.Hash{testdata.TX2Hash},
-		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
- Do not check for expiry when getting hash from processor response map
- Expiry duration is needed only when cleaning processor response map