### PR TITLE
Refactor/metamorph processor

### DIFF
--- a/cmd/metamorph.go
+++ b/cmd/metamorph.go
@@ -121,6 +121,12 @@ func StartMetamorph(logger *slog.Logger) (func(), error) {
 	)
 
 	metamorphProcessor.StartLockTransactions()
+	time.Sleep(200 * time.Millisecond) // wait a short time so that process expired transactions will start shortly after lock transactions go routine
+
+	metamorphProcessor.StartProcessExpiredTransactions()
+	metamorphProcessor.StartProcessStatusUpdatesInStorage()
+	metamorphProcessor.StartProcessMinedCallbacks()
+
 	http.HandleFunc("/pstats", metamorphProcessor.HandleStats)
 
 	go func() {

--- a/cmd/metamorph.go
+++ b/cmd/metamorph.go
@@ -120,6 +120,7 @@ func StartMetamorph(logger *slog.Logger) (func(), error) {
 		metamorph.WithProcessStatusUpdatesInterval(processStatusUpdateInterval),
 	)
 
+	metamorphProcessor.StartLockTransactions()
 	http.HandleFunc("/pstats", metamorphProcessor.HandleStats)
 
 	go func() {

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -26,7 +26,7 @@ const (
 	MaxRetries = 15
 	// length of interval for checking transactions if they are seen on the network
 	// if not we resend them again for a few times
-	unseenTransactionRebroadcastingInterval = 60
+	unseenTransactionRebroadcastingInterval = 60 * time.Second
 
 	mapExpiryTimeDefault = 24 * time.Hour
 	LogLevelDefault      = slog.LevelInfo
@@ -47,28 +47,35 @@ var (
 )
 
 type Processor struct {
-	store                   store.MetamorphStore
-	ProcessorResponseMap    *ProcessorResponseMap
-	pm                      p2p.PeerManagerI
-	mqClient                MessageQueueClient
-	logger                  *slog.Logger
-	mapExpiryTime           time.Duration
-	dataRetentionPeriod     time.Duration
-	now                     func() time.Time
-	processExpiredTxsTicker *time.Ticker
-	lockTransactionsTicker  *time.Ticker
-	httpClient              HttpClient
-	maxMonitoredTxs         int64
+	store                store.MetamorphStore
+	ProcessorResponseMap *ProcessorResponseMap
+	pm                   p2p.PeerManagerI
+	mqClient             MessageQueueClient
+	logger               *slog.Logger
+	mapExpiryTime        time.Duration
+	dataRetentionPeriod  time.Duration
+	now                  func() time.Time
 
-	quitListenTxChannel         chan struct{}
-	quitListenTxChannelComplete chan struct{}
-	minedTxsChan                chan *blocktx_api.TransactionBlocks
+	httpClient      HttpClient
+	maxMonitoredTxs int64
 
-	storageStatusUpdateCh            chan store.UpdateStatus
-	quitListenStatusUpdateCh         chan struct{}
-	quitListenStatusUpdateChComplete chan struct{}
-	processStatusUpdatesInterval     time.Duration
-	processStatusUpdatesBatchSize    int
+	lockTransactionsInterval     time.Duration
+	quitLockTransactions         chan struct{}
+	quitLockTransactionsComplete chan struct{}
+
+	quitProcessMinedCallbacks         chan struct{}
+	quitProcessMinedCallbacksComplete chan struct{}
+	minedTxsChan                      chan *blocktx_api.TransactionBlocks
+
+	storageStatusUpdateCh                     chan store.UpdateStatus
+	quitProcessStatusUpdatesInStorage         chan struct{}
+	quitProcessStatusUpdatesInStorageComplete chan struct{}
+	processStatusUpdatesInterval              time.Duration
+	processStatusUpdatesBatchSize             int
+
+	processExpiredTxsInterval              time.Duration
+	quitProcessExpiredTransactions         chan struct{}
+	quitProcessExpiredTransactionsComplete chan struct{}
 
 	startTime           time.Time
 	queueLength         atomic.Int32
@@ -101,24 +108,22 @@ func NewProcessor(s store.MetamorphStore, pm p2p.PeerManagerI, opts ...Option) (
 	}
 
 	p := &Processor{
-		startTime:               time.Now().UTC(),
-		store:                   s,
-		pm:                      pm,
-		dataRetentionPeriod:     dataRetentionPeriodDefault,
-		mapExpiryTime:           mapExpiryTimeDefault,
-		now:                     time.Now,
-		processExpiredTxsTicker: time.NewTicker(unseenTransactionRebroadcastingInterval * time.Second),
-		lockTransactionsTicker:  time.NewTicker(unseenTransactionRebroadcastingInterval * time.Second),
-		maxMonitoredTxs:         maxMonitoriedTxs,
+		startTime:           time.Now().UTC(),
+		store:               s,
+		pm:                  pm,
+		dataRetentionPeriod: dataRetentionPeriodDefault,
+		mapExpiryTime:       mapExpiryTimeDefault,
+		now:                 time.Now,
 
-		quitListenTxChannel:         make(chan struct{}),
-		quitListenTxChannelComplete: make(chan struct{}),
+		processExpiredTxsInterval: unseenTransactionRebroadcastingInterval,
+		lockTransactionsInterval:  unseenTransactionRebroadcastingInterval,
 
-		quitListenStatusUpdateCh:         make(chan struct{}),
-		quitListenStatusUpdateChComplete: make(chan struct{}),
-		processStatusUpdatesInterval:     processStatusUpdatesIntervalDefault,
-		processStatusUpdatesBatchSize:    processStatusUpdatesBatchSizeDefault,
-		storageStatusUpdateCh:            make(chan store.UpdateStatus, processStatusUpdatesBatchSizeDefault),
+		maxMonitoredTxs: maxMonitoriedTxs,
+
+		processStatusUpdatesInterval:  processStatusUpdatesIntervalDefault,
+		processStatusUpdatesBatchSize: processStatusUpdatesBatchSizeDefault,
+		storageStatusUpdateCh:         make(chan store.UpdateStatus, processStatusUpdatesBatchSizeDefault),
+
 		httpClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
@@ -145,11 +150,6 @@ func NewProcessor(s store.MetamorphStore, pm p2p.PeerManagerI, opts ...Option) (
 
 	p.logger.Info("Starting processor", slog.String("cacheExpiryTime", p.mapExpiryTime.String()))
 
-	// Start a goroutine to resend transactions that have not been seen on the network
-	go p.processExpiredTransactions()
-	go p.processMinedCallbacks()
-	go p.processStatusUpdatesInStorage()
-
 	gocore.AddAppPayloadFn("mtm", func() interface{} {
 		return p.GetStats(false)
 	})
@@ -167,11 +167,25 @@ func (p *Processor) Shutdown() {
 	if err != nil {
 		p.logger.Error("Failed to unlock all hashes", slog.String("err", err.Error()))
 	}
-	p.processExpiredTxsTicker.Stop()
-	p.quitListenTxChannel <- struct{}{}
-	<-p.quitListenTxChannelComplete
-	p.quitListenStatusUpdateCh <- struct{}{}
-	<-p.quitListenStatusUpdateChComplete
+
+	if p.quitLockTransactions != nil {
+		p.quitLockTransactions <- struct{}{}
+		<-p.quitLockTransactionsComplete
+	}
+	if p.quitProcessMinedCallbacks != nil {
+		p.quitProcessMinedCallbacks <- struct{}{}
+		<-p.quitProcessMinedCallbacksComplete
+	}
+
+	if p.quitProcessStatusUpdatesInStorage != nil {
+		p.quitProcessStatusUpdatesInStorage <- struct{}{}
+		<-p.quitProcessStatusUpdatesInStorageComplete
+	}
+
+	if p.quitProcessExpiredTransactions != nil {
+		p.quitProcessExpiredTransactions <- struct{}{}
+		<-p.quitProcessExpiredTransactionsComplete
+	}
 }
 
 func (p *Processor) unlockItems() error {
@@ -195,15 +209,19 @@ func (p *Processor) unlockItems() error {
 	return nil
 }
 
-func (p *Processor) processMinedCallbacks() {
+func (p *Processor) StartProcessMinedCallbacks() {
+
+	p.quitProcessMinedCallbacks = make(chan struct{})
+	p.quitProcessMinedCallbacksComplete = make(chan struct{})
+
 	go func() {
 		defer func() {
-			p.quitListenTxChannelComplete <- struct{}{}
+			p.quitProcessMinedCallbacksComplete <- struct{}{}
 		}()
 
 		for {
 			select {
-			case <-p.quitListenTxChannel:
+			case <-p.quitProcessMinedCallbacks:
 				return
 			case txBlocks := <-p.minedTxsChan:
 				updatedData, err := p.store.UpdateMined(context.Background(), txBlocks)
@@ -239,19 +257,22 @@ func (p *Processor) CheckAndUpdate(statusUpdatesMap *map[chainhash.Hash]store.Up
 	*statusUpdatesMap = map[chainhash.Hash]store.UpdateStatus{}
 }
 
-func (p *Processor) processStatusUpdatesInStorage() {
+func (p *Processor) StartProcessStatusUpdatesInStorage() {
 	ticker := time.NewTicker(p.processStatusUpdatesInterval)
+
+	p.quitProcessStatusUpdatesInStorage = make(chan struct{})
+	p.quitProcessStatusUpdatesInStorageComplete = make(chan struct{})
 
 	go func() {
 		defer func() {
-			p.quitListenStatusUpdateChComplete <- struct{}{}
+			p.quitProcessStatusUpdatesInStorageComplete <- struct{}{}
 		}()
 
 		statusUpdatesMap := map[chainhash.Hash]store.UpdateStatus{}
 
 		for {
 			select {
-			case <-p.quitListenStatusUpdateCh:
+			case <-p.quitProcessStatusUpdatesInStorage:
 				return
 			case statusUpdate := <-p.storageStatusUpdateCh:
 				// Ensure no duplicate hashes, overwrite value if the status has higher value than existing status
@@ -288,60 +309,88 @@ func (p *Processor) StartLockTransactions() {
 	span, _ := opentracing.StartSpanFromContext(context.Background(), "Processor:lockTransactions")
 	dbctx := opentracing.ContextWithSpan(context.Background(), span)
 	defer span.Finish()
+	ticker := time.NewTicker(p.lockTransactionsInterval)
 
-	for range p.lockTransactionsTicker.C {
-		err := p.store.SetLocked(dbctx, loadUnminedLimit)
-		if err != nil {
-			p.logger.Error("Failed to set transactions locked", slog.String("err", err.Error()))
+	p.quitLockTransactions = make(chan struct{})
+	p.quitLockTransactionsComplete = make(chan struct{})
+
+	go func() {
+		defer func() {
+			p.quitLockTransactionsComplete <- struct{}{}
+		}()
+		for {
+			select {
+			case <-p.quitLockTransactions:
+				return
+			case <-ticker.C:
+				err := p.store.SetLocked(dbctx, loadUnminedLimit)
+				if err != nil {
+					p.logger.Error("Failed to set transactions locked", slog.String("err", err.Error()))
+				}
+			}
 		}
-	}
+	}()
 }
 
-func (p *Processor) processExpiredTransactions() {
+func (p *Processor) StartProcessExpiredTransactions() {
 	span, _ := opentracing.StartSpanFromContext(context.Background(), "Processor:processExpiredTransactions")
 	dbctx := opentracing.ContextWithSpan(context.Background(), span)
-	defer span.Finish()
 
-	// Periodically read unmined transactions from database and announce them again
-	for range p.processExpiredTxsTicker.C {
-		// define from what point in time we are interested in unmined transactions
-		getUnminedSince := p.now().Add(-1 * p.mapExpiryTime)
-		var offset int64
+	ticker := time.NewTicker(p.processExpiredTxsInterval)
+
+	p.quitProcessExpiredTransactions = make(chan struct{})
+	p.quitProcessExpiredTransactionsComplete = make(chan struct{})
+
+	defer span.Finish()
+	go func() {
+		defer func() {
+			p.quitProcessExpiredTransactionsComplete <- struct{}{}
+		}()
 
 		for {
-			// get all transactions since then chunk by chunk
-			unminedTxs, err := p.store.GetUnmined(dbctx, getUnminedSince, loadUnminedLimit, offset)
-			if err != nil {
-				p.logger.Error("Failed to get unmined transactions", slog.String("err", err.Error()))
-				continue
-			}
+			select {
+			case <-p.quitProcessExpiredTransactions:
+				return
+			case <-ticker.C: // Periodically read unmined transactions from database and announce them again
+				// define from what point in time we are interested in unmined transactions
+				getUnminedSince := p.now().Add(-1 * p.mapExpiryTime)
+				var offset int64
 
-			offset += loadUnminedLimit
-			if len(unminedTxs) == 0 {
-				break
-			}
+				for {
+					// get all transactions since then chunk by chunk
+					unminedTxs, err := p.store.GetUnmined(dbctx, getUnminedSince, loadUnminedLimit, offset)
+					if err != nil {
+						p.logger.Error("Failed to get unmined transactions", slog.String("err", err.Error()))
+						continue
+					}
 
-			p.logger.Info("Resending unmined transactions", slog.Int("number", len(unminedTxs)))
-			for _, tx := range unminedTxs {
-				// mark that we retried processing this transaction once more
-				if err = p.store.IncrementRetries(dbctx, tx.Hash); err != nil {
-					p.logger.Error("Failed to increment retries in database", slog.String("err", err.Error()))
+					offset += loadUnminedLimit
+					if len(unminedTxs) == 0 {
+						break
+					}
+
+					p.logger.Info("Resending unmined transactions", slog.Int("number", len(unminedTxs)))
+					for _, tx := range unminedTxs {
+						// mark that we retried processing this transaction once more
+						if err = p.store.IncrementRetries(dbctx, tx.Hash); err != nil {
+							p.logger.Error("Failed to increment retries in database", slog.String("err", err.Error()))
+						}
+
+						if tx.Retries > MaxRetries {
+							// Sending GETDATA to peers to see if they have it
+							p.logger.Debug("Re-getting expired tx", slog.String("hash", tx.Hash.String()))
+							p.pm.RequestTransaction(tx.Hash)
+						} else {
+							p.logger.Debug("Re-announcing expired tx", slog.String("hash", tx.Hash.String()))
+							p.pm.AnnounceTransaction(tx.Hash, nil)
+						}
+
+						p.retries.AddDuration(time.Since(time.Now()))
+					}
 				}
-
-				if tx.Retries > MaxRetries {
-					// Sending GETDATA to peers to see if they have it
-					p.logger.Debug("Re-getting expired tx", slog.String("hash", tx.Hash.String()))
-					p.pm.RequestTransaction(tx.Hash)
-				} else {
-					p.logger.Debug("Re-announcing expired tx", slog.String("hash", tx.Hash.String()))
-					p.pm.AnnounceTransaction(tx.Hash, nil)
-				}
-
-				p.retries.AddDuration(time.Since(time.Now()))
 			}
 		}
-
-	}
+	}()
 }
 
 // GetPeers returns a list of connected and a list of disconnected peers

--- a/metamorph/processor_options.go
+++ b/metamorph/processor_options.go
@@ -29,7 +29,7 @@ func WithNow(nowFunc func() time.Time) func(*Processor) {
 
 func WithProcessExpiredTxsInterval(d time.Duration) func(*Processor) {
 	return func(p *Processor) {
-		p.processExpiredTxsTicker = time.NewTicker(d)
+		p.processExpiredTxsInterval = d
 	}
 }
 

--- a/metamorph/processor_options.go
+++ b/metamorph/processor_options.go
@@ -33,6 +33,12 @@ func WithProcessExpiredTxsInterval(d time.Duration) func(*Processor) {
 	}
 }
 
+func WithLockTxsInterval(d time.Duration) func(*Processor) {
+	return func(p *Processor) {
+		p.lockTransactionsInterval = d
+	}
+}
+
 func WithProcessStatusUpdatesInterval(d time.Duration) func(*Processor) {
 	return func(p *Processor) {
 		p.processStatusUpdatesInterval = d

--- a/metamorph/store/postgresql/fixtures/metamorph.transactions.yaml
+++ b/metamorph/store/postgresql/fixtures/metamorph.transactions.yaml
@@ -39,6 +39,18 @@
   stored_at: 2023-10-01 14:00:00
   announced_at: 2023-10-01 14:05:00
   inserted_at_num: 2023100114
+- hash: 0x78d66c8391ff5e4a65b494e39645facb420b744f77f3f3b83a3aa8573282176e
+  locked_by: NONE
+  status: 5
+  stored_at: 2023-10-01 14:00:00
+  announced_at: 2023-10-01 14:05:00
+  inserted_at_num: 2023100114
+- hash: 0x319b5eb9d99084b72002640d1445f49b8c83539260a7e5b2cbb16c1d2954a743
+  locked_by: NONE
+  status: 6
+  stored_at: 2023-10-01 14:00:00
+  announced_at: 2023-10-01 14:05:00
+  inserted_at_num: 2023100114
 - hash: 0xa8b965b5901163a9bdcd38d2ad524c3bb27ae31fb86dc8947253b541af8dd308
   locked_by: NONE
   status: 9

--- a/metamorph/store/store.go
+++ b/metamorph/store/store.go
@@ -38,6 +38,7 @@ type MetamorphStore interface {
 	Del(ctx context.Context, key []byte) error
 
 	SetUnlocked(ctx context.Context, hashes []*chainhash.Hash) error
+	SetLocked(ctx context.Context, limit int64) error
 	IncrementRetries(ctx context.Context, hash *chainhash.Hash) error
 	SetUnlockedByName(ctx context.Context, lockedBy string) (int64, error)
 	GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64) ([]*StoreData, error)


### PR DESCRIPTION
Currently it can happen that multiple metamorphs are loading the same umined transactions. Updates to the statuses of these transactions can result in Postgres deadlocks. Thus it has to be ensured that each unmined transaction gets loaded exclusively.

- Do not update and query unmined transactions in the same function
- Set transactions as locked to the metamorph instance in a separate function periodically
- Refactoring so that go routines are started not in the constructor, but have to be started explicitly outside of the constructor.