### PR TITLE
change bulk update size, run updates in separate routines to speed up process

### DIFF
--- a/internal/blocktx/store/postgresql/postgres.go
+++ b/internal/blocktx/store/postgresql/postgres.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	postgresDriverName        = "postgres"
-	maxPostgresBulkInsertRows = 1000
+	maxPostgresBulkInsertRows = 8192
 )
 
 var tracer trace.Tracer


### PR DESCRIPTION
As bulk updates don't have intersection in transactions they can be running separately (using db connection pool) to speed up block processing. Also increasing bulk size.