### PR TITLE
Revert/check db before retry

### DIFF
--- a/metamorph/mocks/store_mock.go
+++ b/metamorph/mocks/store_mock.go
@@ -34,9 +34,6 @@ var _ store.MetamorphStore = &MetamorphStoreMock{}
 //			GetFunc: func(ctx context.Context, key []byte) (*store.StoreData, error) {
 //				panic("mock out the Get method")
 //			},
-//			GetMinedOrSeenFunc: func(ctx context.Context, hashes []*chainhash.Hash) ([]*store.StoreData, error) {
-//				panic("mock out the GetMinedOrSeen method")
-//			},
 //			GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64) ([]*store.StoreData, error) {
 //				panic("mock out the GetUnmined method")
 //			},
@@ -76,9 +73,6 @@ type MetamorphStoreMock struct {
 
 	// GetFunc mocks the Get method.
 	GetFunc func(ctx context.Context, key []byte) (*store.StoreData, error)
-
-	// GetMinedOrSeenFunc mocks the GetMinedOrSeen method.
-	GetMinedOrSeenFunc func(ctx context.Context, hashes []*chainhash.Hash) ([]*store.StoreData, error)
 
 	// GetUnminedFunc mocks the GetUnmined method.
 	GetUnminedFunc func(ctx context.Context, since time.Time, limit int64) ([]*store.StoreData, error)
@@ -128,13 +122,6 @@ type MetamorphStoreMock struct {
 			Ctx context.Context
 			// Key is the key argument value.
 			Key []byte
-		}
-		// GetMinedOrSeen holds details about calls to the GetMinedOrSeen method.
-		GetMinedOrSeen []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// Hashes is the hashes argument value.
-			Hashes []*chainhash.Hash
 		}
 		// GetUnmined holds details about calls to the GetUnmined method.
 		GetUnmined []struct {
@@ -192,7 +179,6 @@ type MetamorphStoreMock struct {
 	lockClose             sync.RWMutex
 	lockDel               sync.RWMutex
 	lockGet               sync.RWMutex
-	lockGetMinedOrSeen    sync.RWMutex
 	lockGetUnmined        sync.RWMutex
 	lockPing              sync.RWMutex
 	lockSet               sync.RWMutex
@@ -339,42 +325,6 @@ func (mock *MetamorphStoreMock) GetCalls() []struct {
 	mock.lockGet.RLock()
 	calls = mock.calls.Get
 	mock.lockGet.RUnlock()
-	return calls
-}
-
-// GetMinedOrSeen calls GetMinedOrSeenFunc.
-func (mock *MetamorphStoreMock) GetMinedOrSeen(ctx context.Context, hashes []*chainhash.Hash) ([]*store.StoreData, error) {
-	if mock.GetMinedOrSeenFunc == nil {
-		panic("MetamorphStoreMock.GetMinedOrSeenFunc: method is nil but MetamorphStore.GetMinedOrSeen was just called")
-	}
-	callInfo := struct {
-		Ctx    context.Context
-		Hashes []*chainhash.Hash
-	}{
-		Ctx:    ctx,
-		Hashes: hashes,
-	}
-	mock.lockGetMinedOrSeen.Lock()
-	mock.calls.GetMinedOrSeen = append(mock.calls.GetMinedOrSeen, callInfo)
-	mock.lockGetMinedOrSeen.Unlock()
-	return mock.GetMinedOrSeenFunc(ctx, hashes)
-}
-
-// GetMinedOrSeenCalls gets all the calls that were made to GetMinedOrSeen.
-// Check the length with:
-//
-//	len(mockedMetamorphStore.GetMinedOrSeenCalls())
-func (mock *MetamorphStoreMock) GetMinedOrSeenCalls() []struct {
-	Ctx    context.Context
-	Hashes []*chainhash.Hash
-} {
-	var calls []struct {
-		Ctx    context.Context
-		Hashes []*chainhash.Hash
-	}
-	mock.lockGetMinedOrSeen.RLock()
-	calls = mock.calls.GetMinedOrSeen
-	mock.lockGetMinedOrSeen.RUnlock()
 	return calls
 }
 

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -432,13 +432,6 @@ var statusValueMap = map[metamorph_api.Status]int{
 func (p *Processor) SendStatusForTransaction(hash *chainhash.Hash, status metamorph_api.Status, source string, statusErr error) error {
 	processorResponse, ok := p.ProcessorResponseMap.Get(hash)
 	if !ok {
-		if status == metamorph_api.Status_SEEN_ON_NETWORK {
-			p.statusUpdateCh <- store.UpdateStatus{
-				Hash:   *hash,
-				Status: status,
-			}
-		}
-
 		return nil
 	}
 

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -483,29 +483,6 @@ func TestSendStatusForTransaction(t *testing.T) {
 			expectedUpdateStatusCalls: 1,
 			expectedCallbacks:         1,
 		},
-		{
-			name: "status update - seen on network, not found in response map",
-			inputs: []input{
-				{
-					hash:      testdata.TX5Hash,
-					newStatus: metamorph_api.Status_SEEN_ON_NETWORK,
-				},
-			},
-			updateResp: [][]*store.StoreData{
-				{
-					{
-						Hash:              testdata.TX5Hash,
-						Status:            metamorph_api.Status_SEEN_ON_NETWORK,
-						RejectReason:      "",
-						FullStatusUpdates: true,
-						CallbackUrl:       "http://callback.com",
-					},
-				},
-			},
-
-			expectedCallbacks:         1,
-			expectedUpdateStatusCalls: 1,
-		},
 	}
 
 	for _, tc := range tt {

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -567,9 +567,8 @@ func (r readCloser) Close() error                     { return nil }
 
 func TestProcessExpiredTransactions(t *testing.T) {
 	tt := []struct {
-		name        string
-		retries     uint32
-		minedOrSeen []*store.StoreData
+		name    string
+		retries uint32
 
 		expectedRequests      int
 		expectedAnnouncements int
@@ -581,26 +580,11 @@ func TestProcessExpiredTransactions(t *testing.T) {
 			expectedRequests:      0,
 		},
 		{
-			name:        "expired txs - one seen",
-			minedOrSeen: []*store.StoreData{{Hash: testdata.TX1Hash, Status: metamorph_api.Status_SEEN_ON_NETWORK}},
-
-			expectedAnnouncements: 4,
-			expectedRequests:      0,
-		},
-		{
 			name:    "expired txs - max retries exceeded",
 			retries: 16,
 
 			expectedAnnouncements: 0,
 			expectedRequests:      6,
-		},
-		{
-			name:        "expired txs - max retries exceeded, one seen",
-			minedOrSeen: []*store.StoreData{{Hash: testdata.TX1Hash, Status: metamorph_api.Status_SEEN_ON_NETWORK}},
-			retries:     16,
-
-			expectedAnnouncements: 0,
-			expectedRequests:      4,
 		},
 	}
 
@@ -611,9 +595,6 @@ func TestProcessExpiredTransactions(t *testing.T) {
 					return &store.StoreData{Hash: testdata.TX2Hash}, nil
 				},
 				SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error { return nil },
-				GetMinedOrSeenFunc: func(ctx context.Context, hashes []*chainhash.Hash) ([]*store.StoreData, error) {
-					return tc.minedOrSeen, nil
-				},
 			}
 			pm := &mocks.PeerManagerMock{
 				RequestTransactionFunc: func(txHash *chainhash.Hash) p2p.PeerI {

--- a/metamorph/store/postgresql/postgres_test.go
+++ b/metamorph/store/postgresql/postgres_test.go
@@ -411,34 +411,6 @@ func TestPostgresDB(t *testing.T) {
 
 	})
 
-	t.Run("get mined or seen transactions", func(t *testing.T) {
-		defer require.NoError(t, pruneTables(postgresDB.db))
-
-		require.NoError(t, loadFixtures(postgresDB.db, "fixtures"))
-
-		hash5, err := hex.DecodeString("1e7ce0d2fcac0a1a0c174e57a7334f9bf6803280af838a0a0389b230ee488dad") // mined
-		require.NoError(t, err)
-		chainHash5, err := chainhash.NewHash(hash5)
-		require.NoError(t, err)
-
-		hash6, err := hex.DecodeString("9a391adf8c716cfdb5fc17dadc85761259762a099dd4727b4412288661ef3c95") // mined
-		require.NoError(t, err)
-		chainHash6, err := chainhash.NewHash(hash6)
-		require.NoError(t, err)
-
-		hash7, err := hex.DecodeString("a8b965b5901163a9bdcd38d2ad524c3bb27ae31fb86dc8947253b541af8dd308") // mined
-		require.NoError(t, err)
-		chainHash7, err := chainhash.NewHash(hash7)
-		require.NoError(t, err)
-
-		hashes := []*chainhash.Hash{chainHash1, chainHash2, chainHash4, chainHash5, chainHash6, chainHash7}
-
-		minedSeen, err := postgresDB.GetMinedOrSeen(ctx, hashes)
-		require.NoError(t, err)
-		require.Len(t, minedSeen, 5)
-
-	})
-
 	t.Run("update mined - missing block info", func(t *testing.T) {
 		defer require.NoError(t, pruneTables(postgresDB.db))
 

--- a/metamorph/store/store.go
+++ b/metamorph/store/store.go
@@ -40,7 +40,6 @@ type MetamorphStore interface {
 	GetUnmined(ctx context.Context, since time.Time, limit int64) ([]*StoreData, error)
 	UpdateStatusBulk(ctx context.Context, updates []UpdateStatus) ([]*StoreData, error)
 	UpdateMined(ctx context.Context, txsBlocks *blocktx_api.TransactionBlocks) ([]*StoreData, error)
-	GetMinedOrSeen(ctx context.Context, hashes []*chainhash.Hash) ([]*StoreData, error)
 	Close(ctx context.Context) error
 	ClearData(ctx context.Context, retentionDays int32) (int64, error)
 	Ping(ctx context.Context) error


### PR DESCRIPTION
- Revert updating SEEN_ON_NETWORK status from every metamorph as this can cause deadlocks in bulk update queries