### PR TITLE
Fix/unknown status

### DIFF
--- a/metamorph/processor_response/processor_response.go
+++ b/metamorph/processor_response/processor_response.go
@@ -45,7 +45,7 @@ type ProcessorResponse struct {
 }
 
 func NewProcessorResponse(hash *chainhash.Hash) *ProcessorResponse {
-	return newProcessorResponse(hash, metamorph_api.Status_UNKNOWN, nil)
+	return newProcessorResponse(hash, metamorph_api.Status_RECEIVED, nil)
 }
 
 // NewProcessorResponseWithStatus creates a new ProcessorResponse with the given status.
@@ -55,7 +55,7 @@ func NewProcessorResponseWithStatus(hash *chainhash.Hash, status metamorph_api.S
 }
 
 func NewProcessorResponseWithChannel(hash *chainhash.Hash, ch chan StatusAndError) *ProcessorResponse {
-	return newProcessorResponse(hash, metamorph_api.Status_UNKNOWN, ch)
+	return newProcessorResponse(hash, metamorph_api.Status_RECEIVED, ch)
 }
 
 func newProcessorResponse(hash *chainhash.Hash, status metamorph_api.Status, ch chan StatusAndError) *ProcessorResponse {

--- a/metamorph/processor_response/processor_response_test.go
+++ b/metamorph/processor_response/processor_response_test.go
@@ -22,14 +22,14 @@ func TestNewProcessorResponse(t *testing.T) {
 		response := NewProcessorResponse(testdata.TX1Hash)
 		assert.NotNil(t, response.Start)
 		assert.Equal(t, testdata.TX1Hash, response.Hash)
-		assert.Equal(t, metamorph_api.Status_UNKNOWN, response.Status)
+		assert.Equal(t, metamorph_api.Status_RECEIVED, response.Status)
 	})
 }
 
 func TestGetStatus(t *testing.T) {
 	t.Run("GetStatus", func(t *testing.T) {
 		response := NewProcessorResponse(testdata.TX1Hash)
-		assert.Equal(t, metamorph_api.Status_UNKNOWN, response.GetStatus())
+		assert.Equal(t, metamorph_api.Status_RECEIVED, response.GetStatus())
 	})
 }
 
