### PR TITLE
Fix/allow callbacks without block info

### DIFF
--- a/blocktx/store/sql/fixtures/get_transaction_blocks/block_transactions_map.yaml
+++ b/blocktx/store/sql/fixtures/get_transaction_blocks/block_transactions_map.yaml
@@ -1,0 +1,4 @@
+- blockid: 9736
+  txid: 115361489
+  pos: 36
+  inserted_at_num: 2024011012

--- a/blocktx/store/sql/fixtures/get_transaction_blocks/blocks.yaml
+++ b/blocktx/store/sql/fixtures/get_transaction_blocks/blocks.yaml
@@ -1,0 +1,12 @@
+- inserted_at:  2024-01-10 13:06:03.375
+  id:  9736
+  hash:  0x6258b02da70a3e367e4c993b049fa9b76ef8f090ef9fd2010000000000000000
+  prevhash:  0x000000000000000001a7aa3999410ca53fb645851531ec0a7a5cb9ce2d4ae313
+  merkleroot:  0x0d72bf92e7862df18d1935c171ca4dbb70d268b0f025e46716e913bc7e4f2bdb
+  height:  826481
+  processed_at:  2024-01-10 13:06:06.122
+  size:  108689370
+  tx_count:  799
+  orphanedyn: FALSE
+  merkle_path: ""
+  inserted_at_num: 2024011012

--- a/blocktx/store/sql/fixtures/get_transaction_blocks/transactions.yaml
+++ b/blocktx/store/sql/fixtures/get_transaction_blocks/transactions.yaml
@@ -1,0 +1,10 @@
+- id: 110383995
+  hash: 0x76732b80598326a18d3bf0a86518adbdf95d0ddc6ff6693004440f4776168c3b
+  source: ""
+  merkle_path: ""
+  inserted_at_num: 2024010913
+- id: 115361489
+  hash: 0x164e85a5d5bc2b2372e8feaa266e5e4b7d0808f8d2b784fb1f7349c4726392b0
+  source: ""
+  merkle_path: ""
+  inserted_at_num: 2024011012

