### PR TITLE
feat(ARCO-139): submit unmined parent txs in beef with callbacks

### DIFF
--- a/internal/beef/beef.go
+++ b/internal/beef/beef.go
@@ -59,20 +59,20 @@ func CheckBeefFormat(txHex []byte) bool {
 	return true
 }
 
-func DecodeBEEF(beefHex []byte) (*bt.Tx, *BEEF, []byte, error) {
+func DecodeBEEF(beefHex []byte) (*BEEF, []byte, error) {
 	remainingBytes, err := extractBytesWithoutVersionAndMarker(beefHex)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	bumps, remainingBytes, err := decodeBUMPs(remainingBytes)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	transactions, remainingBytes, err := decodeTransactionsWithPathIndexes(remainingBytes)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	decodedBeef := &BEEF{
@@ -80,7 +80,7 @@ func DecodeBEEF(beefHex []byte) (*bt.Tx, *BEEF, []byte, error) {
 		Transactions: transactions,
 	}
 
-	return decodedBeef.GetLatestTx(), decodedBeef, remainingBytes, nil
+	return decodedBeef, remainingBytes, nil
 }
 
 func (d *BEEF) GetLatestTx() *bt.Tx {

--- a/internal/beef/beef_test.go
+++ b/internal/beef/beef_test.go
@@ -111,7 +111,7 @@ func TestDecodeBEEF_DecodeBEEF_HappyPaths(t *testing.T) {
 			require.Nil(t, err)
 
 			// when
-			_, decodedBEEF, _, err := DecodeBEEF(beefHex)
+			decodedBEEF, _, err := DecodeBEEF(beefHex)
 
 			// then
 			assert.Nil(t, err)
@@ -221,7 +221,7 @@ func TestDecodeBEEF_DecodeBEEF_HandlingErrors(t *testing.T) {
 			beefHex, _ := hex.DecodeString(tc.hexStream)
 
 			// when
-			_, result, _, err := DecodeBEEF(beefHex)
+			result, _, err := DecodeBEEF(beefHex)
 
 			// then
 			assert.Equal(t, tc.expectedError, err, "expected error %v, but got %v", tc.expectedError, err)
@@ -283,7 +283,7 @@ func TestDecodeBEEF_InvalidBeef_ReturnError(t *testing.T) {
 			require.Nil(t, err)
 
 			// when
-			_, result, _, err := DecodeBEEF(beefHex)
+			result, _, err := DecodeBEEF(beefHex)
 
 			// then
 			assert.Equal(t, tc.expectedError, err, "expected error %v, but got %v", tc.expectedError, err)

--- a/internal/beef/bump_validation_test.go
+++ b/internal/beef/bump_validation_test.go
@@ -41,10 +41,10 @@ func TestCalculateInputOutputsSatoshis(t *testing.T) {
 			beefHex, err := hex.DecodeString(tc.beefStr)
 			require.NoError(t, err)
 
-			tx, beefTx, _, err := DecodeBEEF(beefHex)
+			beefTx, _, err := DecodeBEEF(beefHex)
 			require.NoError(t, err)
 
-			inputs, outputs, err := CalculateInputsOutputsSatoshis(tx, beefTx.Transactions)
+			inputs, outputs, err := CalculateInputsOutputsSatoshis(beefTx.GetLatestTx(), beefTx.Transactions)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedInputs, inputs)
 			assert.Equal(t, tc.expectedOutputs, outputs)
@@ -80,10 +80,10 @@ func TestValidateScripts(t *testing.T) {
 			beefHex, err := hex.DecodeString(tc.beefStr)
 			require.NoError(t, err)
 
-			tx, beefTx, _, err := DecodeBEEF(beefHex)
+			beefTx, _, err := DecodeBEEF(beefHex)
 			require.NoError(t, err)
 
-			err = ValidateScripts(tx, beefTx.Transactions)
+			err = ValidateScripts(beefTx.GetLatestTx(), beefTx.Transactions)
 			assert.Equal(t, tc.expectedError, err)
 		})
 	}
@@ -121,10 +121,10 @@ func TestEnsureAncestorsArePresentInBump(t *testing.T) {
 		beefHex, err := hex.DecodeString(tc.beefStr)
 		require.NoError(t, err)
 
-		tx, beefTx, _, err := DecodeBEEF(beefHex)
+		beefTx, _, err := DecodeBEEF(beefHex)
 		require.NoError(t, err)
 
-		err = EnsureAncestorsArePresentInBump(tx, beefTx)
+		err = EnsureAncestorsArePresentInBump(beefTx.GetLatestTx(), beefTx)
 		assert.Equal(t, tc.expectedError, err)
 	}
 }

--- a/internal/validator/default/default_validator_test.go
+++ b/internal/validator/default/default_validator_test.go
@@ -173,7 +173,7 @@ func TestBeefValidator(t *testing.T) {
 			beefHex, err := hex.DecodeString(tc.beefStr)
 			require.NoError(t, err)
 
-			_, beef, _, err := beef.DecodeBEEF(beefHex)
+			beef, _, err := beef.DecodeBEEF(beefHex)
 			require.NoError(t, err)
 
 			policy := getPolicy(1)

--- a/pkg/api/handler/default.go
+++ b/pkg/api/handler/default.go
@@ -359,7 +359,7 @@ func (m ArcDefaultHandler) processBEEFTransaction(ctx context.Context, transacti
 		return nil, nil, arcError
 	}
 
-	lastStatus := findLastStatus(beefTx.GetLatestTx().TxID(), txStatuses)
+	lastStatus := findStatusByTxID(beefTx.GetLatestTx().TxID(), txStatuses)
 	if lastStatus == nil {
 		return nil, nil, api.NewErrorFields(api.ErrStatusNotFound, "last tx of BEEF not found in metamorph submit response")
 	}
@@ -441,7 +441,7 @@ func (m ArcDefaultHandler) processTransactions(ctx context.Context, transactions
 		return nil, nil, arcError
 	}
 
-	txStatuses = filterStatusesOfInterest(txIds, txStatuses)
+	txStatuses = filterStatusesByTxIDs(txIds, txStatuses)
 
 	// process returned transaction statuses and return to user
 	transactionsOutputs := make([]interface{}, 0, len(transactions))

--- a/pkg/api/handler/default_test.go
+++ b/pkg/api/handler/default_test.go
@@ -540,6 +540,10 @@ func TestPOSTTransaction(t *testing.T) { //nolint:funlen
 				SubmitTransactionFunc: func(ctx context.Context, tx []byte, options *metamorph.TransactionOptions) (*metamorph.TransactionStatus, error) {
 					return tc.submitTxResponse, tc.submitTxErr
 				},
+
+				SubmitTransactionsFunc: func(ctx context.Context, tx [][]byte, options *metamorph.TransactionOptions) ([]*metamorph.TransactionStatus, error) {
+					return []*metamorph.TransactionStatus{tc.submitTxResponse}, tc.submitTxErr
+				},
 			}
 
 			merkleRootsVerifier := &btxMocks.MerkleRootsVerifierMock{
@@ -845,14 +849,14 @@ func TestPOSTTransactions(t *testing.T) { //nolint:funlen
 	t.Run("multiple formats - success", func(t *testing.T) {
 		txResults := []*metamorph.TransactionStatus{
 			{
-				TxID:        validTxID,
+				TxID:        validBeefTxID,
 				BlockHash:   "",
 				BlockHeight: 0,
 				Status:      "OK",
 				Timestamp:   time.Now().Unix(),
 			},
 			{
-				TxID:        validBeefTxID,
+				TxID:        validTxID,
 				BlockHash:   "",
 				BlockHeight: 0,
 				Status:      "OK",
@@ -878,9 +882,9 @@ func TestPOSTTransactions(t *testing.T) { //nolint:funlen
 		require.NoError(t, err)
 
 		inputTxs := map[string]io.Reader{
-			echo.MIMETextPlain:       strings.NewReader(validTx + "\n" + validBeef + "\n"),
-			echo.MIMEApplicationJSON: strings.NewReader("[{\"rawTx\":\"" + validTx + "\"}, {\"rawTx\":\"" + validBeef + "\"}]"),
-			echo.MIMEOctetStream:     bytes.NewReader(append(validTxBytes, validBeefBytes...)),
+			echo.MIMETextPlain:       strings.NewReader(validBeef + "\n" + validTx + "\n"),
+			echo.MIMEApplicationJSON: strings.NewReader("[{\"rawTx\":\"" + validBeef + "\"}, {\"rawTx\":\"" + validTx + "\"}]"),
+			echo.MIMEOctetStream:     bytes.NewReader(append(validBeefBytes, validTxBytes...)),
 		}
 
 		for contentType, inputTx := range inputTxs {
@@ -893,8 +897,8 @@ func TestPOSTTransactions(t *testing.T) { //nolint:funlen
 			var bResponse []api.TransactionResponse
 			_ = json.Unmarshal(b, &bResponse)
 
-			require.Equal(t, validTxID, bResponse[0].Txid)
-			require.Equal(t, validBeefTxID, bResponse[1].Txid)
+			require.Equal(t, validBeefTxID, bResponse[0].Txid)
+			require.Equal(t, validTxID, bResponse[1].Txid)
 		}
 	})
 }

--- a/pkg/api/handler/helpers.go
+++ b/pkg/api/handler/helpers.go
@@ -123,3 +123,28 @@ func convertMerkleRootsRequest(beefMerkleRoots []beef.MerkleRootVerificationRequ
 
 	return merkleRoots
 }
+
+func findLastStatus(lastTxId string, statuses []*metamorph.TransactionStatus) *metamorph.TransactionStatus {
+	for _, status := range statuses {
+		if status.TxID == lastTxId {
+			return status
+		}
+	}
+	return nil
+}
+
+func filterStatusesOfInterest(txIds []string, allStatuses []*metamorph.TransactionStatus) []*metamorph.TransactionStatus {
+	idsMap := make(map[string]struct{})
+	for _, id := range txIds {
+		idsMap[id] = struct{}{}
+	}
+
+	filteredStatuses := make([]*metamorph.TransactionStatus, 0)
+	for _, txStatus := range allStatuses {
+		if _, ok := idsMap[txStatus.TxID]; ok {
+			filteredStatuses = append(filteredStatuses, txStatus)
+		}
+	}
+
+	return filteredStatuses
+}

--- a/pkg/api/handler/helpers.go
+++ b/pkg/api/handler/helpers.go
@@ -124,18 +124,18 @@ func convertMerkleRootsRequest(beefMerkleRoots []beef.MerkleRootVerificationRequ
 	return merkleRoots
 }
 
-func findStatusByTxID(lastTxId string, statuses []*metamorph.TransactionStatus) *metamorph.TransactionStatus {
+func findStatusByTxID(txID string, statuses []*metamorph.TransactionStatus) *metamorph.TransactionStatus {
 	for _, status := range statuses {
-		if status.TxID == lastTxId {
+		if status.TxID == txID {
 			return status
 		}
 	}
 	return nil
 }
 
-func filterStatusesByTxIDs(txIds []string, allStatuses []*metamorph.TransactionStatus) []*metamorph.TransactionStatus {
+func filterStatusesByTxIDs(txIDs []string, allStatuses []*metamorph.TransactionStatus) []*metamorph.TransactionStatus {
 	idsMap := make(map[string]struct{})
-	for _, id := range txIds {
+	for _, id := range txIDs {
 		idsMap[id] = struct{}{}
 	}
 

--- a/pkg/api/handler/helpers.go
+++ b/pkg/api/handler/helpers.go
@@ -124,7 +124,7 @@ func convertMerkleRootsRequest(beefMerkleRoots []beef.MerkleRootVerificationRequ
 	return merkleRoots
 }
 
-func findLastStatus(lastTxId string, statuses []*metamorph.TransactionStatus) *metamorph.TransactionStatus {
+func findStatusByTxID(lastTxId string, statuses []*metamorph.TransactionStatus) *metamorph.TransactionStatus {
 	for _, status := range statuses {
 		if status.TxID == lastTxId {
 			return status
@@ -133,7 +133,7 @@ func findLastStatus(lastTxId string, statuses []*metamorph.TransactionStatus) *m
 	return nil
 }
 
-func filterStatusesOfInterest(txIds []string, allStatuses []*metamorph.TransactionStatus) []*metamorph.TransactionStatus {
+func filterStatusesByTxIDs(txIds []string, allStatuses []*metamorph.TransactionStatus) []*metamorph.TransactionStatus {
 	idsMap := make(map[string]struct{})
 	for _, id := range txIds {
 		idsMap[id] = struct{}{}

--- a/test/beef_test.go
+++ b/test/beef_test.go
@@ -60,6 +60,8 @@ func TestBeef(t *testing.T) {
 			response, err := arcClient.POSTTransactionWithResponse(context.Background(), params, body)
 
 			// then
+			t.Logf("response txid: %s", *response.JSON465.Txid)
+			t.Logf("response extra info: %s", *response.JSON465.ExtraInfo)
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, response.StatusCode())
 			require.NotNil(t, response.JSON200)
@@ -167,6 +169,7 @@ func prepareBeef(t *testing.T, inputTxID, blockHash, fromAddress, toAddress, pri
 	middleAddress, middlePrivKey := getNewWalletAddress(t)
 	middleTx, err := createTx(privateKey, middleAddress, utxos[0])
 	require.NoError(t, err, "could not create middle tx for beef")
+	t.Logf("middle tx created, hex: %s, txid: %s", middleTx.String(), middleTx.TxID())
 
 	middleUtxo := NodeUnspentUtxo{
 		Txid:         middleTx.TxID(),
@@ -177,7 +180,7 @@ func prepareBeef(t *testing.T, inputTxID, blockHash, fromAddress, toAddress, pri
 
 	tx, err := createTx(middlePrivKey, toAddress, middleUtxo)
 	require.NoError(t, err, "could not create tx")
-	t.Logf("tx created, hex: %s", tx.String())
+	t.Logf("tx created, hex: %s, txid: %s", tx.String(), tx.TxID())
 
 	beef := buildBeefString(t, rawTx.Hex, bump, middleTx, tx)
 	t.Logf("beef created, hex: %s", beef)

--- a/test/beef_test.go
+++ b/test/beef_test.go
@@ -80,10 +80,10 @@ func TestBeef(t *testing.T) {
 			select {
 			case status := <-callbackReceivedChan:
 				if status.Txid == middleTx.TxID() {
-					require.Equal(t, metamorph_api.Status_MINED.String(), status.TxStatus)
+					require.Equal(t, metamorph_api.Status_MINED.String(), *status.TxStatus)
 					middleTxCallbackReceived = true
 				} else if status.Txid == tx.TxID() {
-					require.Equal(t, metamorph_api.Status_MINED.String(), status.TxStatus)
+					require.Equal(t, metamorph_api.Status_MINED.String(), *status.TxStatus)
 					lastTxCallbackReceived = true
 				} else {
 					t.Fatalf("received unknown status for txid: %s", status.Txid)

--- a/test/beef_test.go
+++ b/test/beef_test.go
@@ -74,10 +74,11 @@ func TestBeef(t *testing.T) {
 			require.Equal(t, metamorph_api.Status_MINED.String(), *statusResponse.JSON200.TxStatus)
 
 			// verify callbacks for both unmined txs in BEEF
+			expectedCallbacks := 2
 			lastTxCallbackReceived := false
 			middleTxCallbackReceived := false
 
-			for i := 0; i < 2; i++ {
+			for i := 0; i < expectedCallbacks; i++ {
 				select {
 				case status := <-callbackReceivedChan:
 					if status.Txid == middleTx.TxID() {

--- a/test/beef_test.go
+++ b/test/beef_test.go
@@ -61,7 +61,8 @@ func TestBeef(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			t.Logf("response: %+v", response)
+			t.Logf("response txid: %s", *response.JSON465.Txid)
+			t.Logf("response extra info: %s", *response.JSON465.ExtraInfo)
 			require.Equal(t, http.StatusOK, response.StatusCode())
 			require.NotNil(t, response.JSON200)
 			require.Equal(t, tc.expectedStatus.String(), response.JSON200.TxStatus, "status not SEEN_ON_NETWORK")

--- a/test/beef_test.go
+++ b/test/beef_test.go
@@ -34,7 +34,7 @@ func TestBeef(t *testing.T) {
 			address, privateKey := getNewWalletAddress(t)
 			dstAddress, _ := getNewWalletAddress(t)
 
-			txID := sendToAddress(t, address, 0.001)
+			txID := sendToAddress(t, address, 0.002)
 			hash := generate(t, 1)
 
 			beef, middleTx, tx := prepareBeef(t, txID, hash, address, dstAddress, privateKey)
@@ -61,6 +61,7 @@ func TestBeef(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
+			t.Logf("response: %+v", response)
 			require.Equal(t, http.StatusOK, response.StatusCode())
 			require.NotNil(t, response.JSON200)
 			require.Equal(t, tc.expectedStatus.String(), response.JSON200.TxStatus, "status not SEEN_ON_NETWORK")

--- a/test/beef_test.go
+++ b/test/beef_test.go
@@ -61,8 +61,6 @@ func TestBeef(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			t.Logf("response txid: %s", *response.JSON465.Txid)
-			t.Logf("response extra info: %s", *response.JSON465.ExtraInfo)
 			require.Equal(t, http.StatusOK, response.StatusCode())
 			require.NotNil(t, response.JSON200)
 			require.Equal(t, tc.expectedStatus.String(), response.JSON200.TxStatus, "status not SEEN_ON_NETWORK")

--- a/test/beef_test.go
+++ b/test/beef_test.go
@@ -60,8 +60,6 @@ func TestBeef(t *testing.T) {
 			response, err := arcClient.POSTTransactionWithResponse(context.Background(), params, body)
 
 			// then
-			t.Logf("response txid: %s", *response.JSON465.Txid)
-			t.Logf("response extra info: %s", *response.JSON465.ExtraInfo)
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, response.StatusCode())
 			require.NotNil(t, response.JSON200)
@@ -175,7 +173,7 @@ func prepareBeef(t *testing.T, inputTxID, blockHash, fromAddress, toAddress, pri
 		Txid:         middleTx.TxID(),
 		Vout:         0,
 		ScriptPubKey: middleTx.Outputs[0].LockingScriptHexString(),
-		Amount:       float64(middleTx.Outputs[0].Satoshis),
+		Amount:       float64(middleTx.Outputs[0].Satoshis) / 1e8, // satoshis to BSV
 	}
 
 	tx, err := createTx(middlePrivKey, toAddress, middleUtxo)

--- a/test/utils.go
+++ b/test/utils.go
@@ -177,7 +177,7 @@ func createTx(privateKey string, address string, utxo NodeUnspentUtxo, fee ...ui
 	} else {
 		feeValue = 20 // Set your default fee value here
 	}
-	amountToSend := uint64(utxoSatoshis) - feeValue
+	amountToSend := utxoSatoshis - feeValue
 
 	recipientScript, err := bscript.NewP2PKHFromAddress(recipientAddress)
 	if err != nil {

--- a/test/utils.go
+++ b/test/utils.go
@@ -177,7 +177,7 @@ func createTx(privateKey string, address string, utxo NodeUnspentUtxo, fee ...ui
 	} else {
 		feeValue = 20 // Set your default fee value here
 	}
-	amountToSend := uint64(30) - feeValue // Example value - 0.009 BTC (taking fees into account)
+	amountToSend := uint64(utxoSatoshis) - feeValue
 
 	recipientScript, err := bscript.NewP2PKHFromAddress(recipientAddress)
 	if err != nil {


### PR DESCRIPTION
When sending BEEF to Arc with unmined ancestors of a transaction, ARC will return a status of the last transaction in BEEF, but will submit and register callbacks for all unmined transactions in BEEF.