### PR TITLE
fix metamorph updates

### DIFF
--- a/metamorph/mocks/store_mock.go
+++ b/metamorph/mocks/store_mock.go
@@ -46,7 +46,7 @@ var _ store.MetamorphStore = &MetamorphStoreMock{}
 //			SetFunc: func(ctx context.Context, key []byte, value *store.StoreData) error {
 //				panic("mock out the Set method")
 //			},
-//			SetLockedFunc: func(ctx context.Context, limit int64) error {
+//			SetLockedFunc: func(ctx context.Context, since time.Time, limit int64) error {
 //				panic("mock out the SetLocked method")
 //			},
 //			SetUnlockedFunc: func(ctx context.Context, hashes []*chainhash.Hash) error {
@@ -93,7 +93,7 @@ type MetamorphStoreMock struct {
 	SetFunc func(ctx context.Context, key []byte, value *store.StoreData) error
 
 	// SetLockedFunc mocks the SetLocked method.
-	SetLockedFunc func(ctx context.Context, limit int64) error
+	SetLockedFunc func(ctx context.Context, since time.Time, limit int64) error
 
 	// SetUnlockedFunc mocks the SetUnlocked method.
 	SetUnlockedFunc func(ctx context.Context, hashes []*chainhash.Hash) error
@@ -171,6 +171,8 @@ type MetamorphStoreMock struct {
 		SetLocked []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// Since is the since argument value.
+			Since time.Time
 			// Limit is the limit argument value.
 			Limit int64
 		}
@@ -511,21 +513,23 @@ func (mock *MetamorphStoreMock) SetCalls() []struct {
 }
 
 // SetLocked calls SetLockedFunc.
-func (mock *MetamorphStoreMock) SetLocked(ctx context.Context, limit int64) error {
+func (mock *MetamorphStoreMock) SetLocked(ctx context.Context, since time.Time, limit int64) error {
 	if mock.SetLockedFunc == nil {
 		panic("MetamorphStoreMock.SetLockedFunc: method is nil but MetamorphStore.SetLocked was just called")
 	}
 	callInfo := struct {
 		Ctx   context.Context
+		Since time.Time
 		Limit int64
 	}{
 		Ctx:   ctx,
+		Since: since,
 		Limit: limit,
 	}
 	mock.lockSetLocked.Lock()
 	mock.calls.SetLocked = append(mock.calls.SetLocked, callInfo)
 	mock.lockSetLocked.Unlock()
-	return mock.SetLockedFunc(ctx, limit)
+	return mock.SetLockedFunc(ctx, since, limit)
 }
 
 // SetLockedCalls gets all the calls that were made to SetLocked.
@@ -534,10 +538,12 @@ func (mock *MetamorphStoreMock) SetLocked(ctx context.Context, limit int64) erro
 //	len(mockedMetamorphStore.SetLockedCalls())
 func (mock *MetamorphStoreMock) SetLockedCalls() []struct {
 	Ctx   context.Context
+	Since time.Time
 	Limit int64
 } {
 	var calls []struct {
 		Ctx   context.Context
+		Since time.Time
 		Limit int64
 	}
 	mock.lockSetLocked.RLock()

--- a/metamorph/processor.go
+++ b/metamorph/processor.go
@@ -323,7 +323,8 @@ func (p *Processor) StartLockTransactions() {
 			case <-p.quitLockTransactions:
 				return
 			case <-ticker.C:
-				err := p.store.SetLocked(dbctx, loadUnminedLimit)
+				expiredSince := p.now().Add(-1 * p.mapExpiryTime)
+				err := p.store.SetLocked(dbctx, expiredSince, loadUnminedLimit)
 				if err != nil {
 					p.logger.Error("Failed to set transactions locked", slog.String("err", err.Error()))
 				}

--- a/metamorph/processor_test.go
+++ b/metamorph/processor_test.go
@@ -112,7 +112,7 @@ func TestStartLockTransactions(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			metamorphStore := &mocks.MetamorphStoreMock{
-				SetLockedFunc: func(ctx context.Context, limit int64) error {
+				SetLockedFunc: func(ctx context.Context, since time.Time, limit int64) error {
 					require.Equal(t, int64(5000), limit)
 					return tc.setLockedErr
 				},

--- a/metamorph/store/postgresql/fixtures/metamorph.transactions.yaml
+++ b/metamorph/store/postgresql/fixtures/metamorph.transactions.yaml
@@ -51,6 +51,12 @@
   stored_at: 2023-10-01 14:00:00
   announced_at: 2023-10-01 14:05:00
   inserted_at_num: 2023100114
+- hash: 0x392ea135503bf49f46eb421af01153a2bdcedeba0ee13aa1dd36983861cc5ddd
+  locked_by: NONE
+  status: 6
+  stored_at: 2023-09-01 14:00:00
+  announced_at: 2023-09-01 14:00:00
+  inserted_at_num: 2023090114
 - hash: 0xa8b965b5901163a9bdcd38d2ad524c3bb27ae31fb86dc8947253b541af8dd308
   locked_by: NONE
   status: 9

--- a/metamorph/store/postgresql/postgres.go
+++ b/metamorph/store/postgresql/postgres.go
@@ -445,7 +445,7 @@ func (p *PostgreSQL) UpdateStatusBulk(ctx context.Context, updates []store.Updat
 				AS t(hash, status, reject_reason)
 			) AS bulk_query
 			WHERE
-			metamorph.transactions.hash=bulk_query.hash
+			metamorph.transactions.hash=bulk_query.hash AND metamorph.transactions.locked_by = $4
 		RETURNING metamorph.transactions.stored_at
 		,metamorph.transactions.announced_at
 		,metamorph.transactions.mined_at
@@ -464,7 +464,7 @@ func (p *PostgreSQL) UpdateStatusBulk(ctx context.Context, updates []store.Updat
 		;
     `
 
-	rows, err := p.db.QueryContext(ctx, qBulk, pq.Array(txHashes), pq.Array(statuses), pq.Array(rejectReasons))
+	rows, err := p.db.QueryContext(ctx, qBulk, pq.Array(txHashes), pq.Array(statuses), pq.Array(rejectReasons), p.hostname)
 	if err != nil {
 		return nil, err
 	}

--- a/metamorph/store/postgresql/postgres_test.go
+++ b/metamorph/store/postgresql/postgres_test.go
@@ -362,6 +362,10 @@ func TestPostgresDB(t *testing.T) {
 		err = postgresDB.Set(ctx, testdata.TX6Hash[:], tx6Data)
 		require.NoError(t, err)
 
+		// will not be updated because it is locked by metamorph-3
+		metamorph3Hash, err := chainhash.NewHashFromStr("538808e847d0add40ed9622fff53954c79e1f52db7c47ea0b6cdc0df972f3dcd")
+		require.NoError(t, err)
+
 		updates := []store.UpdateStatus{
 			{
 				Hash:         *testdata.TX1Hash,
@@ -380,6 +384,10 @@ func TestPostgresDB(t *testing.T) {
 			{
 				Hash:   *testdata.TX4Hash, // hash non-existent in db
 				Status: metamorph_api.Status_ANNOUNCED_TO_NETWORK,
+			},
+			{
+				Hash:   *metamorph3Hash,
+				Status: metamorph_api.Status_MINED,
 			},
 		}
 

--- a/metamorph/store/postgresql/postgres_test.go
+++ b/metamorph/store/postgresql/postgres_test.go
@@ -276,7 +276,7 @@ func TestPostgresDB(t *testing.T) {
 
 		require.NoError(t, loadFixtures(postgresDB.db, "fixtures"))
 
-		err := postgresDB.SetLocked(ctx, 2)
+		err := postgresDB.SetLocked(ctx, time.Date(2023, 9, 15, 1, 0, 0, 0, time.UTC), 2)
 		require.NoError(t, err)
 
 		// locked by NONE
@@ -492,7 +492,7 @@ func TestPostgresDB(t *testing.T) {
 
 		res, err := postgresDB.ClearData(ctx, 14)
 		require.NoError(t, err)
-		require.Equal(t, int64(3), res)
+		require.Equal(t, int64(4), res)
 
 		var numberOfRemainingTxs int
 		err = postgresDB.db.QueryRowContext(ctx, "SELECT count(*) FROM metamorph.transactions;").Scan(&numberOfRemainingTxs)

--- a/metamorph/store/store.go
+++ b/metamorph/store/store.go
@@ -38,7 +38,7 @@ type MetamorphStore interface {
 	Del(ctx context.Context, key []byte) error
 
 	SetUnlocked(ctx context.Context, hashes []*chainhash.Hash) error
-	SetLocked(ctx context.Context, limit int64) error
+	SetLocked(ctx context.Context, since time.Time, limit int64) error
 	IncrementRetries(ctx context.Context, hash *chainhash.Hash) error
 	SetUnlockedByName(ctx context.Context, lockedBy string) (int64, error)
 	GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64) ([]*StoreData, error)


### PR DESCRIPTION
As multiple metamorph instances can get the INV message, each of them will attempt to update the tx status to SEEN_ON_NETWORK. That can lead to update deadlocks. Therefore only those records should be update which are locked by it's instance.

- Bulk update only those rows which are locked by that metamorph instance
- Set locked only those which have been inserted since a time stamp