### PR TITLE
Refactor/rm grpc logs

### DIFF
--- a/cmd/arc/services/api.go
+++ b/cmd/arc/services/api.go
@@ -98,7 +98,7 @@ func LoadArcHandler(e *echo.Echo, logger *slog.Logger) error {
 
 	prometheusEndpoint := viper.GetString("prometheusEndpoint")
 
-	conn, err := metamorph.DialGRPC(logger, metamorphAddress, prometheusEndpoint, grpcMessageSize)
+	conn, err := metamorph.DialGRPC(metamorphAddress, prometheusEndpoint, grpcMessageSize)
 	if err != nil {
 		return fmt.Errorf("failed to connect to metamorph server: %v", err)
 	}

--- a/cmd/arc/services/k8s_watcher.go
+++ b/cmd/arc/services/k8s_watcher.go
@@ -29,7 +29,7 @@ func StartK8sWatcher(logger *slog.Logger) (func(), error) {
 
 	prometheusEndpoint := viper.GetString("prometheusEndpoint")
 
-	mtmConn, err := metamorph.DialGRPC(logger, metamorphAddress, prometheusEndpoint, grpcMessageSize)
+	mtmConn, err := metamorph.DialGRPC(metamorphAddress, prometheusEndpoint, grpcMessageSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to metamorph server: %v", err)
 	}
@@ -51,7 +51,7 @@ func StartK8sWatcher(logger *slog.Logger) (func(), error) {
 		return nil, err
 	}
 
-	blocktxConn, err := blocktx.DialGRPC(logger, blocktxAddress, prometheusEndpoint, grpcMessageSize)
+	blocktxConn, err := blocktx.DialGRPC(blocktxAddress, prometheusEndpoint, grpcMessageSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to block-tx server: %v", err)
 	}

--- a/examples/custom/main.go
+++ b/examples/custom/main.go
@@ -70,7 +70,7 @@ func main() {
 
 	grpcMessageSize := viper.GetInt("grpcMessageSize")
 	// add a single metamorph, with the BlockTx client we want to use
-	conn, err := metamorph.DialGRPC(logger, "localhost:8011", "", grpcMessageSize)
+	conn, err := metamorph.DialGRPC("localhost:8011", "", grpcMessageSize)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/blocktx/client.go
+++ b/pkg/blocktx/client.go
@@ -2,11 +2,11 @@ package blocktx
 
 import (
 	"context"
+
 	"github.com/bitcoin-sv/arc/internal/grpc_opts"
 	"github.com/bitcoin-sv/arc/pkg/blocktx/blocktx_api"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"log/slog"
 )
 
 type BlocktxClient interface {
@@ -70,8 +70,8 @@ func (btc *Client) ClearBlockTransactionsMap(ctx context.Context, retentionDays 
 	return resp.Rows, nil
 }
 
-func DialGRPC(logger *slog.Logger, address string, prometheusEndpoint string, grpcMessageSize int) (*grpc.ClientConn, error) {
-	dialOpts, err := grpc_opts.GetGRPCClientOpts(logger, prometheusEndpoint, grpcMessageSize)
+func DialGRPC(address string, prometheusEndpoint string, grpcMessageSize int) (*grpc.ClientConn, error) {
+	dialOpts, err := grpc_opts.GetGRPCClientOpts(prometheusEndpoint, grpcMessageSize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/metamorph/client.go
+++ b/pkg/metamorph/client.go
@@ -3,7 +3,6 @@ package metamorph
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -55,8 +54,8 @@ func NewClient(client metamorph_api.MetaMorphAPIClient) *Metamorph {
 	}
 }
 
-func DialGRPC(logger *slog.Logger, address string, prometheusEndpoint string, grpcMessageSize int) (*grpc.ClientConn, error) {
-	dialOpts, err := grpc_opts.GetGRPCClientOpts(logger, prometheusEndpoint, grpcMessageSize)
+func DialGRPC(address string, prometheusEndpoint string, grpcMessageSize int) (*grpc.ClientConn, error) {
+	dialOpts, err := grpc_opts.GetGRPCClientOpts(prometheusEndpoint, grpcMessageSize)
 	if err != nil {
 		return nil, err
 	}

--- a/test/double_spend_test.go
+++ b/test/double_spend_test.go
@@ -38,9 +38,6 @@ func TestDoubleSpend(t *testing.T) {
 
 			sendToAddress(t, address, 0.001)
 
-			txID := sendToAddress(t, address, 0.02)
-			t.Logf("sent 0.02 BSV to: %s", txID)
-
 			hash := generate(t, 1)
 			t.Logf("generated 1 block: %s", hash)
 

--- a/test/endpoint_test.go
+++ b/test/endpoint_test.go
@@ -137,7 +137,7 @@ func TestBatchChainedTxs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			address, privateKey := getNewWalletAddress(t)
 
-			generate(t, 100)
+			generate(t, 10)
 
 			t.Logf("generated address: %s", address)
 
@@ -277,7 +277,7 @@ func TestPostCallbackToken(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			address, privateKey := getNewWalletAddress(t)
 
-			generate(t, 100)
+			generate(t, 10)
 
 			t.Logf("generated address: %s", address)
 
@@ -479,7 +479,7 @@ func TestPostSkipFee(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			address, privateKey := getNewWalletAddress(t)
 
-			generate(t, 100)
+			generate(t, 10)
 
 			t.Logf("generated address: %s", address)
 
@@ -525,7 +525,7 @@ func TestPostSkipTxValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			address, privateKey := getNewWalletAddress(t)
 
-			generate(t, 100)
+			generate(t, 10)
 
 			t.Logf("generated address: %s", address)
 
@@ -712,7 +712,7 @@ func postTx(t *testing.T, jsonPayload string, headers map[string]string) (*http.
 func createTxHexStringExtended(t *testing.T) *bt.Tx {
 	address, privateKey := getNewWalletAddress(t)
 
-	generate(t, 100)
+	generate(t, 10)
 	t.Logf("generated address: %s", address)
 
 	sendToAddress(t, address, 0.001)


### PR DESCRIPTION
- Remove gRPC logs as they do not add any value
- Reduce time consumption of e2e tests by generating fewer blocks in between tests