### PR TITLE
remove objects from map after client connection

### DIFF
--- a/blocktx/store/postgresql/postgres_test.go
+++ b/blocktx/store/postgresql/postgres_test.go
@@ -228,7 +228,6 @@ func TestPostgresDB(t *testing.T) {
 
 		id, err := postgresDB.InsertBlock(ctx, block)
 		require.NoError(t, err)
-		fmt.Println(id)
 		require.Equal(t, uint64(1), id)
 
 		blockResp, err := postgresDB.GetBlock(ctx, blockHash2)

--- a/metamorph/mocks/processor_mock.go
+++ b/metamorph/mocks/processor_mock.go
@@ -203,19 +203,6 @@ func (mock *ProcessorIMock) HealthCalls() []struct {
 	return calls
 }
 
-// LoadUnmined calls LoadUnminedFunc.
-func (mock *ProcessorIMock) LoadUnmined() {
-	if mock.LoadUnminedFunc == nil {
-		panic("ProcessorIMock.LoadUnminedFunc: method is nil but ProcessorI.LoadUnmined was just called")
-	}
-	callInfo := struct {
-	}{}
-	mock.lockLoadUnmined.Lock()
-	mock.calls.LoadUnmined = append(mock.calls.LoadUnmined, callInfo)
-	mock.lockLoadUnmined.Unlock()
-	mock.LoadUnminedFunc()
-}
-
 // LoadUnminedCalls gets all the calls that were made to LoadUnmined.
 // Check the length with:
 //

--- a/metamorph/mocks/processor_mock.go
+++ b/metamorph/mocks/processor_mock.go
@@ -30,9 +30,6 @@ var _ metamorph.ProcessorI = &ProcessorIMock{}
 //			HealthFunc: func() error {
 //				panic("mock out the Health method")
 //			},
-//			LoadUnminedFunc: func()  {
-//				panic("mock out the LoadUnmined method")
-//			},
 //			ProcessTransactionFunc: func(ctx context.Context, req *metamorph.ProcessorRequest)  {
 //				panic("mock out the ProcessTransaction method")
 //			},
@@ -58,9 +55,6 @@ type ProcessorIMock struct {
 	// HealthFunc mocks the Health method.
 	HealthFunc func() error
 
-	// LoadUnminedFunc mocks the LoadUnmined method.
-	LoadUnminedFunc func()
-
 	// ProcessTransactionFunc mocks the ProcessTransaction method.
 	ProcessTransactionFunc func(ctx context.Context, req *metamorph.ProcessorRequest)
 
@@ -82,9 +76,6 @@ type ProcessorIMock struct {
 		}
 		// Health holds details about calls to the Health method.
 		Health []struct {
-		}
-		// LoadUnmined holds details about calls to the LoadUnmined method.
-		LoadUnmined []struct {
 		}
 		// ProcessTransaction holds details about calls to the ProcessTransaction method.
 		ProcessTransaction []struct {
@@ -111,7 +102,6 @@ type ProcessorIMock struct {
 	lockGetPeers                 sync.RWMutex
 	lockGetStats                 sync.RWMutex
 	lockHealth                   sync.RWMutex
-	lockLoadUnmined              sync.RWMutex
 	lockProcessTransaction       sync.RWMutex
 	lockSendStatusForTransaction sync.RWMutex
 	lockShutdown                 sync.RWMutex
@@ -200,20 +190,6 @@ func (mock *ProcessorIMock) HealthCalls() []struct {
 	mock.lockHealth.RLock()
 	calls = mock.calls.Health
 	mock.lockHealth.RUnlock()
-	return calls
-}
-
-// LoadUnminedCalls gets all the calls that were made to LoadUnmined.
-// Check the length with:
-//
-//	len(mockedProcessorI.LoadUnminedCalls())
-func (mock *ProcessorIMock) LoadUnminedCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockLoadUnmined.RLock()
-	calls = mock.calls.LoadUnmined
-	mock.lockLoadUnmined.RUnlock()
 	return calls
 }
 

--- a/metamorph/mocks/store_mock.go
+++ b/metamorph/mocks/store_mock.go
@@ -34,8 +34,11 @@ var _ store.MetamorphStore = &MetamorphStoreMock{}
 //			GetFunc: func(ctx context.Context, key []byte) (*store.StoreData, error) {
 //				panic("mock out the Get method")
 //			},
-//			GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64) ([]*store.StoreData, error) {
+//			GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
 //				panic("mock out the GetUnmined method")
+//			},
+//			IncrementRetriesFunc: func(ctx context.Context, hash *chainhash.Hash) error {
+//				panic("mock out the IncrementRetries method")
 //			},
 //			PingFunc: func(ctx context.Context) error {
 //				panic("mock out the Ping method")
@@ -75,7 +78,10 @@ type MetamorphStoreMock struct {
 	GetFunc func(ctx context.Context, key []byte) (*store.StoreData, error)
 
 	// GetUnminedFunc mocks the GetUnmined method.
-	GetUnminedFunc func(ctx context.Context, since time.Time, limit int64) ([]*store.StoreData, error)
+	GetUnminedFunc func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error)
+
+	// IncrementRetriesFunc mocks the IncrementRetries method.
+	IncrementRetriesFunc func(ctx context.Context, hash *chainhash.Hash) error
 
 	// PingFunc mocks the Ping method.
 	PingFunc func(ctx context.Context) error
@@ -131,6 +137,15 @@ type MetamorphStoreMock struct {
 			Since time.Time
 			// Limit is the limit argument value.
 			Limit int64
+			// Offset is the offset argument value.
+			Offset int64
+		}
+		// IncrementRetries holds details about calls to the IncrementRetries method.
+		IncrementRetries []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Hash is the hash argument value.
+			Hash *chainhash.Hash
 		}
 		// Ping holds details about calls to the Ping method.
 		Ping []struct {
@@ -180,6 +195,7 @@ type MetamorphStoreMock struct {
 	lockDel               sync.RWMutex
 	lockGet               sync.RWMutex
 	lockGetUnmined        sync.RWMutex
+	lockIncrementRetries  sync.RWMutex
 	lockPing              sync.RWMutex
 	lockSet               sync.RWMutex
 	lockSetUnlocked       sync.RWMutex
@@ -329,23 +345,25 @@ func (mock *MetamorphStoreMock) GetCalls() []struct {
 }
 
 // GetUnmined calls GetUnminedFunc.
-func (mock *MetamorphStoreMock) GetUnmined(ctx context.Context, since time.Time, limit int64) ([]*store.StoreData, error) {
+func (mock *MetamorphStoreMock) GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
 	if mock.GetUnminedFunc == nil {
 		panic("MetamorphStoreMock.GetUnminedFunc: method is nil but MetamorphStore.GetUnmined was just called")
 	}
 	callInfo := struct {
-		Ctx   context.Context
-		Since time.Time
-		Limit int64
+		Ctx    context.Context
+		Since  time.Time
+		Limit  int64
+		Offset int64
 	}{
-		Ctx:   ctx,
-		Since: since,
-		Limit: limit,
+		Ctx:    ctx,
+		Since:  since,
+		Limit:  limit,
+		Offset: offset,
 	}
 	mock.lockGetUnmined.Lock()
 	mock.calls.GetUnmined = append(mock.calls.GetUnmined, callInfo)
 	mock.lockGetUnmined.Unlock()
-	return mock.GetUnminedFunc(ctx, since, limit)
+	return mock.GetUnminedFunc(ctx, since, limit, offset)
 }
 
 // GetUnminedCalls gets all the calls that were made to GetUnmined.
@@ -353,18 +371,56 @@ func (mock *MetamorphStoreMock) GetUnmined(ctx context.Context, since time.Time,
 //
 //	len(mockedMetamorphStore.GetUnminedCalls())
 func (mock *MetamorphStoreMock) GetUnminedCalls() []struct {
-	Ctx   context.Context
-	Since time.Time
-	Limit int64
+	Ctx    context.Context
+	Since  time.Time
+	Limit  int64
+	Offset int64
 } {
 	var calls []struct {
-		Ctx   context.Context
-		Since time.Time
-		Limit int64
+		Ctx    context.Context
+		Since  time.Time
+		Limit  int64
+		Offset int64
 	}
 	mock.lockGetUnmined.RLock()
 	calls = mock.calls.GetUnmined
 	mock.lockGetUnmined.RUnlock()
+	return calls
+}
+
+// IncrementRetries calls IncrementRetriesFunc.
+func (mock *MetamorphStoreMock) IncrementRetries(ctx context.Context, hash *chainhash.Hash) error {
+	if mock.IncrementRetriesFunc == nil {
+		panic("MetamorphStoreMock.IncrementRetriesFunc: method is nil but MetamorphStore.IncrementRetries was just called")
+	}
+	callInfo := struct {
+		Ctx  context.Context
+		Hash *chainhash.Hash
+	}{
+		Ctx:  ctx,
+		Hash: hash,
+	}
+	mock.lockIncrementRetries.Lock()
+	mock.calls.IncrementRetries = append(mock.calls.IncrementRetries, callInfo)
+	mock.lockIncrementRetries.Unlock()
+	return mock.IncrementRetriesFunc(ctx, hash)
+}
+
+// IncrementRetriesCalls gets all the calls that were made to IncrementRetries.
+// Check the length with:
+//
+//	len(mockedMetamorphStore.IncrementRetriesCalls())
+func (mock *MetamorphStoreMock) IncrementRetriesCalls() []struct {
+	Ctx  context.Context
+	Hash *chainhash.Hash
+} {
+	var calls []struct {
+		Ctx  context.Context
+		Hash *chainhash.Hash
+	}
+	mock.lockIncrementRetries.RLock()
+	calls = mock.calls.IncrementRetries
+	mock.lockIncrementRetries.RUnlock()
 	return calls
 }
 

--- a/metamorph/mocks/store_mock.go
+++ b/metamorph/mocks/store_mock.go
@@ -34,7 +34,7 @@ var _ store.MetamorphStore = &MetamorphStoreMock{}
 //			GetFunc: func(ctx context.Context, key []byte) (*store.StoreData, error) {
 //				panic("mock out the Get method")
 //			},
-//			GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+//			GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
 //				panic("mock out the GetUnmined method")
 //			},
 //			IncrementRetriesFunc: func(ctx context.Context, hash *chainhash.Hash) error {
@@ -78,7 +78,7 @@ type MetamorphStoreMock struct {
 	GetFunc func(ctx context.Context, key []byte) (*store.StoreData, error)
 
 	// GetUnminedFunc mocks the GetUnmined method.
-	GetUnminedFunc func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error)
+	GetUnminedFunc func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error)
 
 	// IncrementRetriesFunc mocks the IncrementRetries method.
 	IncrementRetriesFunc func(ctx context.Context, hash *chainhash.Hash) error
@@ -139,6 +139,8 @@ type MetamorphStoreMock struct {
 			Limit int64
 			// Offset is the offset argument value.
 			Offset int64
+			// Hostname is the hostname argument value.
+			Hostname string
 		}
 		// IncrementRetries holds details about calls to the IncrementRetries method.
 		IncrementRetries []struct {
@@ -345,25 +347,27 @@ func (mock *MetamorphStoreMock) GetCalls() []struct {
 }
 
 // GetUnmined calls GetUnminedFunc.
-func (mock *MetamorphStoreMock) GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+func (mock *MetamorphStoreMock) GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
 	if mock.GetUnminedFunc == nil {
 		panic("MetamorphStoreMock.GetUnminedFunc: method is nil but MetamorphStore.GetUnmined was just called")
 	}
 	callInfo := struct {
-		Ctx    context.Context
-		Since  time.Time
-		Limit  int64
-		Offset int64
+		Ctx      context.Context
+		Since    time.Time
+		Limit    int64
+		Offset   int64
+		Hostname string
 	}{
-		Ctx:    ctx,
-		Since:  since,
-		Limit:  limit,
-		Offset: offset,
+		Ctx:      ctx,
+		Since:    since,
+		Limit:    limit,
+		Offset:   offset,
+		Hostname: hostname,
 	}
 	mock.lockGetUnmined.Lock()
 	mock.calls.GetUnmined = append(mock.calls.GetUnmined, callInfo)
 	mock.lockGetUnmined.Unlock()
-	return mock.GetUnminedFunc(ctx, since, limit, offset)
+	return mock.GetUnminedFunc(ctx, since, limit, offset, hostname)
 }
 
 // GetUnminedCalls gets all the calls that were made to GetUnmined.
@@ -371,16 +375,18 @@ func (mock *MetamorphStoreMock) GetUnmined(ctx context.Context, since time.Time,
 //
 //	len(mockedMetamorphStore.GetUnminedCalls())
 func (mock *MetamorphStoreMock) GetUnminedCalls() []struct {
-	Ctx    context.Context
-	Since  time.Time
-	Limit  int64
-	Offset int64
+	Ctx      context.Context
+	Since    time.Time
+	Limit    int64
+	Offset   int64
+	Hostname string
 } {
 	var calls []struct {
-		Ctx    context.Context
-		Since  time.Time
-		Limit  int64
-		Offset int64
+		Ctx      context.Context
+		Since    time.Time
+		Limit    int64
+		Offset   int64
+		Hostname string
 	}
 	mock.lockGetUnmined.RLock()
 	calls = mock.calls.GetUnmined

--- a/metamorph/mocks/store_mock.go
+++ b/metamorph/mocks/store_mock.go
@@ -34,7 +34,7 @@ var _ store.MetamorphStore = &MetamorphStoreMock{}
 //			GetFunc: func(ctx context.Context, key []byte) (*store.StoreData, error) {
 //				panic("mock out the Get method")
 //			},
-//			GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
+//			GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
 //				panic("mock out the GetUnmined method")
 //			},
 //			IncrementRetriesFunc: func(ctx context.Context, hash *chainhash.Hash) error {
@@ -78,7 +78,7 @@ type MetamorphStoreMock struct {
 	GetFunc func(ctx context.Context, key []byte) (*store.StoreData, error)
 
 	// GetUnminedFunc mocks the GetUnmined method.
-	GetUnminedFunc func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error)
+	GetUnminedFunc func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error)
 
 	// IncrementRetriesFunc mocks the IncrementRetries method.
 	IncrementRetriesFunc func(ctx context.Context, hash *chainhash.Hash) error
@@ -139,8 +139,6 @@ type MetamorphStoreMock struct {
 			Limit int64
 			// Offset is the offset argument value.
 			Offset int64
-			// Hostname is the hostname argument value.
-			Hostname string
 		}
 		// IncrementRetries holds details about calls to the IncrementRetries method.
 		IncrementRetries []struct {
@@ -347,27 +345,25 @@ func (mock *MetamorphStoreMock) GetCalls() []struct {
 }
 
 // GetUnmined calls GetUnminedFunc.
-func (mock *MetamorphStoreMock) GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
+func (mock *MetamorphStoreMock) GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
 	if mock.GetUnminedFunc == nil {
 		panic("MetamorphStoreMock.GetUnminedFunc: method is nil but MetamorphStore.GetUnmined was just called")
 	}
 	callInfo := struct {
-		Ctx      context.Context
-		Since    time.Time
-		Limit    int64
-		Offset   int64
-		Hostname string
+		Ctx    context.Context
+		Since  time.Time
+		Limit  int64
+		Offset int64
 	}{
-		Ctx:      ctx,
-		Since:    since,
-		Limit:    limit,
-		Offset:   offset,
-		Hostname: hostname,
+		Ctx:    ctx,
+		Since:  since,
+		Limit:  limit,
+		Offset: offset,
 	}
 	mock.lockGetUnmined.Lock()
 	mock.calls.GetUnmined = append(mock.calls.GetUnmined, callInfo)
 	mock.lockGetUnmined.Unlock()
-	return mock.GetUnminedFunc(ctx, since, limit, offset, hostname)
+	return mock.GetUnminedFunc(ctx, since, limit, offset)
 }
 
 // GetUnminedCalls gets all the calls that were made to GetUnmined.
@@ -375,18 +371,16 @@ func (mock *MetamorphStoreMock) GetUnmined(ctx context.Context, since time.Time,
 //
 //	len(mockedMetamorphStore.GetUnminedCalls())
 func (mock *MetamorphStoreMock) GetUnminedCalls() []struct {
-	Ctx      context.Context
-	Since    time.Time
-	Limit    int64
-	Offset   int64
-	Hostname string
+	Ctx    context.Context
+	Since  time.Time
+	Limit  int64
+	Offset int64
 } {
 	var calls []struct {
-		Ctx      context.Context
-		Since    time.Time
-		Limit    int64
-		Offset   int64
-		Hostname string
+		Ctx    context.Context
+		Since  time.Time
+		Limit  int64
+		Offset int64
 	}
 	mock.lockGetUnmined.RLock()
 	calls = mock.calls.GetUnmined

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -3,7 +3,6 @@ package metamorph
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -140,7 +139,7 @@ func NewProcessor(s store.MetamorphStore, pm p2p.PeerManagerI, opts ...Option) (
 		opt(p)
 	}
 
-	p.ProcessorResponseMap = NewProcessorResponseMap(s, p.mapExpiryTime, WithNowResponseMap(p.now))
+	p.ProcessorResponseMap = NewProcessorResponseMap(p.mapExpiryTime, WithNowResponseMap(p.now))
 
 	p.logger.Info("Starting processor", slog.String("cacheExpiryTime", p.mapExpiryTime.String()))
 
@@ -256,7 +255,6 @@ func (p *Processor) processStatusUpdates() {
 				if !found || (found && statusValueMap[foundStatusUpdate.Status] < statusValueMap[statusUpdate.Status]) {
 					statusUpdatesMap[statusUpdate.Hash] = statusUpdate
 				}
-				fmt.Println("AAAAA")
 				p.CheckAndUpdate(&statusUpdates, &statusUpdatesMap, true)
 			case <-ticker.C:
 				p.CheckAndUpdate(&statusUpdates, &statusUpdatesMap, false)

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -291,8 +291,7 @@ func (p *Processor) processExpiredTransactions() {
 
 		for {
 			// get all transactions since then chunk by chunk
-			hostname, _ := os.Hostname()
-			unminedTxs, err := p.store.GetUnmined(dbctx, getUnminedSince, loadUnminedLimit, offset, hostname)
+			unminedTxs, err := p.store.GetUnmined(dbctx, getUnminedSince, loadUnminedLimit, offset)
 			if err != nil {
 				p.logger.Error("Failed to get unmined transactions", slog.String("err", err.Error()))
 				continue

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -305,7 +305,9 @@ func (p *Processor) processExpiredTransactions() {
 			p.logger.Info("Resending unmined transactions", slog.Int("number", len(unminedTxs)))
 			for _, tx := range unminedTxs {
 				// mark that we retried processing this transaction once more
-				p.store.IncrementRetries(dbctx, tx.Hash)
+				if err = p.store.IncrementRetries(dbctx, tx.Hash); err != nil {
+					p.logger.Error("Failed to increment retries in database", slog.String("err", err.Error()))
+				}
 
 				if tx.Retries > MaxRetries {
 					// Sending GETDATA to peers to see if they have it

--- a/metamorph/processor_helpers.go
+++ b/metamorph/processor_helpers.go
@@ -12,7 +12,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"sort"
 	"strings"
 	"time"
 
@@ -169,10 +168,6 @@ func (p *Processor) HandleStats(w http.ResponseWriter, r *http.Request) {
 			processorResponses = append(processorResponses, item)
 		}
 
-		sort.Slice(processorResponses, func(i, j int) bool {
-			return processorResponses[i].Start.Before(processorResponses[j].Start)
-		})
-
 		txids.WriteString(`<br/><h2 class="subtitle">Transactions</h2>`)
 
 		if len(processorResponses) > 0 {
@@ -182,8 +177,6 @@ func (p *Processor) HandleStats(w http.ResponseWriter, r *http.Request) {
 			for _, processorResponse := range processorResponses {
 				txids.WriteString(`<tr>`)
 
-				txids.WriteString(fmt.Sprintf(`<td>%s</td>`, processorResponse.Start.UTC().Format(time.RFC3339Nano)))
-				txids.WriteString(fmt.Sprintf(`<td>%d</td>`, processorResponse.Retries.Load()))
 				txids.WriteString(fmt.Sprintf(`<td>%s</td>`, processorResponse.GetStatus().String()))
 				txids.WriteString(fmt.Sprintf(`<td><a href="/pstats?tx=%v">%v</a></td>`, processorResponse.Hash, processorResponse.Hash))
 
@@ -382,13 +375,9 @@ func (p *Processor) writeTransaction(w http.ResponseWriter, hash *chainhash.Hash
 func (p *Processor) processorResponseStatsTable(w http.ResponseWriter, prm *processor_response.ProcessorResponse) []byte {
 
 	res := &statResponse{
-		Txid:                  prm.Hash.String(),
-		Start:                 prm.Start,
-		Retries:               prm.Retries.Load(),
-		Err:                   prm.Err,
-		Status:                prm.GetStatus(),
-		NoStats:               prm.NoStats,
-		LastStatusUpdateNanos: prm.LastStatusUpdateNanos.Load(),
+		Txid:   prm.Hash.String(),
+		Err:    prm.Err,
+		Status: prm.GetStatus(),
 	}
 
 	resLog := strings.Builder{}

--- a/metamorph/processor_options.go
+++ b/metamorph/processor_options.go
@@ -1,9 +1,10 @@
 package metamorph
 
 import (
-	"github.com/bitcoin-sv/arc/metamorph/store"
 	"log/slog"
 	"time"
+
+	"github.com/bitcoin-sv/arc/metamorph/store"
 
 	"github.com/bitcoin-sv/arc/blocktx/blocktx_api"
 )
@@ -41,7 +42,7 @@ func WithProcessStatusUpdatesInterval(d time.Duration) func(*Processor) {
 func WithProcessStatusUpdatesBatchSize(size int) func(*Processor) {
 	return func(p *Processor) {
 		p.processStatusUpdatesBatchSize = size
-		p.statusUpdateCh = make(chan store.UpdateStatus, size)
+		p.storageStatusUpdateCh = make(chan store.UpdateStatus, size)
 	}
 }
 

--- a/metamorph/processor_response/processor_response.go
+++ b/metamorph/processor_response/processor_response.go
@@ -70,12 +70,12 @@ func (r *ProcessorResponse) String() string {
 func (r *ProcessorResponse) setStatus(status metamorph_api.Status) bool {
 	r.mu.Lock()
 	r.Status = status
-	r.mu.Unlock()
 
 	sae := StatusAndError{
 		Hash:   r.Hash,
 		Status: r.Status,
 	}
+	r.mu.Unlock()
 
 	if r.callerCh != nil {
 		return utils.SafeSend(r.callerCh, sae)

--- a/metamorph/processor_response/processor_response.go
+++ b/metamorph/processor_response/processor_response.go
@@ -2,13 +2,11 @@ package processor_response
 
 import (
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"github.com/bitcoin-sv/arc/metamorph/metamorph_api"
 	"github.com/libsv/go-p2p/chaincfg/chainhash"
 	"github.com/ordishs/go-utils"
-	"github.com/ordishs/gocore"
 	"github.com/sasha-s/go-deadlock"
 )
 
@@ -19,21 +17,14 @@ type StatusAndError struct {
 }
 
 type ProcessorResponseStatusUpdate struct {
-	Status         metamorph_api.Status
-	StatusErr      error
-	UpdateStore    func() error
-	IgnoreCallback bool
-	Callback       func(err error)
+	Status    metamorph_api.Status
+	StatusErr error
 }
 
 type ProcessorResponse struct {
-	callerCh              chan StatusAndError
-	NoStats               bool `json:"noStats"`
-	statusUpdateCh        chan *ProcessorResponseStatusUpdate
-	Hash                  *chainhash.Hash `json:"hash"`
-	Start                 time.Time       `json:"start"`
-	Retries               atomic.Uint32   `json:"retries"`
-	LastStatusUpdateNanos atomic.Int64    `json:"lastStatusUpdateNanos"`
+	callerCh chan StatusAndError
+	NoStats  bool            `json:"noStats"`
+	Hash     *chainhash.Hash `json:"hash"`
 	// The following fields are protected by the mutex
 	mu     deadlock.RWMutex
 	Err    error                `json:"err"`
@@ -41,78 +32,30 @@ type ProcessorResponse struct {
 }
 
 func NewProcessorResponse(hash *chainhash.Hash) *ProcessorResponse {
-	return newProcessorResponse(hash, metamorph_api.Status_RECEIVED, nil)
+	return newProcessorResponse(hash, metamorph_api.Status_RECEIVED, nil, time.Second)
 }
 
-// NewProcessorResponseWithStatus creates a new ProcessorResponse with the given status.
-// It is used when restoring the ProcessorResponseMap from the database.
-func NewProcessorResponseWithStatus(hash *chainhash.Hash, status metamorph_api.Status) *ProcessorResponse {
-	return newProcessorResponse(hash, status, nil)
+func NewProcessorResponseWithChannel(hash *chainhash.Hash, ch chan StatusAndError, timeout time.Duration) *ProcessorResponse {
+	return newProcessorResponse(hash, metamorph_api.Status_RECEIVED, ch, timeout)
 }
 
-func NewProcessorResponseWithChannel(hash *chainhash.Hash, ch chan StatusAndError) *ProcessorResponse {
-	return newProcessorResponse(hash, metamorph_api.Status_RECEIVED, ch)
-}
-
-func newProcessorResponse(hash *chainhash.Hash, status metamorph_api.Status, ch chan StatusAndError) *ProcessorResponse {
+func newProcessorResponse(hash *chainhash.Hash, status metamorph_api.Status, ch chan StatusAndError, timeout time.Duration) *ProcessorResponse {
 	pr := &ProcessorResponse{
-		Start:          time.Now(),
-		Hash:           hash,
-		Status:         status,
-		callerCh:       ch,
-		statusUpdateCh: make(chan *ProcessorResponseStatusUpdate, 10),
+		Hash:     hash,
+		Status:   status,
+		callerCh: ch,
 	}
-	pr.LastStatusUpdateNanos.Store(pr.Start.UnixNano())
-
-	go func() {
-		for statusUpdate := range pr.statusUpdateCh {
-			pr.updateStatus(statusUpdate)
-		}
-	}()
 
 	return pr
 }
 
-func (r *ProcessorResponse) Close() {
-	defer func() {
-		_ = recover()
-	}()
-
-	if r.statusUpdateCh != nil {
-		close(r.statusUpdateCh)
-	}
-}
-
 func (r *ProcessorResponse) UpdateStatus(statusUpdate *ProcessorResponseStatusUpdate) {
-	r.statusUpdateCh <- statusUpdate
-}
-
-func (r *ProcessorResponse) updateStatus(statusUpdate *ProcessorResponseStatusUpdate) {
-	// If this transaction has already been mined, ignore any further updates
-	if r.Status == metamorph_api.Status_MINED {
-		return
-	}
-
-	if statusUpdate.UpdateStore != nil {
-		if err := statusUpdate.UpdateStore(); err != nil {
-			r.setErr(err, "processorResponse")
-			statusUpdate.Callback(err)
-			return
-		}
-	}
-
 	if statusUpdate.StatusErr != nil {
 		_ = r.setStatusAndError(statusUpdate.Status, statusUpdate.StatusErr)
 	} else {
 		_ = r.setStatus(statusUpdate.Status)
 	}
 
-	statKey := fmt.Sprintf("%d: %s", statusUpdate.Status, statusUpdate.Status.String())
-	r.LastStatusUpdateNanos.Store(gocore.NewStat("processorResponse").NewStat(statKey).AddTime(r.LastStatusUpdateNanos.Load()))
-
-	if !statusUpdate.IgnoreCallback {
-		statusUpdate.Callback(nil)
-	}
 }
 
 func (r *ProcessorResponse) String() string {
@@ -120,9 +63,9 @@ func (r *ProcessorResponse) String() string {
 	defer r.mu.RUnlock()
 
 	if r.Err != nil {
-		return fmt.Sprintf("%v: %s [%s] %s", r.Hash, r.Start.Format(time.RFC3339), r.Status.String(), r.Err.Error())
+		return fmt.Sprintf("%v: [%s] %s", r.Hash, r.Status.String(), r.Err.Error())
 	}
-	return fmt.Sprintf("%v: %s [%s]", r.Hash, r.Start.Format(time.RFC3339), r.Status.String())
+	return fmt.Sprintf("%v: [%s]", r.Hash, r.Status.String())
 }
 
 func (r *ProcessorResponse) setStatus(status metamorph_api.Status) bool {
@@ -135,10 +78,8 @@ func (r *ProcessorResponse) setStatus(status metamorph_api.Status) bool {
 		Status: r.Status,
 	}
 
-	ch := r.callerCh
-
-	if ch != nil {
-		return utils.SafeSend(ch, sae)
+	if r.callerCh != nil {
+		return utils.SafeSend(r.callerCh, sae)
 	}
 
 	return true
@@ -162,31 +103,10 @@ func (r *ProcessorResponse) setErr(err error, source string) bool {
 		Err:    err,
 	}
 
-	ch := r.callerCh
-
 	r.mu.Unlock()
 
-	if ch != nil {
-		return utils.SafeSend(ch, sae)
-	}
-
-	return true
-}
-
-func (r *ProcessorResponse) setStatusAndError(status metamorph_api.Status, err error) bool {
-	r.Status = status
-	r.Err = err
-
-	sae := StatusAndError{
-		Hash:   r.Hash,
-		Status: r.Status,
-		Err:    err,
-	}
-
-	ch := r.callerCh
-
-	if ch != nil {
-		return utils.SafeSend(ch, sae)
+	if r.callerCh != nil {
+		return utils.SafeSend(r.callerCh, sae)
 	}
 
 	return true
@@ -199,11 +119,19 @@ func (r *ProcessorResponse) GetErr() error {
 	return r.Err
 }
 
-func (r *ProcessorResponse) GetRetries() uint32 {
-	return r.Retries.Load()
-}
+func (r *ProcessorResponse) setStatusAndError(status metamorph_api.Status, err error) bool {
+	r.Status = status
+	r.Err = err
 
-func (r *ProcessorResponse) IncrementRetry() uint32 {
-	r.Retries.Add(1)
-	return r.Retries.Load()
+	sae := StatusAndError{
+		Hash:   r.Hash,
+		Status: r.Status,
+		Err:    err,
+	}
+
+	if r.callerCh != nil {
+		return utils.SafeSend(r.callerCh, sae)
+	}
+
+	return true
 }

--- a/metamorph/processor_response/processor_response.go
+++ b/metamorph/processor_response/processor_response.go
@@ -23,7 +23,6 @@ type ProcessorResponseStatusUpdate struct {
 
 type ProcessorResponse struct {
 	callerCh chan StatusAndError
-	NoStats  bool            `json:"noStats"`
 	Hash     *chainhash.Hash `json:"hash"`
 	// The following fields are protected by the mutex
 	mu     deadlock.RWMutex

--- a/metamorph/processor_response/processor_response_test.go
+++ b/metamorph/processor_response/processor_response_test.go
@@ -20,7 +20,6 @@ func TestString(t *testing.T) {
 func TestNewProcessorResponse(t *testing.T) {
 	t.Run("NewProcessorResponse", func(t *testing.T) {
 		response := NewProcessorResponse(testdata.TX1Hash)
-		assert.NotNil(t, response.Start)
 		assert.Equal(t, testdata.TX1Hash, response.Hash)
 		assert.Equal(t, metamorph_api.Status_RECEIVED, response.Status)
 	})

--- a/metamorph/processor_response/processor_response_test.go
+++ b/metamorph/processor_response/processor_response_test.go
@@ -10,13 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestString(t *testing.T) {
-	t.Run("String", func(t *testing.T) {
-		response := NewProcessorResponse(testdata.TX1Hash)
-		assert.IsType(t, "string", response.String())
-	})
-}
-
 func TestNewProcessorResponse(t *testing.T) {
 	t.Run("NewProcessorResponse", func(t *testing.T) {
 		response := NewProcessorResponse(testdata.TX1Hash)

--- a/metamorph/processor_response_map.go
+++ b/metamorph/processor_response_map.go
@@ -1,11 +1,11 @@
 package metamorph
 
 import (
-	"log"
 	"log/slog"
 	"time"
 
 	"github.com/bitcoin-sv/arc/metamorph/processor_response"
+	"github.com/bitcoin-sv/arc/metamorph/store"
 	"github.com/libsv/go-p2p/chaincfg/chainhash"
 	"github.com/sasha-s/go-deadlock"
 )
@@ -19,6 +19,7 @@ type ProcessorResponseMap struct {
 	Expiry        time.Duration
 	ResponseItems map[chainhash.Hash]*processor_response.ProcessorResponse
 	now           func() time.Time
+	store         store.MetamorphStore
 }
 
 func WithNowResponseMap(nowFunc func() time.Time) func(*ProcessorResponseMap) {
@@ -29,23 +30,18 @@ func WithNowResponseMap(nowFunc func() time.Time) func(*ProcessorResponseMap) {
 
 type OptionProcRespMap func(p *ProcessorResponseMap)
 
-func NewProcessorResponseMap(expiry time.Duration, opts ...OptionProcRespMap) *ProcessorResponseMap {
+func NewProcessorResponseMap(s store.MetamorphStore, expiry time.Duration, opts ...OptionProcRespMap) *ProcessorResponseMap {
 	m := &ProcessorResponseMap{
 		Expiry:        expiry,
 		ResponseItems: make(map[chainhash.Hash]*processor_response.ProcessorResponse),
 		now:           time.Now,
+		store:         s,
 	}
 
 	// apply options
 	for _, opt := range opts {
 		opt(m)
 	}
-
-	go func() {
-		for range time.NewTicker(cleanUpInterval).C {
-			m.Clean()
-		}
-	}()
 
 	return m
 }
@@ -90,28 +86,6 @@ func (m *ProcessorResponseMap) Len() int {
 	defer m.mu.RUnlock()
 
 	return len(m.ResponseItems)
-}
-
-func (m *ProcessorResponseMap) Retries(hash *chainhash.Hash) uint32 {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if _, ok := m.ResponseItems[*hash]; !ok {
-		return 0
-	}
-
-	return m.ResponseItems[*hash].GetRetries()
-}
-
-func (m *ProcessorResponseMap) IncrementRetry(hash *chainhash.Hash) uint32 {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if _, ok := m.ResponseItems[*hash]; !ok {
-		return 0
-	}
-
-	return m.ResponseItems[*hash].IncrementRetry()
 }
 
 // Hashes will return a slice of the hashes in the map.
@@ -180,7 +154,7 @@ func (m *ProcessorResponseMap) logMapItems(logger *slog.Logger) {
 	defer m.mu.RUnlock()
 
 	for hash, processorResponse := range m.ResponseItems {
-		logger.Debug("Processor response map item", slog.String("hash", hash.String()), slog.String("status", processorResponse.GetStatus().String()), slog.Int("retries", int(processorResponse.Retries.Load())), slog.String("err", processorResponse.Err.Error()), slog.Time("start", processorResponse.Start))
+		logger.Debug("Processor response map item", slog.String("hash", hash.String()), slog.String("status", processorResponse.GetStatus().String()), slog.String("err", processorResponse.Err.Error()))
 	}
 }
 
@@ -190,26 +164,4 @@ func (m *ProcessorResponseMap) Clear() {
 	defer m.mu.Unlock()
 
 	m.ResponseItems = make(map[chainhash.Hash]*processor_response.ProcessorResponse)
-}
-
-func (m *ProcessorResponseMap) Close() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for _, item := range m.ResponseItems {
-		item.Close()
-	}
-}
-
-// Todo: unlock in storage
-func (m *ProcessorResponseMap) Clean() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	for key, item := range m.ResponseItems {
-		if time.Since(item.Start) > m.Expiry {
-			log.Printf("ProcessorResponseMap: Expired %s", key)
-			item.Close()
-			delete(m.ResponseItems, key)
-		}
-	}
 }

--- a/metamorph/processor_response_map.go
+++ b/metamorph/processor_response_map.go
@@ -9,10 +9,6 @@ import (
 	"github.com/sasha-s/go-deadlock"
 )
 
-const (
-	cleanUpInterval = 15 * time.Minute
-)
-
 type ProcessorResponseMap struct {
 	mu            deadlock.RWMutex
 	ResponseItems map[chainhash.Hash]*processor_response.ProcessorResponse

--- a/metamorph/processor_response_map_test.go
+++ b/metamorph/processor_response_map_test.go
@@ -13,15 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewProcessorResponseMap(t *testing.T) {
-	t.Run("default", func(t *testing.T) {
-		expiry := 10 * time.Second
-		prm := metamorph.NewProcessorResponseMap(expiry)
-		assert.Equalf(t, expiry, prm.Expiry, "NewProcessorResponseMap(%v)", expiry)
-		assert.Len(t, prm.ResponseItems, 0)
-	})
-}
-
 func TestProcessorResponseMapGet(t *testing.T) {
 	tt := []struct {
 		name string
@@ -46,47 +37,31 @@ func TestProcessorResponseMapGet(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			proc := metamorph.NewProcessorResponseMap(50 * time.Millisecond)
-			proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SENT_TO_NETWORK))
+			proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponse(testdata.TX1Hash))
 
 			item, ok := proc.Get(tc.hash)
 			require.Equal(t, tc.expectedFound, ok)
 
 			if tc.expectedFound {
-				require.Equal(t, metamorph_api.Status_SENT_TO_NETWORK, item.GetStatus())
+				require.Equal(t, metamorph_api.Status_RECEIVED, item.GetStatus())
 			}
 		})
 	}
 }
 
-func TestProcessorResponseMap_Clear(t *testing.T) {
-	t.Run("default", func(t *testing.T) {
-		proc := metamorph.NewProcessorResponseMap(50 * time.Millisecond)
-		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SENT_TO_NETWORK))
-		item, ok := proc.Get(testdata.TX1Hash)
-		assert.True(t, ok)
-		assert.Equal(t, metamorph_api.Status_SENT_TO_NETWORK, item.GetStatus())
-
-		proc.Clear()
-
-		item, ok = proc.Get(testdata.TX1Hash)
-		assert.False(t, ok)
-		assert.Nil(t, item)
-	})
-}
-
 func TestProcessorResponseMap_Delete(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		proc := metamorph.NewProcessorResponseMap(2 * time.Second)
-		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SENT_TO_NETWORK))
-		proc.Set(testdata.TX2Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX2Hash, metamorph_api.Status_ANNOUNCED_TO_NETWORK))
+		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponse(testdata.TX1Hash))
+		proc.Set(testdata.TX2Hash, processor_response.NewProcessorResponse(testdata.TX2Hash))
 
 		item, ok := proc.Get(testdata.TX1Hash)
 		require.True(t, ok)
-		assert.Equal(t, metamorph_api.Status_SENT_TO_NETWORK, item.GetStatus())
+		assert.Equal(t, metamorph_api.Status_RECEIVED, item.GetStatus())
 
 		item2, ok2 := proc.Get(testdata.TX2Hash)
 		require.True(t, ok2)
-		assert.Equal(t, metamorph_api.Status_ANNOUNCED_TO_NETWORK, item2.GetStatus())
+		assert.Equal(t, metamorph_api.Status_RECEIVED, item2.GetStatus())
 
 		proc.Delete(testdata.TX1Hash)
 
@@ -96,7 +71,7 @@ func TestProcessorResponseMap_Delete(t *testing.T) {
 
 		item2, ok2 = proc.Get(testdata.TX2Hash)
 		require.True(t, ok2)
-		assert.Equal(t, metamorph_api.Status_ANNOUNCED_TO_NETWORK, item2.GetStatus())
+		assert.Equal(t, metamorph_api.Status_RECEIVED, item2.GetStatus())
 	})
 }
 
@@ -109,39 +84,11 @@ func TestProcessorResponseMap_Get(t *testing.T) {
 
 	t.Run("returned", func(t *testing.T) {
 		proc := metamorph.NewProcessorResponseMap(2 * time.Second)
-		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SENT_TO_NETWORK))
+		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponse(testdata.TX1Hash))
 
 		item, ok := proc.Get(testdata.TX1Hash)
 		require.True(t, ok)
-		assert.Equal(t, metamorph_api.Status_SENT_TO_NETWORK, item.GetStatus())
-	})
-
-	t.Run("status returned", func(t *testing.T) {
-		tests := []struct {
-			status metamorph_api.Status
-			ok     bool
-		}{
-			{status: metamorph_api.Status_UNKNOWN, ok: true},
-			{status: metamorph_api.Status_QUEUED, ok: true},
-			{status: metamorph_api.Status_RECEIVED, ok: true},
-			{status: metamorph_api.Status_STORED, ok: true},
-			{status: metamorph_api.Status_ANNOUNCED_TO_NETWORK, ok: true},
-			{status: metamorph_api.Status_SENT_TO_NETWORK, ok: true},
-			{status: metamorph_api.Status_SEEN_ON_NETWORK, ok: true},
-			{status: metamorph_api.Status_MINED, ok: true},
-			{status: metamorph_api.Status_CONFIRMED, ok: true},
-			{status: metamorph_api.Status_REJECTED, ok: true},
-		}
-		for _, tt := range tests {
-			proc := metamorph.NewProcessorResponseMap(2 * time.Second)
-			proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, tt.status))
-
-			item, ok := proc.Get(testdata.TX1Hash)
-			require.Equal(t, ok, tt.ok)
-			if tt.ok {
-				assert.Equal(t, tt.status, item.GetStatus())
-			}
-		}
+		assert.Equal(t, metamorph_api.Status_RECEIVED, item.GetStatus())
 	})
 }
 
@@ -153,8 +100,8 @@ func TestProcessorResponseMap_Items(t *testing.T) {
 
 	t.Run("default", func(t *testing.T) {
 		proc := metamorph.NewProcessorResponseMap(2 * time.Second)
-		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SENT_TO_NETWORK))
-		proc.Set(testdata.TX2Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX2Hash, metamorph_api.Status_ANNOUNCED_TO_NETWORK))
+		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponse(testdata.TX1Hash))
+		proc.Set(testdata.TX2Hash, processor_response.NewProcessorResponse(testdata.TX2Hash))
 
 		items := proc.Items()
 		assert.Equal(t, 2, len(items))
@@ -171,8 +118,8 @@ func TestProcessorResponseMap_Len(t *testing.T) {
 
 	t.Run("default", func(t *testing.T) {
 		proc := metamorph.NewProcessorResponseMap(2 * time.Second)
-		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SENT_TO_NETWORK))
-		proc.Set(testdata.TX2Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX2Hash, metamorph_api.Status_ANNOUNCED_TO_NETWORK))
+		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponse(testdata.TX1Hash))
+		proc.Set(testdata.TX2Hash, processor_response.NewProcessorResponse(testdata.TX2Hash))
 
 		assert.Equal(t, 2, proc.Len())
 	})
@@ -181,46 +128,22 @@ func TestProcessorResponseMap_Len(t *testing.T) {
 func TestProcessorResponseMap_Set(t *testing.T) {
 	t.Run("empty key", func(t *testing.T) {
 		proc := metamorph.NewProcessorResponseMap(2 * time.Second)
-		proc.Set(&chainhash.Hash{}, processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SENT_TO_NETWORK))
+		proc.Set(&chainhash.Hash{}, processor_response.NewProcessorResponse(testdata.TX1Hash))
 		assert.Len(t, proc.ResponseItems, 1)
 
 		item := proc.ResponseItems[chainhash.Hash{}]
-		assert.Equal(t, metamorph_api.Status_SENT_TO_NETWORK, item.GetStatus())
+		assert.Equal(t, metamorph_api.Status_RECEIVED, item.GetStatus())
 	})
 
 	t.Run("default", func(t *testing.T) {
 		proc := metamorph.NewProcessorResponseMap(2 * time.Second)
 		assert.Len(t, proc.ResponseItems, 0)
 
-		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SENT_TO_NETWORK))
+		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponse(testdata.TX1Hash))
 
 		assert.Len(t, proc.ResponseItems, 1)
 
 		item := proc.ResponseItems[*testdata.TX1Hash]
-		assert.Equal(t, metamorph_api.Status_SENT_TO_NETWORK, item.GetStatus())
-	})
-}
-
-func TestProcessorResponseMap_clean(t *testing.T) {
-	t.Run("default", func(t *testing.T) {
-		proc := metamorph.NewProcessorResponseMap(2 * time.Second)
-		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SENT_TO_NETWORK))
-		proc.Set(testdata.TX2Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX2Hash, metamorph_api.Status_ANNOUNCED_TO_NETWORK))
-
-		proc.Clean()
-
-		assert.Equal(t, 2, proc.Len())
-	})
-
-	t.Run("Expiry", func(t *testing.T) {
-		proc := metamorph.NewProcessorResponseMap(50 * time.Millisecond)
-		proc.Set(testdata.TX1Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SENT_TO_NETWORK))
-		proc.Set(testdata.TX2Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX2Hash, metamorph_api.Status_ANNOUNCED_TO_NETWORK))
-
-		time.Sleep(100 * time.Millisecond)
-
-		proc.Clean()
-
-		assert.Equal(t, 0, proc.Len())
+		assert.Equal(t, metamorph_api.Status_RECEIVED, item.GetStatus())
 	})
 }

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -171,7 +171,7 @@ func TestLoadUnmined(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pm := &mocks.PeerManagerMock{}
 			mtmStore := &mocks.MetamorphStoreMock{
-				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
 					if offset != 0 {
 						return nil, nil
 					}
@@ -272,7 +272,7 @@ func TestProcessTransaction(t *testing.T) {
 
 					return nil
 				},
-				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
 					if offset != 0 {
 						return nil, nil
 					}
@@ -618,7 +618,7 @@ func TestProcessExpiredTransactions(t *testing.T) {
 					return &store.StoreData{Hash: testdata.TX2Hash}, nil
 				},
 				SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error { return nil },
-				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
 					if offset != 0 {
 						return nil, nil
 					}
@@ -701,7 +701,7 @@ func TestProcessorHealth(t *testing.T) {
 					return &store.StoreData{Hash: testdata.TX2Hash}, nil
 				},
 				SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error { return nil },
-				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
 					if offset != 0 {
 						return nil, nil
 					}

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -344,7 +344,6 @@ func TestProcessTransaction(t *testing.T) {
 }
 
 func TestSendStatusForTransaction(t *testing.T) {
-	return
 	type input struct {
 		hash      *chainhash.Hash
 		newStatus metamorph_api.Status
@@ -375,10 +374,10 @@ func TestSendStatusForTransaction(t *testing.T) {
 				},
 			},
 
-			expectedUpdateStatusCalls: 0,
+			expectedUpdateStatusCalls: 1,
 		},
 		{
-			name: "tx in response map - current status REJECTED, new status SEEN_ON_NETWORK - no update",
+			name: "tx in response map - current status REJECTED, new status SEEN_ON_NETWORK - still updates",
 			inputs: []input{
 				{
 					hash:                testdata.TX1Hash,
@@ -389,7 +388,7 @@ func TestSendStatusForTransaction(t *testing.T) {
 				},
 			},
 
-			expectedUpdateStatusCalls: 0,
+			expectedUpdateStatusCalls: 1,
 		},
 		{
 			name: "new status MINED - update error",
@@ -554,12 +553,7 @@ func TestSendStatusForTransaction(t *testing.T) {
 			)
 			require.NoError(t, err)
 			assert.Equal(t, 0, processor.ProcessorResponseMap.Len())
-
 			for _, testInput := range tc.inputs {
-				if testInput.txResponseHash != nil {
-					processor.ProcessorResponseMap.Set(testInput.txResponseHash, testInput.txResponseHashValue)
-				}
-
 				sendErr := processor.SendStatusForTransaction(testInput.hash, testInput.newStatus, "test", testInput.statusErr)
 				assert.NoError(t, sendErr)
 			}
@@ -576,8 +570,8 @@ func TestSendStatusForTransaction(t *testing.T) {
 					t.Fatal("expected callbacks never sent")
 				}
 			}
-
 			time.Sleep(time.Millisecond * 100)
+			fmt.Println("aaaaa", len(metamorphStore.UpdateStatusBulkCalls()))
 
 			assert.Equal(t, tc.expectedUpdateStatusCalls, len(metamorphStore.UpdateStatusBulkCalls()))
 			assert.Equal(t, tc.expectedCallbacks, len(httpClientMock.DoCalls()))

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -170,7 +170,6 @@ func TestLoadUnmined(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			pm := &mocks.PeerManagerMock{}
-
 			mtmStore := &mocks.MetamorphStoreMock{
 				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
 					if offset != 0 {
@@ -191,6 +190,7 @@ func TestLoadUnmined(t *testing.T) {
 					return nil
 				},
 			}
+			fmt.Println("movida aq ukve")
 
 			processor, err := metamorph.NewProcessor(mtmStore, pm,
 				metamorph.WithCacheExpiryTime(time.Hour*24),

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -133,7 +133,7 @@ func TestLoadUnmined(t *testing.T) {
 			maxMonitoredTxs: 5,
 
 			expectedGetTransactionBlocksCalls: 1,
-			expectedItemTxHashesFinal:         []*chainhash.Hash{testdata.TX1Hash, testdata.TX2Hash, testdata.TX3Hash, testdata.TX4Hash},
+			expectedItemTxHashesFinal:         []*chainhash.Hash{testdata.TX3Hash, testdata.TX4Hash},
 		},
 		{
 			name:            "load 2 unmined transactions, failed to get unmined",
@@ -171,16 +171,20 @@ func TestLoadUnmined(t *testing.T) {
 			pm := &mocks.PeerManagerMock{}
 
 			mtmStore := &mocks.MetamorphStoreMock{
-				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64) ([]*store.StoreData, error) {
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
 					return tc.storedData, tc.getUnminedErr
 				},
 				SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error {
-					require.ElementsMatch(t, tc.expectedItemTxHashesFinal, hashes)
 					require.Equal(t, len(tc.expectedItemTxHashesFinal), len(hashes))
+					require.ElementsMatch(t, tc.expectedItemTxHashesFinal, hashes)
 					return nil
 				},
 				UpdateMinedFunc: func(ctx context.Context, txsBlocks *blocktx_api.TransactionBlocks) ([]*store.StoreData, error) {
 					return nil, nil
+				},
+
+				IncrementRetriesFunc: func(ctx context.Context, hash *chainhash.Hash) error {
+					return nil
 				},
 			}
 
@@ -196,8 +200,8 @@ func TestLoadUnmined(t *testing.T) {
 			defer processor.Shutdown()
 			require.Equal(t, 0, processor.ProcessorResponseMap.Len())
 
-			processor.ProcessorResponseMap.Set(testdata.TX3Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX3Hash, metamorph_api.Status_ANNOUNCED_TO_NETWORK))
-			processor.ProcessorResponseMap.Set(testdata.TX4Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX4Hash, metamorph_api.Status_ANNOUNCED_TO_NETWORK))
+			processor.ProcessorResponseMap.Set(testdata.TX3Hash, processor_response.NewProcessorResponse(testdata.TX3Hash))
+			processor.ProcessorResponseMap.Set(testdata.TX4Hash, processor_response.NewProcessorResponse(testdata.TX4Hash))
 
 			time.Sleep(time.Millisecond * 200)
 
@@ -262,6 +266,25 @@ func TestProcessTransaction(t *testing.T) {
 				SetFunc: func(ctx context.Context, key []byte, value *store.StoreData) error {
 					require.Equal(t, testdata.TX1Hash[:], key)
 
+					return nil
+				},
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+					return []*store.StoreData{
+						{
+							StoredAt:    time.Now(),
+							AnnouncedAt: time.Now(),
+							Hash:        testdata.TX1Hash,
+							Status:      metamorph_api.Status_ANNOUNCED_TO_NETWORK,
+						},
+						{
+							StoredAt:    time.Now(),
+							AnnouncedAt: time.Now(),
+							Hash:        testdata.TX2Hash,
+							Status:      metamorph_api.Status_STORED,
+						},
+					}, nil
+				},
+				IncrementRetriesFunc: func(ctx context.Context, hash *chainhash.Hash) error {
 					return nil
 				},
 			}
@@ -359,7 +382,7 @@ func TestSendStatusForTransaction(t *testing.T) {
 					newStatus:           metamorph_api.Status_SEEN_ON_NETWORK,
 					statusErr:           nil,
 					txResponseHash:      testdata.TX1Hash,
-					txResponseHashValue: processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_REJECTED),
+					txResponseHashValue: processor_response.NewProcessorResponse(testdata.TX1Hash),
 				},
 			},
 
@@ -372,7 +395,7 @@ func TestSendStatusForTransaction(t *testing.T) {
 					hash:                testdata.TX1Hash,
 					newStatus:           metamorph_api.Status_MINED,
 					txResponseHash:      testdata.TX1Hash,
-					txResponseHashValue: processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SEEN_ON_NETWORK),
+					txResponseHashValue: processor_response.NewProcessorResponse(testdata.TX1Hash),
 				},
 			},
 			updateErr: errors.New("failed to update status"),
@@ -387,38 +410,38 @@ func TestSendStatusForTransaction(t *testing.T) {
 					newStatus:           metamorph_api.Status_ANNOUNCED_TO_NETWORK,
 					statusErr:           nil,
 					txResponseHash:      testdata.TX1Hash,
-					txResponseHashValue: processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_STORED),
+					txResponseHashValue: processor_response.NewProcessorResponse(testdata.TX1Hash),
 				},
 				{
 					hash:                testdata.TX2Hash,
 					newStatus:           metamorph_api.Status_REJECTED,
 					statusErr:           errors.New("missing inputs"),
 					txResponseHash:      testdata.TX2Hash,
-					txResponseHashValue: processor_response.NewProcessorResponseWithStatus(testdata.TX2Hash, metamorph_api.Status_SENT_TO_NETWORK),
+					txResponseHashValue: processor_response.NewProcessorResponse(testdata.TX2Hash),
 				},
 				{
 					hash:                testdata.TX3Hash,
 					newStatus:           metamorph_api.Status_SENT_TO_NETWORK,
 					txResponseHash:      testdata.TX3Hash,
-					txResponseHashValue: processor_response.NewProcessorResponseWithStatus(testdata.TX3Hash, metamorph_api.Status_SENT_TO_NETWORK),
+					txResponseHashValue: processor_response.NewProcessorResponse(testdata.TX3Hash),
 				},
 				{
 					hash:                testdata.TX4Hash,
 					newStatus:           metamorph_api.Status_ACCEPTED_BY_NETWORK,
 					txResponseHash:      testdata.TX4Hash,
-					txResponseHashValue: processor_response.NewProcessorResponseWithStatus(testdata.TX4Hash, metamorph_api.Status_SENT_TO_NETWORK),
+					txResponseHashValue: processor_response.NewProcessorResponse(testdata.TX4Hash),
 				},
 				{
 					hash:                testdata.TX5Hash,
 					newStatus:           metamorph_api.Status_SEEN_ON_NETWORK,
 					txResponseHash:      testdata.TX5Hash,
-					txResponseHashValue: processor_response.NewProcessorResponseWithStatus(testdata.TX5Hash, metamorph_api.Status_REQUESTED_BY_NETWORK),
+					txResponseHashValue: processor_response.NewProcessorResponse(testdata.TX5Hash),
 				},
 				{
 					hash:                testdata.TX6Hash,
 					newStatus:           metamorph_api.Status_REQUESTED_BY_NETWORK,
 					txResponseHash:      testdata.TX6Hash,
-					txResponseHashValue: processor_response.NewProcessorResponseWithStatus(testdata.TX6Hash, metamorph_api.Status_STORED),
+					txResponseHashValue: processor_response.NewProcessorResponse(testdata.TX6Hash),
 				},
 			},
 			updateResp: [][]*store.StoreData{
@@ -452,7 +475,7 @@ func TestSendStatusForTransaction(t *testing.T) {
 					newStatus: metamorph_api.Status_REQUESTED_BY_NETWORK,
 
 					txResponseHash:      testdata.TX1Hash,
-					txResponseHashValue: processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_ANNOUNCED_TO_NETWORK),
+					txResponseHashValue: processor_response.NewProcessorResponse(testdata.TX1Hash),
 				},
 				{
 					hash:      testdata.TX1Hash,
@@ -502,6 +525,9 @@ func TestSendStatusForTransaction(t *testing.T) {
 						return tc.updateResp[counter-1], tc.updateErr
 					}
 					return nil, tc.updateErr
+				},
+				IncrementRetriesFunc: func(ctx context.Context, hash *chainhash.Hash) error {
+					return nil
 				},
 			}
 
@@ -588,11 +614,31 @@ func TestProcessExpiredTransactions(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+
 			metamorphStore := &mocks.MetamorphStoreMock{
 				GetFunc: func(ctx context.Context, key []byte) (*store.StoreData, error) {
 					return &store.StoreData{Hash: testdata.TX2Hash}, nil
 				},
 				SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error { return nil },
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+					return []*store.StoreData{
+						{
+							StoredAt:    time.Now(),
+							AnnouncedAt: time.Now(),
+							Hash:        testdata.TX1Hash,
+							Status:      metamorph_api.Status_ANNOUNCED_TO_NETWORK,
+						},
+						{
+							StoredAt:    time.Now(),
+							AnnouncedAt: time.Now(),
+							Hash:        testdata.TX2Hash,
+							Status:      metamorph_api.Status_STORED,
+						},
+					}, nil
+				},
+				IncrementRetriesFunc: func(ctx context.Context, hash *chainhash.Hash) error {
+					return nil
+				},
 			}
 			pm := &mocks.PeerManagerMock{
 				RequestTransactionFunc: func(txHash *chainhash.Hash) p2p.PeerI {
@@ -613,14 +659,11 @@ func TestProcessExpiredTransactions(t *testing.T) {
 
 			require.Equal(t, 0, processor.ProcessorResponseMap.Len())
 
-			respSent := processor_response.NewProcessorResponseWithStatus(testdata.TX1Hash, metamorph_api.Status_SENT_TO_NETWORK)
-			respSent.Retries.Add(tc.retries)
+			respSent := processor_response.NewProcessorResponse(testdata.TX1Hash)
 
-			respAnnounced := processor_response.NewProcessorResponseWithStatus(testdata.TX2Hash, metamorph_api.Status_ANNOUNCED_TO_NETWORK)
-			respAnnounced.Retries.Add(tc.retries)
+			respAnnounced := processor_response.NewProcessorResponse(testdata.TX2Hash)
 
-			respAccepted := processor_response.NewProcessorResponseWithStatus(testdata.TX3Hash, metamorph_api.Status_ACCEPTED_BY_NETWORK)
-			respAccepted.Retries.Add(tc.retries)
+			respAccepted := processor_response.NewProcessorResponse(testdata.TX3Hash)
 
 			processor.ProcessorResponseMap.Set(testdata.TX1Hash, respSent)
 			processor.ProcessorResponseMap.Set(testdata.TX2Hash, respAnnounced)
@@ -660,6 +703,22 @@ func TestProcessorHealth(t *testing.T) {
 					return &store.StoreData{Hash: testdata.TX2Hash}, nil
 				},
 				SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error { return nil },
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+					return []*store.StoreData{
+						{
+							StoredAt:    time.Now(),
+							AnnouncedAt: time.Now(),
+							Hash:        testdata.TX1Hash,
+							Status:      metamorph_api.Status_ANNOUNCED_TO_NETWORK,
+						},
+						{
+							StoredAt:    time.Now(),
+							AnnouncedAt: time.Now(),
+							Hash:        testdata.TX2Hash,
+							Status:      metamorph_api.Status_STORED,
+						},
+					}, nil
+				},
 			}
 
 			pm := &mocks.PeerManagerMock{

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -3,6 +3,7 @@ package metamorph_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -172,6 +173,9 @@ func TestLoadUnmined(t *testing.T) {
 
 			mtmStore := &mocks.MetamorphStoreMock{
 				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+					if offset != 0 {
+						return nil, nil
+					}
 					return tc.storedData, tc.getUnminedErr
 				},
 				SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error {
@@ -269,18 +273,15 @@ func TestProcessTransaction(t *testing.T) {
 					return nil
 				},
 				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+					if offset != 0 {
+						return nil, nil
+					}
 					return []*store.StoreData{
 						{
 							StoredAt:    time.Now(),
 							AnnouncedAt: time.Now(),
 							Hash:        testdata.TX1Hash,
 							Status:      metamorph_api.Status_ANNOUNCED_TO_NETWORK,
-						},
-						{
-							StoredAt:    time.Now(),
-							AnnouncedAt: time.Now(),
-							Hash:        testdata.TX2Hash,
-							Status:      metamorph_api.Status_STORED,
 						},
 					}, nil
 				},
@@ -311,6 +312,7 @@ func TestProcessTransaction(t *testing.T) {
 				n := 0
 				for response := range responseChannel {
 					status := response.Status
+					fmt.Println(status.String())
 					require.Equal(t, testdata.TX1Hash, response.Hash)
 					require.Equalf(t, tc.expectedResponses[n], status, "Iteration %d: Expected %s, got %s", n, tc.expectedResponses[n].String(), status.String())
 					wg.Done()
@@ -621,6 +623,9 @@ func TestProcessExpiredTransactions(t *testing.T) {
 				},
 				SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error { return nil },
 				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+					if offset != 0 {
+						return nil, nil
+					}
 					return []*store.StoreData{
 						{
 							StoredAt:    time.Now(),
@@ -704,6 +709,9 @@ func TestProcessorHealth(t *testing.T) {
 				},
 				SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error { return nil },
 				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
+					if offset != 0 {
+						return nil, nil
+					}
 					return []*store.StoreData{
 						{
 							StoredAt:    time.Now(),

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -199,8 +199,6 @@ func TestLoadUnmined(t *testing.T) {
 			processor.ProcessorResponseMap.Set(testdata.TX3Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX3Hash, metamorph_api.Status_ANNOUNCED_TO_NETWORK))
 			processor.ProcessorResponseMap.Set(testdata.TX4Hash, processor_response.NewProcessorResponseWithStatus(testdata.TX4Hash, metamorph_api.Status_ANNOUNCED_TO_NETWORK))
 
-			processor.LoadUnmined()
-
 			time.Sleep(time.Millisecond * 200)
 
 			allItemHashes := make([]*chainhash.Hash, 0, len(processor.ProcessorResponseMap.Items()))

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -3,7 +3,6 @@ package metamorph_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -171,7 +170,7 @@ func TestLoadUnmined(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pm := &mocks.PeerManagerMock{}
 			mtmStore := &mocks.MetamorphStoreMock{
-				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
 					if offset != 0 {
 						return nil, nil
 					}
@@ -190,7 +189,6 @@ func TestLoadUnmined(t *testing.T) {
 					return nil
 				},
 			}
-			fmt.Println("movida aq ukve")
 
 			processor, err := metamorph.NewProcessor(mtmStore, pm,
 				metamorph.WithCacheExpiryTime(time.Hour*24),
@@ -272,7 +270,7 @@ func TestProcessTransaction(t *testing.T) {
 
 					return nil
 				},
-				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
 					if offset != 0 {
 						return nil, nil
 					}
@@ -312,7 +310,6 @@ func TestProcessTransaction(t *testing.T) {
 				n := 0
 				for response := range responseChannel {
 					status := response.Status
-					fmt.Println(status.String())
 					require.Equal(t, testdata.TX1Hash, response.Hash)
 					require.Equalf(t, tc.expectedResponses[n], status, "Iteration %d: Expected %s, got %s", n, tc.expectedResponses[n].String(), status.String())
 					wg.Done()
@@ -571,7 +568,6 @@ func TestSendStatusForTransaction(t *testing.T) {
 				}
 			}
 			time.Sleep(time.Millisecond * 100)
-			fmt.Println("aaaaa", len(metamorphStore.UpdateStatusBulkCalls()))
 
 			assert.Equal(t, tc.expectedUpdateStatusCalls, len(metamorphStore.UpdateStatusBulkCalls()))
 			assert.Equal(t, tc.expectedCallbacks, len(httpClientMock.DoCalls()))
@@ -618,7 +614,7 @@ func TestProcessExpiredTransactions(t *testing.T) {
 					return &store.StoreData{Hash: testdata.TX2Hash}, nil
 				},
 				SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error { return nil },
-				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
 					if offset != 0 {
 						return nil, nil
 					}
@@ -701,7 +697,7 @@ func TestProcessorHealth(t *testing.T) {
 					return &store.StoreData{Hash: testdata.TX2Hash}, nil
 				},
 				SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error { return nil },
-				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*store.StoreData, error) {
+				GetUnminedFunc: func(ctx context.Context, since time.Time, limit int64, offset int64) ([]*store.StoreData, error) {
 					if offset != 0 {
 						return nil, nil
 					}

--- a/metamorph/store/postgresql/migrations/000011_response_map.down.sql
+++ b/metamorph/store/postgresql/migrations/000011_response_map.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE metamorph.transactions DROP COLUMN retries;

--- a/metamorph/store/postgresql/migrations/000011_response_map.up.sql
+++ b/metamorph/store/postgresql/migrations/000011_response_map.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE metamorph.transactions ADD COLUMN retries INT DEFAULT 0;

--- a/metamorph/store/postgresql/postgres_test.go
+++ b/metamorph/store/postgresql/postgres_test.go
@@ -80,7 +80,6 @@ func TestMain(m *testing.M) {
 	hostPort := resource.GetPort("5432/tcp")
 
 	dbInfo = fmt.Sprintf("host=localhost port=%s user=%s password=%s dbname=%s sslmode=disable", hostPort, dbUsername, dbPassword, dbName)
-	fmt.Println(dbInfo)
 	var postgresDB *PostgreSQL
 	err = pool.Retry(func() error {
 		postgresDB, err = New(dbInfo, "localhost", 10, 10)
@@ -257,7 +256,7 @@ func TestPostgresDB(t *testing.T) {
 
 		expectedHash, err := chainhash.NewHashFromStr("57438c4340b9a5e0d77120d999765589048f6f2dd49a6325cdf14356fc4cc012")
 		require.NoError(t, err)
-		records, err := postgresDB.GetUnmined(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 1)
+		records, err := postgresDB.GetUnmined(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 1, 0)
 		require.NoError(t, err)
 		require.Equal(t, expectedHash, records[0].Hash)
 

--- a/metamorph/store/postgresql/postgres_test.go
+++ b/metamorph/store/postgresql/postgres_test.go
@@ -256,7 +256,7 @@ func TestPostgresDB(t *testing.T) {
 
 		expectedHash, err := chainhash.NewHashFromStr("57438c4340b9a5e0d77120d999765589048f6f2dd49a6325cdf14356fc4cc012")
 		require.NoError(t, err)
-		records, err := postgresDB.GetUnmined(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 1, 0, "hostname")
+		records, err := postgresDB.GetUnmined(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 1, 0)
 		require.NoError(t, err)
 		require.Equal(t, expectedHash, records[0].Hash)
 

--- a/metamorph/store/postgresql/postgres_test.go
+++ b/metamorph/store/postgresql/postgres_test.go
@@ -254,13 +254,32 @@ func TestPostgresDB(t *testing.T) {
 
 		require.NoError(t, loadFixtures(postgresDB.db, "fixtures"))
 
-		expectedHash, err := chainhash.NewHashFromStr("57438c4340b9a5e0d77120d999765589048f6f2dd49a6325cdf14356fc4cc012")
+		// locked by metamorph-1
+		expectedHash0, err := chainhash.NewHashFromStr("30f409d6951483e4d65a586205f373c2f72431ade49abb6f143e82fc53ea6cb1")
 		require.NoError(t, err)
+		// offset 0
 		records, err := postgresDB.GetUnmined(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 1, 0)
 		require.NoError(t, err)
-		require.Equal(t, expectedHash, records[0].Hash)
+		require.Equal(t, expectedHash0, records[0].Hash)
 
-		dataReturned, err := postgresDB.Get(ctx, expectedHash[:])
+		// locked by metamorph-1
+		expectedHash1, err := chainhash.NewHashFromStr("cd8e0640fadac1f9ed854174558e37a54ede58bc85f49bf01041348c215b0b3e")
+		require.NoError(t, err)
+		// offset 1
+		records, err = postgresDB.GetUnmined(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 1, 1)
+		require.NoError(t, err)
+		require.Equal(t, expectedHash1, records[0].Hash)
+
+		// locked by NONE
+		expectedHash2, err := chainhash.NewHashFromStr("57438c4340b9a5e0d77120d999765589048f6f2dd49a6325cdf14356fc4cc012")
+		require.NoError(t, err)
+		// offset 2
+		records, err = postgresDB.GetUnmined(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 1, 2)
+		require.NoError(t, err)
+		require.Equal(t, expectedHash2, records[0].Hash)
+
+		// check if previously unlocked tx has been locked
+		dataReturned, err := postgresDB.Get(ctx, expectedHash2[:])
 		require.NoError(t, err)
 		require.Equal(t, "metamorph-1", dataReturned.LockedBy)
 	})

--- a/metamorph/store/postgresql/postgres_test.go
+++ b/metamorph/store/postgresql/postgres_test.go
@@ -256,7 +256,7 @@ func TestPostgresDB(t *testing.T) {
 
 		expectedHash, err := chainhash.NewHashFromStr("57438c4340b9a5e0d77120d999765589048f6f2dd49a6325cdf14356fc4cc012")
 		require.NoError(t, err)
-		records, err := postgresDB.GetUnmined(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 1, 0)
+		records, err := postgresDB.GetUnmined(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 1, 0, "hostname")
 		require.NoError(t, err)
 		require.Equal(t, expectedHash, records[0].Hash)
 

--- a/metamorph/store/store.go
+++ b/metamorph/store/store.go
@@ -29,6 +29,7 @@ type StoreData struct {
 	Ttl               int64                `dynamodbav:"ttl"`
 	MerklePath        string               `dynamodbav:"merkle_path"`
 	InsertedAtNum     int                  `dynamodbav:"inserted_at_num"`
+	Retries           int                  `dynamodbav:"retries"`
 }
 
 type MetamorphStore interface {
@@ -37,8 +38,9 @@ type MetamorphStore interface {
 	Del(ctx context.Context, key []byte) error
 
 	SetUnlocked(ctx context.Context, hashes []*chainhash.Hash) error
+	IncrementRetries(ctx context.Context, hash *chainhash.Hash) error
 	SetUnlockedByName(ctx context.Context, lockedBy string) (int64, error)
-	GetUnmined(ctx context.Context, since time.Time, limit int64) ([]*StoreData, error)
+	GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64) ([]*StoreData, error)
 	UpdateStatusBulk(ctx context.Context, updates []UpdateStatus) ([]*StoreData, error)
 	UpdateMined(ctx context.Context, txsBlocks *blocktx_api.TransactionBlocks) ([]*StoreData, error)
 	Close(ctx context.Context) error

--- a/metamorph/store/store.go
+++ b/metamorph/store/store.go
@@ -40,7 +40,7 @@ type MetamorphStore interface {
 	SetUnlocked(ctx context.Context, hashes []*chainhash.Hash) error
 	IncrementRetries(ctx context.Context, hash *chainhash.Hash) error
 	SetUnlockedByName(ctx context.Context, lockedBy string) (int64, error)
-	GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*StoreData, error)
+	GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64) ([]*StoreData, error)
 	UpdateStatusBulk(ctx context.Context, updates []UpdateStatus) ([]*StoreData, error)
 	UpdateMined(ctx context.Context, txsBlocks *blocktx_api.TransactionBlocks) ([]*StoreData, error)
 	Close(ctx context.Context) error

--- a/metamorph/store/store.go
+++ b/metamorph/store/store.go
@@ -40,7 +40,7 @@ type MetamorphStore interface {
 	SetUnlocked(ctx context.Context, hashes []*chainhash.Hash) error
 	IncrementRetries(ctx context.Context, hash *chainhash.Hash) error
 	SetUnlockedByName(ctx context.Context, lockedBy string) (int64, error)
-	GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64) ([]*StoreData, error)
+	GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64, hostname string) ([]*StoreData, error)
 	UpdateStatusBulk(ctx context.Context, updates []UpdateStatus) ([]*StoreData, error)
 	UpdateMined(ctx context.Context, txsBlocks *blocktx_api.TransactionBlocks) ([]*StoreData, error)
 	Close(ctx context.Context) error

--- a/metamorph/types.go
+++ b/metamorph/types.go
@@ -31,6 +31,7 @@ type ProcessorStats struct {
 type ProcessorRequest struct {
 	Data            *store.StoreData
 	ResponseChannel chan processor_response.StatusAndError
+	Timeout         time.Duration
 }
 
 type PeerTxMessage struct {


### PR DESCRIPTION
Removed most of stats from code.

Response map doesn't have element after client connection (after ~5 sec)

Getting unmined transactions from database now.

Simplifying some callback hell.