--- a/blocktx/store/sql/get_transaction_blocks_test.go
+++ b/blocktx/store/sql/get_transaction_blocks_test.go
@@ -118,14 +118,15 @@ func TestGetTransactionBlocks(t *testing.T) {
 			name: "query fails",
 			sqlmockExpectations: func(mock sqlmock.Sqlmock) {
 				query := `
-				SELECT
-				b.hash, b.height, t.hash
-				FROM blocks b
-				INNER JOIN block_transactions_map m ON m.blockid = b.id
-				INNER JOIN transactions t ON m.txid = t.id
-				WHERE t.hash = ANY($1)
-				AND b.orphanedyn = FALSE`
+			SELECT
+			b.hash, b.height, t.hash
+			FROM transactions t
+			LEFT JOIN block_transactions_map m ON m.txid = t.id
+			LEFT JOIN blocks b ON m.blockid = b.id
+			WHERE t.hash = ANY($1)
+			;`
 
+				//SELECT b.hash, b.height, t.hash FROM transactions t LEFT JOIN block_transactions_map m ON m.txid = t.id LEFT JOIN blocks b ON m.blockid = b.id WHERE t.hash = ANY($1)
 				mock.ExpectQuery(query).WillReturnError(errors.New("db connection error"))
 			},
 			expectedErrorStr: "db connection error",
@@ -134,13 +135,13 @@ func TestGetTransactionBlocks(t *testing.T) {
 			name: "scanning fails",
 			sqlmockExpectations: func(mock sqlmock.Sqlmock) {
 				query := `
-				SELECT
-				b.hash, b.height, t.hash
-				FROM blocks b
-				INNER JOIN block_transactions_map m ON m.blockid = b.id
-				INNER JOIN transactions t ON m.txid = t.id
-				WHERE t.hash = ANY($1)
-				AND b.orphanedyn = FALSE`
+			SELECT
+			b.hash, b.height, t.hash
+			FROM transactions t
+			LEFT JOIN block_transactions_map m ON m.txid = t.id
+			LEFT JOIN blocks b ON m.blockid = b.id
+			WHERE t.hash = ANY($1)
+			;`
 
 				mock.ExpectQuery(query).WillReturnRows(
 					sqlmock.NewRows([]string{"hash", "height", "hash"}).AddRow(

--- a/blocktx/store/sql/get_transaction_blocks_test.go
+++ b/blocktx/store/sql/get_transaction_blocks_test.go
@@ -2,12 +2,14 @@ package sql
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 
+	"github.com/go-testfixtures/testfixtures/v3"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bitcoin-sv/arc/blocktx/blocktx_api"
-	"github.com/bitcoin-sv/arc/blocktx/store"
 	. "github.com/bitcoin-sv/arc/database_testing"
 	"github.com/libsv/go-p2p/chaincfg/chainhash"
 	"github.com/stretchr/testify/require"
@@ -19,31 +21,54 @@ type GetTransactionBlocksSuite struct {
 }
 
 func (s *GetTransactionBlocksSuite) Test() {
-	block := GetTestBlock()
-	tx := GetTestTransaction()
-	s.InsertBlock(block)
 
-	s.InsertTransaction(tx)
-
-	s.InsertBlockTransactionMap(&store.BlockTransactionMap{
-		BlockID:       block.ID,
-		TransactionID: tx.ID,
-		Pos:           2,
-	})
-
-	store, err := NewPostgresStore(DefaultParams)
+	db, err := sql.Open("postgres", DefaultParams.String())
 	require.NoError(s.T(), err)
 
-	b, err := store.GetTransactionBlocks(context.Background(), &blocktx_api.Transactions{
+	st := &SQL{db: db, engine: postgresEngine}
+
+	fixtures, err := testfixtures.New(
+		testfixtures.Database(db),
+		testfixtures.Dialect("postgresql"),
+		testfixtures.Directory("fixtures/get_transaction_blocks"), // The directory containing the YAML files
+	)
+	require.NoError(s.T(), err)
+
+	err = fixtures.Load()
+	require.NoError(s.T(), err)
+	ctx := context.Background()
+
+	txHash1, err := chainhash.NewHashFromStr("b0926372c449731ffb84b7d2f808087d4b5e6e26aafee872232bbcd5a5854e16")
+	require.NoError(s.T(), err)
+
+	blockHash, err := chainhash.NewHashFromStr("000000000000000001d29fef90f0f86eb7a99f043b994c7e363e0aa72db05862")
+	require.NoError(s.T(), err)
+
+	b, err := st.GetTransactionBlocks(ctx, &blocktx_api.Transactions{
 		Transactions: []*blocktx_api.Transaction{
 			{
-				Hash: []byte(tx.Hash),
+				Hash: txHash1[:],
 			},
 		},
 	})
 	require.NoError(s.T(), err)
-	require.Equal(s.T(), block.Hash, string(b.GetTransactionBlocks()[0].GetBlockHash()))
-	require.Equal(s.T(), tx.Hash, string(b.GetTransactionBlocks()[0].GetTransactionHash()))
+	require.Equal(s.T(), blockHash[:], b.TransactionBlocks[0].BlockHash)
+	require.Equal(s.T(), uint64(826481), b.TransactionBlocks[0].BlockHeight)
+	require.Equal(s.T(), txHash1[:], b.TransactionBlocks[0].TransactionHash)
+
+	txHash2, err := chainhash.NewHashFromStr("3b8c1676470f44043069f66fdc0d5df9bdad1865a8f03b8da1268359802b7376")
+	require.NoError(s.T(), err)
+	b, err = st.GetTransactionBlocks(ctx, &blocktx_api.Transactions{
+		Transactions: []*blocktx_api.Transaction{
+			{
+				Hash: txHash2[:],
+			},
+		},
+	})
+	require.NoError(s.T(), err)
+	require.Nil(s.T(), b.TransactionBlocks[0].BlockHash)
+	require.Equal(s.T(), uint64(0), b.TransactionBlocks[0].BlockHeight)
+	require.Equal(s.T(), txHash2[:], b.TransactionBlocks[0].TransactionHash)
 }
 
 func TestGetTransactionBlocksIntegration(t *testing.T) {

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -202,10 +202,14 @@ func (p *Processor) processCheckIfMined() {
 		p.logger.Debug("found blocks for transactions", slog.Int("number", len(blockTransactions.GetTransactionBlocks())))
 
 		for _, blockTxs := range blockTransactions.GetTransactionBlocks() {
+			var blockHashString string
+
 			blockHash, err := chainhash.NewHash(blockTxs.GetBlockHash())
 			if err != nil {
 				p.logger.Error("failed to parse block hash", slog.String("err", err.Error()))
-				continue
+				blockHashString = ""
+			} else {
+				blockHashString = blockHash.String()
 			}
 
 			txHash, err := chainhash.NewHash(blockTxs.GetTransactionHash())
@@ -213,7 +217,7 @@ func (p *Processor) processCheckIfMined() {
 				p.logger.Error("failed to parse tx hash", slog.String("err", err.Error()))
 				continue
 			}
-			p.logger.Debug("found block for transaction", slog.String("txhash", txHash.String()), slog.String("blockhash", blockHash.String()))
+			p.logger.Debug("found block for transaction", slog.String("txhash", txHash.String()), slog.String("blockhash", blockHashString))
 
 			_, err = p.SendStatusMinedForTransaction(txHash, blockHash, blockTxs.GetBlockHeight())
 			if err != nil {

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -728,6 +728,22 @@ func TestProcessCheckIfMined(t *testing.T) {
 
 			expectedNrOfUpdates: 0,
 		},
+		{
+			name: "missing block info",
+			blocks: []*blocktx_api.TransactionBlock{
+				{
+					TransactionHash: testdata.TX1Hash[:],
+				},
+				{
+					TransactionHash: testdata.TX2Hash[:],
+				},
+				{
+					TransactionHash: testdata.TX3Hash[:],
+				},
+			},
+
+			expectedNrOfUpdates: 3,
+		},
 	}
 
 	for _, tc := range tt {
@@ -739,9 +755,7 @@ func TestProcessCheckIfMined(t *testing.T) {
 				UpdateMinedFunc: func(ctx context.Context, hash *chainhash.Hash, blockHash *chainhash.Hash, blockHeight uint64) error {
 					require.Condition(t, func() (success bool) {
 						oneOfHash := hash.IsEqual(testdata.TX1Hash) || hash.IsEqual(testdata.TX2Hash) || hash.IsEqual(testdata.TX3Hash)
-						isBlockHeight := blockHeight == 1234
-						isBlockHash := blockHash.IsEqual(testdata.Block1Hash)
-						return oneOfHash && isBlockHeight && isBlockHash
+						return oneOfHash
 					})
 
 					return tc.updateMinedErr

--- a/metamorph/store/postgresql/postgres_test.go
+++ b/metamorph/store/postgresql/postgres_test.go
@@ -298,6 +298,26 @@ func TestPostgresDB(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("update mined - missing block info", func(t *testing.T) {
+		unmined := *unminedData
+		err = postgresDB.Set(ctx, unminedHash[:], &unmined)
+		require.NoError(t, err)
+
+		err := postgresDB.UpdateMined(ctx, unminedHash, nil, 0)
+		require.NoError(t, err)
+
+		dataReturned, err := postgresDB.Get(ctx, unminedHash[:])
+		require.NoError(t, err)
+		unmined.Status = metamorph_api.Status_MINED
+		unmined.MinedAt = now
+		unmined.BlockHeight = 0
+		unmined.BlockHash = nil
+		require.Equal(t, dataReturned, &unmined)
+
+		err = postgresDB.Del(ctx, unminedHash[:])
+		require.NoError(t, err)
+	})
+
 	t.Run("get/set block processed", func(t *testing.T) {
 		err = postgresDB.SetBlockProcessed(ctx, testdata.Block1Hash)
 		require.NoError(t, err)


### PR DESCRIPTION
- Allow to find block transaction without block information when block_transactions_map is missing
- Do nothing after loading records. Let go routines do the retrying and checking if mined
- Allow marking as mined with missing block information