### PR TITLE
Refactor/bulk set

### DIFF
--- a/internal/metamorph/async/mq_client_integration_test.go
+++ b/internal/metamorph/async/mq_client_integration_test.go
@@ -140,7 +140,7 @@ func TestNatsClient(t *testing.T) {
 		txRequest := &metamorph_api.TransactionRequest{
 			CallbackUrl:   "callback.example.com",
 			CallbackToken: "test-token",
-			RawTx:         testdata.TX1RawBytes,
+			RawTx:         testdata.TX1Raw.Bytes(),
 			WaitForStatus: metamorph_api.Status_ANNOUNCED_TO_NETWORK,
 		}
 

--- a/internal/metamorph/mocks/processor_mock.go
+++ b/internal/metamorph/mocks/processor_mock.go
@@ -4,7 +4,6 @@
 package mocks
 
 import (
-	"context"
 	"github.com/bitcoin-sv/arc/internal/metamorph"
 	"github.com/libsv/go-p2p"
 	"sync"
@@ -32,7 +31,7 @@ var _ metamorph.ProcessorI = &ProcessorIMock{}
 //			HealthFunc: func() error {
 //				panic("mock out the Health method")
 //			},
-//			ProcessTransactionFunc: func(ctx context.Context, req *metamorph.ProcessorRequest)  {
+//			ProcessTransactionFunc: func(req *metamorph.ProcessorRequest)  {
 //				panic("mock out the ProcessTransaction method")
 //			},
 //			ShutdownFunc: func()  {
@@ -58,7 +57,7 @@ type ProcessorIMock struct {
 	HealthFunc func() error
 
 	// ProcessTransactionFunc mocks the ProcessTransaction method.
-	ProcessTransactionFunc func(ctx context.Context, req *metamorph.ProcessorRequest)
+	ProcessTransactionFunc func(req *metamorph.ProcessorRequest)
 
 	// ShutdownFunc mocks the Shutdown method.
 	ShutdownFunc func()
@@ -79,8 +78,6 @@ type ProcessorIMock struct {
 		}
 		// ProcessTransaction holds details about calls to the ProcessTransaction method.
 		ProcessTransaction []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
 			// Req is the req argument value.
 			Req *metamorph.ProcessorRequest
 		}
@@ -205,21 +202,19 @@ func (mock *ProcessorIMock) HealthCalls() []struct {
 }
 
 // ProcessTransaction calls ProcessTransactionFunc.
-func (mock *ProcessorIMock) ProcessTransaction(ctx context.Context, req *metamorph.ProcessorRequest) {
+func (mock *ProcessorIMock) ProcessTransaction(req *metamorph.ProcessorRequest) {
 	if mock.ProcessTransactionFunc == nil {
 		panic("ProcessorIMock.ProcessTransactionFunc: method is nil but ProcessorI.ProcessTransaction was just called")
 	}
 	callInfo := struct {
-		Ctx context.Context
 		Req *metamorph.ProcessorRequest
 	}{
-		Ctx: ctx,
 		Req: req,
 	}
 	mock.lockProcessTransaction.Lock()
 	mock.calls.ProcessTransaction = append(mock.calls.ProcessTransaction, callInfo)
 	mock.lockProcessTransaction.Unlock()
-	mock.ProcessTransactionFunc(ctx, req)
+	mock.ProcessTransactionFunc(req)
 }
 
 // ProcessTransactionCalls gets all the calls that were made to ProcessTransaction.
@@ -227,11 +222,9 @@ func (mock *ProcessorIMock) ProcessTransaction(ctx context.Context, req *metamor
 //
 //	len(mockedProcessorI.ProcessTransactionCalls())
 func (mock *ProcessorIMock) ProcessTransactionCalls() []struct {
-	Ctx context.Context
 	Req *metamorph.ProcessorRequest
 } {
 	var calls []struct {
-		Ctx context.Context
 		Req *metamorph.ProcessorRequest
 	}
 	mock.lockProcessTransaction.RLock()

--- a/internal/metamorph/processor.go
+++ b/internal/metamorph/processor.go
@@ -635,17 +635,6 @@ func (p *Processor) Health() error {
 }
 
 func (p *Processor) storeData(ctx context.Context, data *store.StoreData) error {
-	/*
-		We make last_submitted_at to be now()
-		to make sure it will be loaded and (re-)broadcasted if needed.
-	*/
-
 	data.LastSubmittedAt = p.now()
-
-	err := p.store.Set(ctx, data.Hash[:], data)
-	if err != nil {
-		p.logger.Error("Failed to store transaction", slog.String("hash", data.Hash.String()), slog.String("err", err.Error()))
-	}
-
-	return err
+	return p.store.Set(ctx, data)
 }

--- a/internal/metamorph/processor_options.go
+++ b/internal/metamorph/processor_options.go
@@ -69,6 +69,12 @@ func WithProcessStatusUpdatesInterval(d time.Duration) func(*Processor) {
 	}
 }
 
+func WithBulkProcessInterval(d time.Duration) func(*Processor) {
+	return func(p *Processor) {
+		p.bulkProcessInterval = d
+	}
+}
+
 func WithProcessStatusUpdatesBatchSize(size int) func(*Processor) {
 	return func(p *Processor) {
 		p.processStatusUpdatesBatchSize = size

--- a/internal/metamorph/processor_options.go
+++ b/internal/metamorph/processor_options.go
@@ -69,9 +69,15 @@ func WithProcessStatusUpdatesInterval(d time.Duration) func(*Processor) {
 	}
 }
 
-func WithBulkProcessInterval(d time.Duration) func(*Processor) {
+func WithProcessTransactionsInterval(d time.Duration) func(*Processor) {
 	return func(p *Processor) {
-		p.bulkProcessInterval = d
+		p.processTransactionsInterval = d
+	}
+}
+
+func WithProcessTransactionsBatchSize(batchSize int) func(*Processor) {
+	return func(p *Processor) {
+		p.processTransactionsBatchSize = batchSize
 	}
 }
 

--- a/internal/metamorph/processor_test.go
+++ b/internal/metamorph/processor_test.go
@@ -186,7 +186,7 @@ func TestProcessTransaction(t *testing.T) {
 					return tc.storeData, tc.storeDataGetErr
 				},
 				SetFunc: func(ctx context.Context, value *store.StoreData) error {
-					require.Equal(t, testdata.TX1Hash[:], value.Hash)
+					require.True(t, bytes.Equal(testdata.TX1Hash[:], value.Hash[:]))
 
 					return nil
 				},

--- a/internal/metamorph/processor_test.go
+++ b/internal/metamorph/processor_test.go
@@ -554,7 +554,8 @@ func TestStartProcessSubmittedTxs(t *testing.T) {
 				metamorph.WithMessageQueueClient(publisher),
 				metamorph.WithSubmittedTxsChan(submittedTxsChan),
 				metamorph.WithProcessStatusUpdatesInterval(20*time.Millisecond),
-				metamorph.WithBulkProcessInterval(20*time.Millisecond),
+				metamorph.WithProcessTransactionsInterval(20*time.Millisecond),
+				metamorph.WithProcessTransactionsBatchSize(4),
 			)
 			require.NoError(t, err)
 			require.Equal(t, 0, processor.ProcessorResponseMap.Len())
@@ -592,7 +593,6 @@ func TestStartProcessSubmittedTxs(t *testing.T) {
 			require.Equal(t, tc.expectedSetBulkCalls, len(s.SetBulkCalls()))
 			require.Equal(t, tc.expectedAnnouncedTxCalls, len(pm.AnnounceTransactionCalls()))
 
-			//fmt.Println(testdata.TX6HString)
 		})
 	}
 }

--- a/internal/metamorph/processor_test.go
+++ b/internal/metamorph/processor_test.go
@@ -237,7 +237,7 @@ func TestProcessTransaction(t *testing.T) {
 				}
 			}()
 
-			processor.ProcessTransaction(context.TODO(), &metamorph.ProcessorRequest{
+			processor.ProcessTransaction(&metamorph.ProcessorRequest{
 				Data: &store.StoreData{
 					Hash: testdata.TX1Hash,
 				},

--- a/internal/metamorph/processor_test.go
+++ b/internal/metamorph/processor_test.go
@@ -185,8 +185,8 @@ func TestProcessTransaction(t *testing.T) {
 
 					return tc.storeData, tc.storeDataGetErr
 				},
-				SetFunc: func(ctx context.Context, key []byte, value *store.StoreData) error {
-					require.Equal(t, testdata.TX1Hash[:], key)
+				SetFunc: func(ctx context.Context, value *store.StoreData) error {
+					require.Equal(t, testdata.TX1Hash[:], value.Hash)
 
 					return nil
 				},
@@ -519,8 +519,8 @@ func TestStartProcessSubmittedTxs(t *testing.T) {
 
 					return nil, tc.storeDataGetErr
 				},
-				SetFunc: func(ctx context.Context, key []byte, value *store.StoreData) error {
-					require.Equal(t, testdata.TX1Hash[:], key)
+				SetFunc: func(ctx context.Context, value *store.StoreData) error {
+					require.Equal(t, testdata.TX1Hash[:], value.Hash)
 
 					return nil
 				},

--- a/internal/metamorph/server_test.go
+++ b/internal/metamorph/server_test.go
@@ -61,7 +61,7 @@ func TestPutTransaction(t *testing.T) {
 			RawTx: testdata.TX1RawBytes,
 		}
 
-		processor.ProcessTransactionFunc = func(ctx context.Context, req *metamorph.ProcessorRequest) {
+		processor.ProcessTransactionFunc = func(req *metamorph.ProcessorRequest) {
 			time.Sleep(10 * time.Millisecond)
 
 			req.ResponseChannel <- processor_response.StatusAndError{
@@ -88,7 +88,7 @@ func TestPutTransaction(t *testing.T) {
 			RawTx: testdata.TX1RawBytes,
 		}
 
-		processor.ProcessTransactionFunc = func(ctx context.Context, req *metamorph.ProcessorRequest) {
+		processor.ProcessTransactionFunc = func(req *metamorph.ProcessorRequest) {
 			time.Sleep(10 * time.Millisecond)
 			req.ResponseChannel <- processor_response.StatusAndError{
 				Hash:   testdata.TX1Hash,
@@ -113,7 +113,7 @@ func TestPutTransaction(t *testing.T) {
 			RawTx:         testdata.TX1RawBytes,
 			WaitForStatus: metamorph_api.Status_SENT_TO_NETWORK,
 		}
-		processor.ProcessTransactionFunc = func(ctx context.Context, req *metamorph.ProcessorRequest) {
+		processor.ProcessTransactionFunc = func(req *metamorph.ProcessorRequest) {
 			time.Sleep(10 * time.Millisecond)
 			req.ResponseChannel <- processor_response.StatusAndError{
 				Hash:   testdata.TX1Hash,
@@ -463,7 +463,7 @@ func TestPutTransactions(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			processor := &mocks.ProcessorIMock{
-				ProcessTransactionFunc: func(_ context.Context, req *metamorph.ProcessorRequest) {
+				ProcessTransactionFunc: func(req *metamorph.ProcessorRequest) {
 					resp, found := tc.processorResponse[req.Data.Hash.String()]
 					if found {
 						req.ResponseChannel <- *resp

--- a/internal/metamorph/server_test.go
+++ b/internal/metamorph/server_test.go
@@ -58,7 +58,7 @@ func TestPutTransaction(t *testing.T) {
 
 		var txStatus *metamorph_api.TransactionStatus
 		txRequest := &metamorph_api.TransactionRequest{
-			RawTx: testdata.TX1RawBytes,
+			RawTx: testdata.TX1Raw.Bytes(),
 		}
 
 		processor.ProcessTransactionFunc = func(req *metamorph.ProcessorRequest) {
@@ -85,7 +85,7 @@ func TestPutTransaction(t *testing.T) {
 
 		var txStatus *metamorph_api.TransactionStatus
 		txRequest := &metamorph_api.TransactionRequest{
-			RawTx: testdata.TX1RawBytes,
+			RawTx: testdata.TX1Raw.Bytes(),
 		}
 
 		processor.ProcessTransactionFunc = func(req *metamorph.ProcessorRequest) {
@@ -110,7 +110,7 @@ func TestPutTransaction(t *testing.T) {
 
 		var txStatus *metamorph_api.TransactionStatus
 		txRequest := &metamorph_api.TransactionRequest{
-			RawTx:         testdata.TX1RawBytes,
+			RawTx:         testdata.TX1Raw.Bytes(),
 			WaitForStatus: metamorph_api.Status_SENT_TO_NETWORK,
 		}
 		processor.ProcessTransactionFunc = func(req *metamorph.ProcessorRequest) {
@@ -171,7 +171,7 @@ func TestServer_GetTransactionStatus(t *testing.T) {
 		{
 			name: "GetTransactionStatus - test.TX1",
 			req: &metamorph_api.TransactionStatusRequest{
-				Txid: testdata.TX1,
+				Txid: testdata.TX1Hash.String(),
 			},
 			status:     metamorph_api.Status_SENT_TO_NETWORK,
 			merklePath: "00000",
@@ -180,7 +180,7 @@ func TestServer_GetTransactionStatus(t *testing.T) {
 				StoredAt:    timestamppb.New(testdata.Time),
 				AnnouncedAt: timestamppb.New(testdata.Time.Add(1 * time.Second)),
 				MinedAt:     timestamppb.New(testdata.Time.Add(2 * time.Second)),
-				Txid:        testdata.TX1,
+				Txid:        testdata.TX1Hash.String(),
 				Status:      metamorph_api.Status_SENT_TO_NETWORK,
 				MerklePath:  "00000",
 			},
@@ -189,7 +189,7 @@ func TestServer_GetTransactionStatus(t *testing.T) {
 		{
 			name: "GetTransactionStatus - test.TX1 - error",
 			req: &metamorph_api.TransactionStatusRequest{
-				Txid: testdata.TX1,
+				Txid: testdata.TX1Hash.String(),
 			},
 			status:             metamorph_api.Status_SENT_TO_NETWORK,
 			getTxMerklePathErr: errors.New("failed to get tx merkle path"),
@@ -198,7 +198,7 @@ func TestServer_GetTransactionStatus(t *testing.T) {
 				StoredAt:    timestamppb.New(testdata.Time),
 				AnnouncedAt: timestamppb.New(testdata.Time.Add(1 * time.Second)),
 				MinedAt:     timestamppb.New(testdata.Time.Add(2 * time.Second)),
-				Txid:        testdata.TX1,
+				Txid:        testdata.TX1Hash.String(),
 				Status:      metamorph_api.Status_SENT_TO_NETWORK,
 				MerklePath:  "00000",
 			},
@@ -207,7 +207,7 @@ func TestServer_GetTransactionStatus(t *testing.T) {
 		{
 			name: "GetTransactionStatus - test.TX1 - tx not found for Merkle path",
 			req: &metamorph_api.TransactionStatusRequest{
-				Txid: testdata.TX1,
+				Txid: testdata.TX1Hash.String(),
 			},
 			status:             metamorph_api.Status_MINED,
 			getTxMerklePathErr: blocktx.ErrMerklePathNotFoundForTransaction,
@@ -216,7 +216,7 @@ func TestServer_GetTransactionStatus(t *testing.T) {
 				StoredAt:    timestamppb.New(testdata.Time),
 				AnnouncedAt: timestamppb.New(testdata.Time.Add(1 * time.Second)),
 				MinedAt:     timestamppb.New(testdata.Time.Add(2 * time.Second)),
-				Txid:        testdata.TX1,
+				Txid:        testdata.TX1Hash.String(),
 				Status:      metamorph_api.Status_MINED,
 				MerklePath:  "00000",
 			},

--- a/internal/metamorph/store/postgresql/fixtures/set_bulk/metamorph.transactions.yaml
+++ b/internal/metamorph/store/postgresql/fixtures/set_bulk/metamorph.transactions.yaml
@@ -1,0 +1,5 @@
+- hash: 0xcd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853
+  locked_by: metamorph-3
+  status: 6
+  stored_at: 2023-10-01 14:00:00
+  last_submitted_at: 2023-10-01 14:00:00

--- a/internal/metamorph/store/postgresql/postgres_test.go
+++ b/internal/metamorph/store/postgresql/postgres_test.go
@@ -212,7 +212,7 @@ func TestPostgresDB(t *testing.T) {
 		defer require.NoError(t, pruneTables(postgresDB.db))
 
 		mined := *minedData
-		err = postgresDB.Set(ctx, minedHash[:], &mined)
+		err = postgresDB.Set(ctx, &mined)
 		require.NoError(t, err)
 
 		dataReturned, err := postgresDB.Get(ctx, minedHash[:])
@@ -220,7 +220,7 @@ func TestPostgresDB(t *testing.T) {
 		require.Equal(t, dataReturned, &mined)
 
 		mined.LastSubmittedAt = time.Date(2024, 5, 31, 15, 16, 0, 0, time.UTC)
-		err = postgresDB.Set(ctx, minedHash[:], &mined)
+		err = postgresDB.Set(ctx, &mined)
 		require.NoError(t, err)
 
 		dataReturned2, err := postgresDB.Get(ctx, minedHash[:])
@@ -235,6 +235,67 @@ func TestPostgresDB(t *testing.T) {
 
 		_, err = postgresDB.Get(ctx, []byte("not to be found"))
 		require.True(t, errors.Is(err, store.ErrNotFound))
+	})
+
+	t.Run("set bulk", func(t *testing.T) {
+		defer require.NoError(t, pruneTables(postgresDB.db))
+
+		require.NoError(t, loadFixtures(postgresDB.db, "fixtures/set_bulk"))
+
+		hash2 := revChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853") // hash already existing in db - no update expected
+
+		data := []*store.StoreData{
+			{
+				RawTx:             testdata.TX1RawBytes,
+				StoredAt:          now,
+				Hash:              testdata.TX1Hash,
+				Status:            metamorph_api.Status_STORED,
+				CallbackUrl:       "callback.example.com",
+				FullStatusUpdates: false,
+				CallbackToken:     "1234",
+				LastSubmittedAt:   now,
+				LockedBy:          "metamorph-1",
+			},
+			{
+				RawTx:             testdata.TX6RawBytes,
+				StoredAt:          now,
+				Hash:              testdata.TX6Hash,
+				Status:            metamorph_api.Status_STORED,
+				CallbackUrl:       "callback-2.example.com",
+				FullStatusUpdates: true,
+				CallbackToken:     "5678",
+				LastSubmittedAt:   now,
+				LockedBy:          "metamorph-1",
+			},
+			{
+				RawTx:             testdata.TX6RawBytes,
+				StoredAt:          now,
+				Hash:              hash2,
+				Status:            metamorph_api.Status_STORED,
+				CallbackUrl:       "callback-3.example.com",
+				FullStatusUpdates: true,
+				CallbackToken:     "5678",
+				LastSubmittedAt:   now,
+				LockedBy:          "metamorph-1",
+			},
+		}
+
+		err = postgresDB.SetBulk(ctx, data)
+		require.NoError(t, err)
+
+		data0, err := postgresDB.Get(ctx, testdata.TX1Hash[:])
+		require.NoError(t, err)
+		require.Equal(t, data[0], data0)
+
+		data1, err := postgresDB.Get(ctx, testdata.TX6Hash[:])
+		require.NoError(t, err)
+		require.Equal(t, data[1], data1)
+
+		data2, err := postgresDB.Get(ctx, hash2[:])
+		require.NoError(t, err)
+		require.NotEqual(t, data[2], data2)
+		require.Equal(t, metamorph_api.Status_SENT_TO_NETWORK, data2.Status)
+		require.Equal(t, "metamorph-3", data2.LockedBy)
 	})
 
 	t.Run("get unmined", func(t *testing.T) {
@@ -381,7 +442,7 @@ func TestPostgresDB(t *testing.T) {
 		require.NoError(t, loadFixtures(postgresDB.db, "fixtures"))
 
 		unmined := *unminedData
-		err = postgresDB.Set(ctx, unminedHash[:], &unmined)
+		err = postgresDB.Set(ctx, &unmined)
 		require.NoError(t, err)
 
 		chainHash2 := revChainhash(t, "ee76f5b746893d3e6ae6a14a15e464704f4ebd601537820933789740acdcf6aa")
@@ -442,7 +503,7 @@ func TestPostgresDB(t *testing.T) {
 		defer require.NoError(t, pruneTables(postgresDB.db))
 
 		unmined := *unminedData
-		err = postgresDB.Set(ctx, unminedHash[:], &unmined)
+		err = postgresDB.Set(ctx, &unmined)
 		require.NoError(t, err)
 		txBlocks := &blocktx_api.TransactionBlocks{TransactionBlocks: []*blocktx_api.TransactionBlock{{
 			BlockHash:       nil,

--- a/internal/metamorph/store/postgresql/postgres_test.go
+++ b/internal/metamorph/store/postgresql/postgres_test.go
@@ -246,7 +246,7 @@ func TestPostgresDB(t *testing.T) {
 
 		data := []*store.StoreData{
 			{
-				RawTx:             testdata.TX1RawBytes,
+				RawTx:             testdata.TX1Raw.Bytes(),
 				StoredAt:          now,
 				Hash:              testdata.TX1Hash,
 				Status:            metamorph_api.Status_STORED,
@@ -257,7 +257,7 @@ func TestPostgresDB(t *testing.T) {
 				LockedBy:          "metamorph-1",
 			},
 			{
-				RawTx:             testdata.TX6RawBytes,
+				RawTx:             testdata.TX6Raw.Bytes(),
 				StoredAt:          now,
 				Hash:              testdata.TX6Hash,
 				Status:            metamorph_api.Status_STORED,
@@ -268,7 +268,7 @@ func TestPostgresDB(t *testing.T) {
 				LockedBy:          "metamorph-1",
 			},
 			{
-				RawTx:             testdata.TX6RawBytes,
+				RawTx:             testdata.TX6Raw.Bytes(),
 				StoredAt:          now,
 				Hash:              hash2,
 				Status:            metamorph_api.Status_STORED,

--- a/internal/metamorph/store/store.go
+++ b/internal/metamorph/store/store.go
@@ -50,7 +50,8 @@ type Stats struct {
 
 type MetamorphStore interface {
 	Get(ctx context.Context, key []byte) (*StoreData, error)
-	Set(ctx context.Context, key []byte, value *StoreData) error
+	Set(ctx context.Context, value *StoreData) error
+	SetBulk(ctx context.Context, data []*StoreData) error
 	Del(ctx context.Context, key []byte) error
 
 	SetLocked(ctx context.Context, since time.Time, limit int64) error

--- a/internal/testdata/data.go
+++ b/internal/testdata/data.go
@@ -1,9 +1,9 @@
 package testdata
 
 import (
-	"encoding/hex"
 	"time"
 
+	"github.com/libsv/go-bt/v2"
 	"github.com/libsv/go-p2p/chaincfg/chainhash"
 )
 
@@ -13,10 +13,9 @@ var (
 	Block2        = "000000000000020441ac25b0a9a1339ed75ff183a2500508eb8a5e035aeaca39"
 	Block2Hash, _ = chainhash.NewHashFromStr(Block2)
 
-	TX1            = "b042f298deabcebbf15355aa3a13c7d7cfe96c44ac4f492735f936f8e50d06f6"
-	TX1Hash, _     = chainhash.NewHashFromStr(TX1)
-	TX1Raw         = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1a0386c40b2f7461616c2e636f6d2f00cf47ad9c7af83836000000ffffffff0117564425000000001976a914522cf9e7626d9bd8729e5a1398ece40dad1b6a2f88ac00000000"
-	TX1RawBytes, _ = hex.DecodeString(TX1Raw)
+	TX1RawString = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1a0386c40b2f7461616c2e636f6d2f00cf47ad9c7af83836000000ffffffff0117564425000000001976a914522cf9e7626d9bd8729e5a1398ece40dad1b6a2f88ac00000000"
+	TX1Raw, _    = bt.NewTxFromString(TX1RawString)
+	TX1Hash, _   = chainhash.NewHashFromStr(TX1Raw.TxID())
 
 	TX2        = "1a8fda8c35b8fc30885e88d6eb0214e2b3a74c96c82c386cb463905446011fdf"
 	TX2Hash, _ = chainhash.NewHashFromStr(TX2)
@@ -30,10 +29,9 @@ var (
 	TX5        = "df931ab7d4ff0bbf96ff186f221c466f09c052c5331733641040defabf9dcd93"
 	TX5Hash, _ = chainhash.NewHashFromStr(TX5)
 
-	TX6            = "fbb5444147cf9fa5c4208ca56e1e2ca061da0153ea72a3fb16993865ba601106"
-	TX6Hash, _     = chainhash.NewHashFromStr(TX6)
-	TX6raw         = "010000000000000000ef016f8828b2d3f8085561d0b4ff6f5d17c269206fa3d32bcd3b22e26ce659ed12e7000000006b483045022100d3649d120249a09af44b4673eecec873109a3e120b9610b78858087fb225c9b9022037f16999b7a4fecdd9f47ebdc44abd74567a18940c37e1481ab0fe84d62152e4412102f87ce69f6ba5444aed49c34470041189c1e1060acd99341959c0594002c61bf0ffffffffe7030000000000001976a914c2b6fd4319122b9b5156a2a0060d19864c24f49a88ac01e7030000000000001976a914c2b6fd4319122b9b5156a2a0060d19864c24f49a88ac00000000"
-	TX6RawBytes, _ = hex.DecodeString(TX6raw)
+	TX6RawString = "010000000000000000ef016f8828b2d3f8085561d0b4ff6f5d17c269206fa3d32bcd3b22e26ce659ed12e7000000006b483045022100d3649d120249a09af44b4673eecec873109a3e120b9610b78858087fb225c9b9022037f16999b7a4fecdd9f47ebdc44abd74567a18940c37e1481ab0fe84d62152e4412102f87ce69f6ba5444aed49c34470041189c1e1060acd99341959c0594002c61bf0ffffffffe7030000000000001976a914c2b6fd4319122b9b5156a2a0060d19864c24f49a88ac01e7030000000000001976a914c2b6fd4319122b9b5156a2a0060d19864c24f49a88ac00000000"
+	TX6Raw, _    = bt.NewTxFromString(TX6RawString)
+	TX6Hash, _   = chainhash.NewHashFromStr(TX6Raw.TxID())
 
 	Time          = time.Date(2009, 1, 03, 18, 15, 05, 0, time.UTC)
 	DefaultPolicy = `{"excessiveblocksize":2000000000,"blockmaxsize":512000000,"maxtxsizepolicy":10000000,"maxorphantxsize":1000000000,"datacarriersize":4294967295,"maxscriptsizepolicy":500000,"maxopsperscriptpolicy":4294967295,"maxscriptnumlengthpolicy":10000,"maxpubkeyspermultisigpolicy":4294967295,"maxtxsigopscountspolicy":4294967295,"maxstackmemoryusagepolicy":100000000,"maxstackmemoryusageconsensus":200000000,"limitancestorcount":10000,"limitcpfpgroupmemberscount":25,"maxmempool":2000000000,"maxmempoolsizedisk":0,"mempoolmaxpercentcpfp":10,"acceptnonstdoutputs":true,"datacarrier":true,"minminingtxfee":5e-7,"maxstdtxvalidationduration":3,"maxnonstdtxvalidationduration":1000,"maxtxchainvalidationbudget":50,"validationclockcpu":true,"minconsolidationfactor":20,"maxconsolidationinputscriptsize":150,"minconfconsolidationinput":6,"minconsolidationinputmaturity":6,"acceptnonstdconsolidationinput":false}`

--- a/pkg/metamorph/async/mq_client_integration_test.go
+++ b/pkg/metamorph/async/mq_client_integration_test.go
@@ -102,7 +102,7 @@ func TestNatsClient(t *testing.T) {
 		txRequest := &metamorph_api.TransactionRequest{
 			CallbackUrl:   "callback.example.com",
 			CallbackToken: "test-token",
-			RawTx:         testdata.TX1RawBytes,
+			RawTx:         testdata.TX1Raw.Bytes(),
 			WaitForStatus: metamorph_api.Status_ANNOUNCED_TO_NETWORK,
 		}
 		txRequests := &metamorph_api.TransactionRequests{Transactions: []*metamorph_api.TransactionRequest{txRequest, txRequest, txRequest, txRequest}}

--- a/pkg/metamorph/client_test.go
+++ b/pkg/metamorph/client_test.go
@@ -75,12 +75,12 @@ func TestClient_SubmitTransaction(t *testing.T) {
 				WaitForStatus: metamorph_api.Status_RECEIVED,
 			},
 			putTxStatus: &metamorph_api.TransactionStatus{
-				Txid:   testdata.TX1,
+				Txid:   testdata.TX1Hash.String(),
 				Status: metamorph_api.Status_RECEIVED,
 			},
 
 			expectedStatus: &metamorph.TransactionStatus{
-				TxID:      testdata.TX1,
+				TxID:      testdata.TX1Hash.String(),
 				Status:    metamorph_api.Status_RECEIVED.String(),
 				Timestamp: now.Unix(),
 			},
@@ -91,7 +91,7 @@ func TestClient_SubmitTransaction(t *testing.T) {
 				WaitForStatus: metamorph_api.Status_RECEIVED,
 			},
 			putTxStatus: &metamorph_api.TransactionStatus{
-				Txid:   testdata.TX1,
+				Txid:   testdata.TX1Hash.String(),
 				Status: metamorph_api.Status_RECEIVED,
 			},
 			putTxErr:     errors.New("failed to put tx"),
@@ -106,14 +106,14 @@ func TestClient_SubmitTransaction(t *testing.T) {
 				WaitForStatus: metamorph_api.Status_RECEIVED,
 			},
 			putTxStatus: &metamorph_api.TransactionStatus{
-				Txid:   testdata.TX1,
+				Txid:   testdata.TX1Hash.String(),
 				Status: metamorph_api.Status_RECEIVED,
 			},
 			putTxErr:     errors.New("failed to put tx"),
 			withMqClient: true,
 
 			expectedStatus: &metamorph.TransactionStatus{
-				TxID:      testdata.TX1,
+				TxID:      testdata.TX1Hash.String(),
 				Status:    metamorph_api.Status_QUEUED.String(),
 				Timestamp: now.Unix(),
 			},
@@ -124,7 +124,7 @@ func TestClient_SubmitTransaction(t *testing.T) {
 				WaitForStatus: metamorph_api.Status_RECEIVED,
 			},
 			putTxStatus: &metamorph_api.TransactionStatus{
-				Txid:   testdata.TX1,
+				Txid:   testdata.TX1Hash.String(),
 				Status: metamorph_api.Status_RECEIVED,
 			},
 			putTxErr:           errors.New("failed to put tx"),
@@ -142,7 +142,7 @@ func TestClient_SubmitTransaction(t *testing.T) {
 			withMqClient: true,
 
 			expectedStatus: &metamorph.TransactionStatus{
-				TxID:      testdata.TX1,
+				TxID:      testdata.TX1Hash.String(),
 				Status:    metamorph_api.Status_QUEUED.String(),
 				Timestamp: now.Unix(),
 			},
@@ -176,7 +176,7 @@ func TestClient_SubmitTransaction(t *testing.T) {
 
 			client := metamorph.NewClient(apiClient, opts...)
 
-			tx, err := bt.NewTxFromString(testdata.TX1Raw)
+			tx, err := bt.NewTxFromString(testdata.TX1RawString)
 			require.NoError(t, err)
 			status, err := client.SubmitTransaction(context.Background(), tx, tc.options)
 

--- a/test/endpoint_test.go
+++ b/test/endpoint_test.go
@@ -477,7 +477,7 @@ func TestPostTx_Queued(t *testing.T) {
 				statusResponse, err := arcClient.GETTransactionStatusWithResponse(ctx, tx.TxID())
 				require.NoError(t, err)
 
-				if metamorph_api.Status_SEEN_ON_NETWORK.String() == *statusResponse.JSON200.TxStatus {
+				if statusResponse != nil && statusResponse.JSON200 != nil && statusResponse.JSON200.TxStatus != nil && metamorph_api.Status_SEEN_ON_NETWORK.String() == *statusResponse.JSON200.TxStatus {
 					break checkSeenLoop
 				}
 			case <-time.NewTimer(10 * time.Second).C:
@@ -494,7 +494,7 @@ func TestPostTx_Queued(t *testing.T) {
 				statusResponse, err := arcClient.GETTransactionStatusWithResponse(ctx, tx.TxID())
 				require.NoError(t, err)
 
-				if metamorph_api.Status_MINED.String() == *statusResponse.JSON200.TxStatus {
+				if statusResponse != nil && statusResponse.JSON200 != nil && statusResponse.JSON200.TxStatus != nil && metamorph_api.Status_MINED.String() == *statusResponse.JSON200.TxStatus {
 					break checkMinedLoop
 				}
 			case <-time.NewTimer(15 * time.Second).C:


### PR DESCRIPTION
- Do not pass context to processor => timeout doesn't stop storing of txs
- Set bulk db function
- Process txs submitted through message queue in batches