@@ -55,7 +55,7 @@ func TestSetErr(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			for status := range ch {
-				assert.Equal(t, metamorph_api.Status_UNKNOWN, status.Status)
+				assert.Equal(t, metamorph_api.Status_RECEIVED, status.Status)
 				assert.ErrorIs(t, err, status.Err)
 				wg.Done()
 			}
@@ -72,7 +72,7 @@ func TestSetStatusAndError(t *testing.T) {
 	t.Run("SetStatusAndError", func(t *testing.T) {
 		response := NewProcessorResponse(testdata.TX1Hash)
 		assert.Nil(t, response.Err)
-		assert.Equal(t, metamorph_api.Status_UNKNOWN, response.Status)
+		assert.Equal(t, metamorph_api.Status_RECEIVED, response.Status)
 
 		err := fmt.Errorf("test error")
 		response.setStatusAndError(metamorph_api.Status_SENT_TO_NETWORK, err, "test")
@@ -85,7 +85,7 @@ func TestSetStatusAndError(t *testing.T) {
 		ch := make(chan StatusAndError)
 		response := NewProcessorResponse(testdata.TX1Hash)
 		assert.Nil(t, response.Err)
-		assert.Equal(t, metamorph_api.Status_UNKNOWN, response.Status)
+		assert.Equal(t, metamorph_api.Status_RECEIVED, response.Status)
 
 		response.callerCh = ch
 		err := fmt.Errorf("test error")

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -630,7 +630,7 @@ func BenchmarkProcessTransaction(b *testing.B) {
 		processor.ProcessTransaction(context.TODO(), &ProcessorRequest{
 			Data: &store.StoreData{
 				Hash:   &txHash,
-				Status: metamorph_api.Status_UNKNOWN,
+				Status: metamorph_api.Status_RECEIVED,
 				RawTx:  testdata.TX1RawBytes,
 			},
 		})

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -244,7 +244,6 @@ func TestProcessTransaction(t *testing.T) {
 			storeDataGetErr: store.ErrNotFound,
 
 			expectedResponses: []metamorph_api.Status{
-				metamorph_api.Status_RECEIVED,
 				metamorph_api.Status_STORED,
 				metamorph_api.Status_ANNOUNCED_TO_NETWORK,
 			},

--- a/metamorph/server.go
+++ b/metamorph/server.go
@@ -205,7 +205,7 @@ func (s *Server) PutTransaction(ctx context.Context, req *metamorph_api.Transact
 		return nil, err
 	}
 	hash := handler.PtrTo(chainhash.DoubleHashH(req.GetRawTx()))
-	status := metamorph_api.Status_UNKNOWN
+	status := metamorph_api.Status_RECEIVED
 
 	// Convert gRPC req to store.StoreData struct...
 	sReq := &store.StoreData{
@@ -256,7 +256,7 @@ func (s *Server) PutTransactions(ctx context.Context, req *metamorph_api.Transac
 			return nil, err
 		}
 
-		status := metamorph_api.Status_UNKNOWN
+		status := metamorph_api.Status_RECEIVED
 		hash := handler.PtrTo(chainhash.DoubleHashH(txReq.GetRawTx()))
 		timeout = txReq.GetMaxTimeout()
 

--- a/metamorph/server.go
+++ b/metamorph/server.go
@@ -318,7 +318,15 @@ func (s *Server) processTransaction(ctx context.Context, waitForStatus metamorph
 	}
 
 	t := time.NewTimer(timeDuration)
-	returnedStatus := &metamorph_api.TransactionStatus{Txid: TxID}
+	returnedStatus := &metamorph_api.TransactionStatus{
+		Txid:   TxID,
+		Status: metamorph_api.Status_RECEIVED,
+	}
+
+	// Return the status if it has greater or equal value
+	if statusValueMap[returnedStatus.GetStatus()] >= statusValueMap[waitForStatus] {
+		return returnedStatus
+	}
 
 	for {
 		select {

--- a/metamorph/server_test.go
+++ b/metamorph/server_test.go
@@ -446,7 +446,27 @@ func TestPutTransactions(t *testing.T) {
 			},
 		},
 		{
-			name: "single new transaction no response",
+			name: "single new transaction - wait for received status",
+			requests: &metamorph_api.TransactionRequests{
+				Transactions: []*metamorph_api.TransactionRequest{{
+					RawTx:         tx0.Bytes(),
+					WaitForStatus: metamorph_api.Status_RECEIVED,
+				}},
+			},
+
+			expectedProcessorProcessTransactionCalls: 1,
+			expectedStatuses: &metamorph_api.TransactionStatuses{
+				Statuses: []*metamorph_api.TransactionStatus{
+					{
+						Txid:     hash0.String(),
+						Status:   metamorph_api.Status_RECEIVED,
+						TimedOut: false,
+					},
+				},
+			},
+		},
+		{
+			name: "single new transaction - time out",
 			requests: &metamorph_api.TransactionRequests{
 				Transactions: []*metamorph_api.TransactionRequest{{RawTx: tx0.Bytes()}},
 			},

--- a/metamorph/server_test.go
+++ b/metamorph/server_test.go
@@ -456,7 +456,7 @@ func TestPutTransactions(t *testing.T) {
 				Statuses: []*metamorph_api.TransactionStatus{
 					{
 						Txid:     hash0.String(),
-						Status:   metamorph_api.Status_UNKNOWN,
+						Status:   metamorph_api.Status_RECEIVED,
 						TimedOut: true,
 					},
 				},

--- a/metamorph/store/postgresql/migrations/000008_transaction_status_default.down.sql
+++ b/metamorph/store/postgresql/migrations/000008_transaction_status_default.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE metamorph.transactions ALTER COLUMN status DROP DEFAULT;

--- a/metamorph/store/postgresql/migrations/000008_transaction_status_default.up.sql
+++ b/metamorph/store/postgresql/migrations/000008_transaction_status_default.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE metamorph.transactions ALTER COLUMN status SET DEFAULT 3;


### PR DESCRIPTION
-  As soon as ARC processes the tx, it has status RECEIVED and not UNKNOWN
- Skip separate RECEIVED step in processor
- Default status of a stored tx is STORED
-  If waiting for <= received status, then return immediately
