### PR TITLE
Refactor/bulk update status

### DIFF
--- a/blocktx/store/postgresql/postgres_test.go
+++ b/blocktx/store/postgresql/postgres_test.go
@@ -379,7 +379,7 @@ func TestPostgresDB(t *testing.T) {
 
 		require.ErrorContains(t, err, "transactions (len=3) and Merkle paths (len=1) have not the same lengths")
 
-		_, err = postgresDB.UpdateBlockTransactions(context.Background(), testBlockID, []*blocktx_api.TransactionAndSource{
+		updateResult, err := postgresDB.UpdateBlockTransactions(context.Background(), testBlockID, []*blocktx_api.TransactionAndSource{
 			{
 				Hash: txHash1[:],
 			},
@@ -391,6 +391,12 @@ func TestPostgresDB(t *testing.T) {
 			},
 		}, testMerklePaths)
 		require.NoError(t, err)
+
+		require.True(t, bytes.Equal(txHash1[:], updateResult[0].TxHash))
+		require.Equal(t, testMerklePaths[0], updateResult[0].MerklePath)
+
+		require.True(t, bytes.Equal(txHash2[:], updateResult[1].TxHash))
+		require.Equal(t, testMerklePaths[1], updateResult[1].MerklePath)
 
 		d, err := sqlx.Open("postgres", dbInfo)
 		require.NoError(t, err)

--- a/cmd/blocktx.go
+++ b/cmd/blocktx.go
@@ -15,8 +15,6 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
-const BecomePrimaryintervalSecs = 30
-
 func StartBlockTx(logger *slog.Logger) (func(), error) {
 	dbMode, err := config.GetString("blocktx.db.mode")
 	if err != nil {

--- a/cmd/metamorph.go
+++ b/cmd/metamorph.go
@@ -89,6 +89,11 @@ func StartMetamorph(logger *slog.Logger) (func(), error) {
 		return nil, err
 	}
 
+	processStatusUpdateInterval, err := config.GetDuration("metamorph.processStatusUpdateInterval")
+	if err != nil {
+		return nil, err
+	}
+
 	// maximum amount of messages that could be coming from a single block
 	capacityRequired := int(float64(targetTps*avgMinPerBlock*secPerMin) / float64(maxBatchSize))
 	minedTxsChan := make(chan *blocktx_api.TransactionBlocks, capacityRequired)
@@ -112,6 +117,7 @@ func StartMetamorph(logger *slog.Logger) (func(), error) {
 		metamorph.WithMaxMonitoredTxs(maxMonitoredTxs),
 		metamorph.WithMessageQueueClient(mqClient),
 		metamorph.WithMinedTxsChan(minedTxsChan),
+		metamorph.WithProcessStatusUpdatesInterval(processStatusUpdateInterval),
 	)
 
 	http.HandleFunc("/pstats", metamorphProcessor.HandleStats)

--- a/config.yaml
+++ b/config.yaml
@@ -47,6 +47,7 @@ metamorph:
       recordRetentionDays: 14 # number of days for which data is kept in the storage before it can be deleted
       executionIntervalHours: 24
   processorCacheExpiryTime: 24h # time after which processor cache is cleaned
+  processStatusUpdateInterval: 5s # interval of procesing status updates
   checkUtxos: false # force check each utxo for validity. If enabled ARC connects to bitcoin node using rpc for each utxo
   statsKeypress: false # enable stats keypress. If enabled pressing any key will print stats to stdout
   profilerAddr: localhost:9992 # address to start profiler server on

--- a/metamorph/mocks/store_mock.go
+++ b/metamorph/mocks/store_mock.go
@@ -6,7 +6,6 @@ package mocks
 import (
 	"context"
 	"github.com/bitcoin-sv/arc/blocktx/blocktx_api"
-	"github.com/bitcoin-sv/arc/metamorph/metamorph_api"
 	"github.com/bitcoin-sv/arc/metamorph/store"
 	"github.com/libsv/go-p2p/chaincfg/chainhash"
 	"sync"
@@ -53,9 +52,6 @@ var _ store.MetamorphStore = &MetamorphStoreMock{}
 //			UpdateMinedFunc: func(ctx context.Context, txsBlocks *blocktx_api.TransactionBlocks) ([]*store.StoreData, error) {
 //				panic("mock out the UpdateMined method")
 //			},
-//			UpdateStatusFunc: func(ctx context.Context, hash *chainhash.Hash, status metamorph_api.Status, rejectReason string) error {
-//				panic("mock out the UpdateStatus method")
-//			},
 //			UpdateStatusBulkFunc: func(ctx context.Context, updates []store.UpdateStatus) ([]*store.StoreData, error) {
 //				panic("mock out the UpdateStatusBulk method")
 //			},
@@ -95,9 +91,6 @@ type MetamorphStoreMock struct {
 
 	// UpdateMinedFunc mocks the UpdateMined method.
 	UpdateMinedFunc func(ctx context.Context, txsBlocks *blocktx_api.TransactionBlocks) ([]*store.StoreData, error)
-
-	// UpdateStatusFunc mocks the UpdateStatus method.
-	UpdateStatusFunc func(ctx context.Context, hash *chainhash.Hash, status metamorph_api.Status, rejectReason string) error
 
 	// UpdateStatusBulkFunc mocks the UpdateStatusBulk method.
 	UpdateStatusBulkFunc func(ctx context.Context, updates []store.UpdateStatus) ([]*store.StoreData, error)
@@ -174,17 +167,6 @@ type MetamorphStoreMock struct {
 			// TxsBlocks is the txsBlocks argument value.
 			TxsBlocks *blocktx_api.TransactionBlocks
 		}
-		// UpdateStatus holds details about calls to the UpdateStatus method.
-		UpdateStatus []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// Hash is the hash argument value.
-			Hash *chainhash.Hash
-			// Status is the status argument value.
-			Status metamorph_api.Status
-			// RejectReason is the rejectReason argument value.
-			RejectReason string
-		}
 		// UpdateStatusBulk holds details about calls to the UpdateStatusBulk method.
 		UpdateStatusBulk []struct {
 			// Ctx is the ctx argument value.
@@ -203,7 +185,6 @@ type MetamorphStoreMock struct {
 	lockSetUnlocked       sync.RWMutex
 	lockSetUnlockedByName sync.RWMutex
 	lockUpdateMined       sync.RWMutex
-	lockUpdateStatus      sync.RWMutex
 	lockUpdateStatusBulk  sync.RWMutex
 }
 
@@ -564,50 +545,6 @@ func (mock *MetamorphStoreMock) UpdateMinedCalls() []struct {
 	mock.lockUpdateMined.RLock()
 	calls = mock.calls.UpdateMined
 	mock.lockUpdateMined.RUnlock()
-	return calls
-}
-
-// UpdateStatus calls UpdateStatusFunc.
-func (mock *MetamorphStoreMock) UpdateStatus(ctx context.Context, hash *chainhash.Hash, status metamorph_api.Status, rejectReason string) error {
-	if mock.UpdateStatusFunc == nil {
-		panic("MetamorphStoreMock.UpdateStatusFunc: method is nil but MetamorphStore.UpdateStatus was just called")
-	}
-	callInfo := struct {
-		Ctx          context.Context
-		Hash         *chainhash.Hash
-		Status       metamorph_api.Status
-		RejectReason string
-	}{
-		Ctx:          ctx,
-		Hash:         hash,
-		Status:       status,
-		RejectReason: rejectReason,
-	}
-	mock.lockUpdateStatus.Lock()
-	mock.calls.UpdateStatus = append(mock.calls.UpdateStatus, callInfo)
-	mock.lockUpdateStatus.Unlock()
-	return mock.UpdateStatusFunc(ctx, hash, status, rejectReason)
-}
-
-// UpdateStatusCalls gets all the calls that were made to UpdateStatus.
-// Check the length with:
-//
-//	len(mockedMetamorphStore.UpdateStatusCalls())
-func (mock *MetamorphStoreMock) UpdateStatusCalls() []struct {
-	Ctx          context.Context
-	Hash         *chainhash.Hash
-	Status       metamorph_api.Status
-	RejectReason string
-} {
-	var calls []struct {
-		Ctx          context.Context
-		Hash         *chainhash.Hash
-		Status       metamorph_api.Status
-		RejectReason string
-	}
-	mock.lockUpdateStatus.RLock()
-	calls = mock.calls.UpdateStatus
-	mock.lockUpdateStatus.RUnlock()
 	return calls
 }
 

--- a/metamorph/processor_helpers.go
+++ b/metamorph/processor_helpers.go
@@ -30,20 +30,21 @@ func (p *Processor) GetStats(debugItems bool) *ProcessorStats {
 	}
 
 	return &ProcessorStats{
-		StartTime:          p.startTime,
-		UptimeMillis:       time.Since(p.startTime).String(),
-		QueueLength:        p.queueLength.Load(),
-		QueuedCount:        p.queuedCount.Load(),
-		Stored:             p.stored,
-		AnnouncedToNetwork: p.announcedToNetwork,
-		RequestedByNetwork: p.requestedByNetwork,
-		SentToNetwork:      p.sentToNetwork,
-		AcceptedByNetwork:  p.acceptedByNetwork,
-		SeenOnNetwork:      p.seenOnNetwork,
-		Rejected:           p.rejected,
-		Mined:              p.mined,
-		Retries:            p.retries,
-		ChannelMapSize:     int32(p.ProcessorResponseMap.Len()),
+		StartTime:           p.startTime,
+		UptimeMillis:        time.Since(p.startTime).String(),
+		QueueLength:         p.queueLength.Load(),
+		QueuedCount:         p.queuedCount.Load(),
+		Stored:              p.stored,
+		AnnouncedToNetwork:  p.announcedToNetwork,
+		RequestedByNetwork:  p.requestedByNetwork,
+		SentToNetwork:       p.sentToNetwork,
+		AcceptedByNetwork:   p.acceptedByNetwork,
+		SeenInOrphanMempool: p.seenInOrphanMempool,
+		SeenOnNetwork:       p.seenOnNetwork,
+		Rejected:            p.rejected,
+		Mined:               p.mined,
+		Retries:             p.retries,
+		ChannelMapSize:      int32(p.ProcessorResponseMap.Len()),
 	}
 }
 
@@ -395,7 +396,6 @@ func (p *Processor) processorResponseStatsTable(w http.ResponseWriter, prm *proc
 		Status:                prm.Status,
 		NoStats:               prm.NoStats,
 		LastStatusUpdateNanos: prm.LastStatusUpdateNanos.Load(),
-		Log:                   prm.Log,
 	}
 
 	resLog := strings.Builder{}

--- a/metamorph/processor_options.go
+++ b/metamorph/processor_options.go
@@ -1,6 +1,7 @@
 package metamorph
 
 import (
+	"github.com/bitcoin-sv/arc/metamorph/store"
 	"log/slog"
 	"time"
 
@@ -28,6 +29,19 @@ func WithNow(nowFunc func() time.Time) func(*Processor) {
 func WithProcessExpiredTxsInterval(d time.Duration) func(*Processor) {
 	return func(p *Processor) {
 		p.processExpiredTxsTicker = time.NewTicker(d)
+	}
+}
+
+func WithProcessStatusUpdatesInterval(d time.Duration) func(*Processor) {
+	return func(p *Processor) {
+		p.processStatusUpdatesInterval = d
+	}
+}
+
+func WithProcessStatusUpdatesBatchSize(size int) func(*Processor) {
+	return func(p *Processor) {
+		p.processStatusUpdatesBatchSize = size
+		p.statusUpdateCh = make(chan store.UpdateStatus, size)
 	}
 }
 

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -263,11 +263,6 @@ func TestProcessTransaction(t *testing.T) {
 
 					return nil
 				},
-				UpdateStatusFunc: func(ctx context.Context, hash *chainhash.Hash, status metamorph_api.Status, rejectReason string) error {
-					require.Equal(t, testdata.TX1Hash, hash)
-
-					return nil
-				},
 			}
 			pm := p2p.NewPeerManagerMock()
 

--- a/metamorph/store/store.go
+++ b/metamorph/store/store.go
@@ -38,7 +38,6 @@ type MetamorphStore interface {
 	SetUnlocked(ctx context.Context, hashes []*chainhash.Hash) error
 	SetUnlockedByName(ctx context.Context, lockedBy string) (int64, error)
 	GetUnmined(ctx context.Context, since time.Time, limit int64) ([]*StoreData, error)
-	UpdateStatus(ctx context.Context, hash *chainhash.Hash, status metamorph_api.Status, rejectReason string) error
 	UpdateStatusBulk(ctx context.Context, updates []UpdateStatus) ([]*StoreData, error)
 	UpdateMined(ctx context.Context, txsBlocks *blocktx_api.TransactionBlocks) ([]*StoreData, error)
 	Close(ctx context.Context) error

--- a/metamorph/store/store.go
+++ b/metamorph/store/store.go
@@ -39,8 +39,15 @@ type MetamorphStore interface {
 	SetUnlockedByName(ctx context.Context, lockedBy string) (int64, error)
 	GetUnmined(ctx context.Context, since time.Time, limit int64) ([]*StoreData, error)
 	UpdateStatus(ctx context.Context, hash *chainhash.Hash, status metamorph_api.Status, rejectReason string) error
+	UpdateStatusBulk(ctx context.Context, updates []UpdateStatus) ([]*StoreData, error)
 	UpdateMined(ctx context.Context, txsBlocks *blocktx_api.TransactionBlocks) ([]*StoreData, error)
 	Close(ctx context.Context) error
 	ClearData(ctx context.Context, retentionDays int32) (int64, error)
 	Ping(ctx context.Context) error
+}
+
+type UpdateStatus struct {
+	Hash         chainhash.Hash
+	Status       metamorph_api.Status
+	RejectReason string
 }

--- a/metamorph/types.go
+++ b/metamorph/types.go
@@ -11,20 +11,21 @@ import (
 )
 
 type ProcessorStats struct {
-	StartTime          time.Time
-	UptimeMillis       string
-	QueueLength        int32
-	QueuedCount        int32
-	Stored             *stat.AtomicStat
-	AnnouncedToNetwork *stat.AtomicStats
-	RequestedByNetwork *stat.AtomicStats
-	SentToNetwork      *stat.AtomicStats
-	AcceptedByNetwork  *stat.AtomicStats
-	SeenOnNetwork      *stat.AtomicStats
-	Rejected           *stat.AtomicStats
-	Mined              *stat.AtomicStat
-	Retries            *stat.AtomicStat
-	ChannelMapSize     int32
+	StartTime           time.Time
+	UptimeMillis        string
+	QueueLength         int32
+	QueuedCount         int32
+	Stored              *stat.AtomicStat
+	AnnouncedToNetwork  *stat.AtomicStats
+	RequestedByNetwork  *stat.AtomicStats
+	SentToNetwork       *stat.AtomicStats
+	AcceptedByNetwork   *stat.AtomicStats
+	SeenOnNetwork       *stat.AtomicStats
+	SeenInOrphanMempool *stat.AtomicStats
+	Rejected            *stat.AtomicStats
+	Mined               *stat.AtomicStat
+	Retries             *stat.AtomicStat
+	ChannelMapSize      int32
 }
 
 type ProcessorRequest struct {

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -44,6 +44,7 @@ metamorph:
     cleanData:
       recordRetentionDays: 14 # number of days for which data is kept in the storage before it can be deleted
   processorCacheExpiryTime: 24h # time after which processor cache is cleaned
+  processStatusUpdateInterval: 100ms # interval of procesing status updates
   checkUtxos: false # force check each utxo for validity. If enabled ARC connects to bitcoin node using rpc for each utxo
   statsKeypress: false # enable stats keypress. If enabled pressing any key will print stats to stdout
   profilerAddr: localhost:9992 # address to start profiler server on

--- a/testdata/data.go
+++ b/testdata/data.go
@@ -30,6 +30,11 @@ var (
 	TX5        = "df931ab7d4ff0bbf96ff186f221c466f09c052c5331733641040defabf9dcd93"
 	TX5Hash, _ = chainhash.NewHashFromStr(TX5)
 
+	TX6            = "fbb5444147cf9fa5c4208ca56e1e2ca061da0153ea72a3fb16993865ba601106"
+	TX6Hash, _     = chainhash.NewHashFromStr(TX6)
+	TX6raw         = "010000000000000000ef016f8828b2d3f8085561d0b4ff6f5d17c269206fa3d32bcd3b22e26ce659ed12e7000000006b483045022100d3649d120249a09af44b4673eecec873109a3e120b9610b78858087fb225c9b9022037f16999b7a4fecdd9f47ebdc44abd74567a18940c37e1481ab0fe84d62152e4412102f87ce69f6ba5444aed49c34470041189c1e1060acd99341959c0594002c61bf0ffffffffe7030000000000001976a914c2b6fd4319122b9b5156a2a0060d19864c24f49a88ac01e7030000000000001976a914c2b6fd4319122b9b5156a2a0060d19864c24f49a88ac00000000"
+	TX6RawBytes, _ = hex.DecodeString(TX6raw)
+
 	Time          = time.Date(2009, 1, 03, 18, 15, 05, 0, time.UTC)
 	DefaultPolicy = `{"excessiveblocksize":2000000000,"blockmaxsize":512000000,"maxtxsizepolicy":10000000,"maxorphantxsize":1000000000,"datacarriersize":4294967295,"maxscriptsizepolicy":500000,"maxopsperscriptpolicy":4294967295,"maxscriptnumlengthpolicy":10000,"maxpubkeyspermultisigpolicy":4294967295,"maxtxsigopscountspolicy":4294967295,"maxstackmemoryusagepolicy":100000000,"maxstackmemoryusageconsensus":200000000,"limitancestorcount":10000,"limitcpfpgroupmemberscount":25,"maxmempool":2000000000,"maxmempoolsizedisk":0,"mempoolmaxpercentcpfp":10,"acceptnonstdoutputs":true,"datacarrier":true,"minminingtxfee":5e-7,"maxstdtxvalidationduration":3,"maxnonstdtxvalidationduration":1000,"maxtxchainvalidationbudget":50,"validationclockcpu":true,"minconsolidationfactor":20,"maxconsolidationinputscriptsize":150,"minconfconsolidationinput":6,"minconsolidationinputmaturity":6,"acceptnonstdconsolidationinput":false}`
 )


### PR DESCRIPTION
- Status updates are as bulk updates in a go routine consuming a channel
- Ensure no duplicate hashes and only latest status when bulk updating status
- Remove unused update function