### PR TITLE
ARCO-155: (PART 2) unify POST transaction(s) endpoints logic

### DIFF
--- a/pkg/api/handler/default_test.go
+++ b/pkg/api/handler/default_test.go
@@ -41,6 +41,8 @@ var (
 	validTxBytes, _           = hex.DecodeString(validTx)
 	validExtendedTx           = "010000000000000000ef01358eb38f1f910e76b33788ff9395a5d2af87721e950ebd3d60cf64bb43e77485010000006a47304402203be8a3ba74e7b770afa2addeff1bbc1eaeb0cedf6b4096c8eb7ec29f1278752602205dc1d1bedf2cab46096bb328463980679d4ce2126cdd6ed191d6224add9910884121021358f252895263cd7a85009fcc615b57393daf6f976662319f7d0c640e6189fcffffffffc70a0000000000001976a914f1e6837cf17b485a1dcea9e943948fafbe5e9f6888ac02bf010000000000001976a91449f066fccf8d392ff6a0a33bc766c9f3436c038a88acfc080000000000001976a914a7dcbd14f83c564e0025a57f79b0b8b591331ae288ac00000000"
 	validTxID                 = "a147cc3c71cc13b29f18273cf50ffeb59fc9758152e2b33e21a8092f0b049118"
+	validTxParentHex          = "0100000001fbbe01d83cb1f53a63ef91c0fce5750cbd8075efef5acd2ff229506a45ab832c010000006a473044022064be2f304950a87782b44e772390836aa613f40312a0df4993e9c5123d0c492d02202009b084b66a3da939fb7dc5d356043986539cac4071372d0a6481d5b5e418ca412103fc12a81e5213e30c7facc15581ac1acbf26a8612a3590ffb48045084b097d52cffffffff02bf010000000000001976a914c2ca67db517c0c972b9a6eb1181880ed3a528e3188acc70a0000000000001976a914f1e6837cf17b485a1dcea9e943948fafbe5e9f6888ac00000000"
+	validTxParentBytes, _     = hex.DecodeString(validTxParentHex)
 	validBeef                 = "0100beef01fe636d0c0007021400fe507c0c7aa754cef1f7889d5fd395cf1f785dd7de98eed895dbedfe4e5bc70d1502ac4e164f5bc16746bb0868404292ac8318bbac3800e4aad13a014da427adce3e010b00bc4ff395efd11719b277694cface5aa50d085a0bb81f613f70313acd28cf4557010400574b2d9142b8d28b61d88e3b2c3f44d858411356b49a28a4643b6d1a6a092a5201030051a05fc84d531b5d250c23f4f886f6812f9fe3f402d61607f977b4ecd2701c19010000fd781529d58fc2523cf396a7f25440b409857e7e221766c57214b1d38c7b481f01010062f542f45ea3660f86c013ced80534cb5fd4c19d66c56e7e8c5d4bf2d40acc5e010100b121e91836fd7cd5102b654e9f72f3cf6fdbfd0b161c53a9c54b12c841126331020100000001cd4e4cac3c7b56920d1e7655e7e260d31f29d9a388d04910f1bbd72304a79029010000006b483045022100e75279a205a547c445719420aa3138bf14743e3f42618e5f86a19bde14bb95f7022064777d34776b05d816daf1699493fcdf2ef5a5ab1ad710d9c97bfb5b8f7cef3641210263e2dee22b1ddc5e11f6fab8bcd2378bdd19580d640501ea956ec0e786f93e76ffffffff013e660000000000001976a9146bfd5c7fbe21529d45803dbcf0c87dd3c71efbc288ac0000000001000100000001ac4e164f5bc16746bb0868404292ac8318bbac3800e4aad13a014da427adce3e000000006a47304402203a61a2e931612b4bda08d541cfb980885173b8dcf64a3471238ae7abcd368d6402204cbf24f04b9aa2256d8901f0ed97866603d2be8324c2bfb7a37bf8fc90edd5b441210263e2dee22b1ddc5e11f6fab8bcd2378bdd19580d640501ea956ec0e786f93e76ffffffff013c660000000000001976a9146bfd5c7fbe21529d45803dbcf0c87dd3c71efbc288ac0000000000"
 	validBeefBytes, _         = hex.DecodeString(validBeef)
 	validBeefTxID             = "157428aee67d11123203735e4c540fa1bdab3b36d5882c6f8c5ff79f07d20d1c"
@@ -311,7 +313,7 @@ func TestPOSTTransaction(t *testing.T) { //nolint:funlen
 			expectedResponse: *api.NewErrorFields(api.ErrStatusBadRequest, "error parsing transaction from request: no transaction found - empty request body"),
 		},
 		{
-			name:        "invalid tx - application/json",
+			name:        "invalid tx - empty payload, application/json",
 			contentType: contentTypes[1],
 
 			expectedStatus:   400,
@@ -349,15 +351,15 @@ func TestPOSTTransaction(t *testing.T) { //nolint:funlen
 			expectedResponse: *api.NewErrorFields(api.ErrStatusBadRequest, "error parsing transaction from request: invalid character 'e' in literal true (expecting 'r')"),
 		},
 		{
-			name:        "invalid tx - application/json",
+			name:        "invalid tx - incorrect json field, application/json",
 			contentType: contentTypes[1],
 			txHexString: fmt.Sprintf("{\"txHex\": \"%s\"}", validTx),
 
 			expectedStatus:   400,
-			expectedResponse: *api.NewErrorFields(api.ErrStatusBadRequest, "EOF"),
+			expectedResponse: *api.NewErrorFields(api.ErrStatusBadRequest, "error parsing transaction from request: no transaction found - empty request body"),
 		},
 		{
-			name:        "invalid tx - application/octet-stream",
+			name:        "invalid tx - invalid hex, application/octet-stream",
 			contentType: contentTypes[2],
 			txHexString: "test",
 
@@ -732,6 +734,9 @@ func TestPOSTTransactions(t *testing.T) { //nolint:funlen
 		}
 		// set the node/metamorph responses for the 3 test requests
 		txHandler := &mtmMocks.TransactionHandlerMock{
+			SubmitTransactionFunc: func(ctx context.Context, tx *bt.Tx, options *metamorph.TransactionOptions) (*metamorph.TransactionStatus, error) {
+				return txResult, nil
+			},
 			SubmitTransactionsFunc: func(ctx context.Context, tx []*bt.Tx, options *metamorph.TransactionOptions) ([]*metamorph.TransactionStatus, error) {
 				txStatuses := []*metamorph.TransactionStatus{txResult}
 				return txStatuses, nil
@@ -770,10 +775,6 @@ func TestPOSTTransactions(t *testing.T) { //nolint:funlen
 		errBEEFDecode := *api.NewErrorFields(api.ErrStatusMalformed, "error decoding BEEF: invalid BEEF - HasBUMP flag set, but no BUMP index")
 		// set the node/metamorph responses for the 3 test requests
 		txHandler := &mtmMocks.TransactionHandlerMock{
-			SubmitTransactionsFunc: func(ctx context.Context, tx []*bt.Tx, options *metamorph.TransactionOptions) ([]*metamorph.TransactionStatus, error) {
-				return nil, nil
-			},
-
 			HealthFunc: func(ctx context.Context) error {
 				return nil
 			},
@@ -813,6 +814,9 @@ func TestPOSTTransactions(t *testing.T) { //nolint:funlen
 		}
 		// set the node/metamorph responses for the 3 test requests
 		txHandler := &mtmMocks.TransactionHandlerMock{
+			SubmitTransactionFunc: func(ctx context.Context, tx *bt.Tx, options *metamorph.TransactionOptions) (*metamorph.TransactionStatus, error) {
+				return txResult, nil
+			},
 			SubmitTransactionsFunc: func(ctx context.Context, tx []*bt.Tx, options *metamorph.TransactionOptions) ([]*metamorph.TransactionStatus, error) {
 				txStatuses := []*metamorph.TransactionStatus{txResult}
 				return txStatuses, nil
@@ -823,7 +827,13 @@ func TestPOSTTransactions(t *testing.T) { //nolint:funlen
 			},
 		}
 
-		defaultHandler, err := NewDefault(testLogger, txHandler, nil, defaultPolicy, nil, nil)
+		merkleRootsVerifier := &btxMocks.MerkleRootsVerifierMock{
+			VerifyMerkleRootsFunc: func(ctx context.Context, merkleRootVerificationRequest []blocktx.MerkleRootVerificationRequest) ([]uint64, error) {
+				return nil, nil
+			},
+		}
+
+		defaultHandler, err := NewDefault(testLogger, txHandler, merkleRootsVerifier, defaultPolicy, nil, nil)
 		require.NoError(t, err)
 
 		inputTxs := map[string]io.Reader{
@@ -866,11 +876,19 @@ func TestPOSTTransactions(t *testing.T) { //nolint:funlen
 		// set the node/metamorph responses for the 3 test requests
 		txHandler := &mtmMocks.TransactionHandlerMock{
 			GetTransactionFunc: func(ctx context.Context, txID string) ([]byte, error) {
-				return inputTxLowFeesBytes, nil
+				return validTxParentBytes, nil
 			},
 
-			SubmitTransactionsFunc: func(ctx context.Context, tx []*bt.Tx, options *metamorph.TransactionOptions) ([]*metamorph.TransactionStatus, error) {
-				return txResults, nil
+			SubmitTransactionsFunc: func(ctx context.Context, txs []*bt.Tx, options *metamorph.TransactionOptions) ([]*metamorph.TransactionStatus, error) {
+				var res []*metamorph.TransactionStatus
+				for _, t := range txs {
+					txID := t.TxID()
+					if status, found := find(txResults, func(e *metamorph.TransactionStatus) bool { return e.TxID == txID }); found {
+						res = append(res, status)
+					}
+				}
+
+				return res, nil
 			},
 
 			HealthFunc: func(ctx context.Context) error {
@@ -878,7 +896,13 @@ func TestPOSTTransactions(t *testing.T) { //nolint:funlen
 			},
 		}
 
-		defaultHandler, err := NewDefault(testLogger, txHandler, nil, defaultPolicy, nil, nil)
+		merkleRootsVerifier := &btxMocks.MerkleRootsVerifierMock{
+			VerifyMerkleRootsFunc: func(ctx context.Context, merkleRootVerificationRequest []blocktx.MerkleRootVerificationRequest) ([]uint64, error) {
+				return nil, nil
+			},
+		}
+
+		defaultHandler, err := NewDefault(testLogger, txHandler, merkleRootsVerifier, defaultPolicy, nil, nil)
 		require.NoError(t, err)
 
 		inputTxs := map[string]io.Reader{
@@ -1206,4 +1230,14 @@ func Test_handleError(t *testing.T) {
 			require.Equal(t, tc.expectedArcErr, arcErr)
 		})
 	}
+}
+
+func find[T any](arr []T, predicate func(T) bool) (T, bool) {
+	for _, element := range arr {
+		if predicate(element) {
+			return element, true
+		}
+	}
+	var zero T
+	return zero, false
 }

--- a/pkg/api/handler/helpers.go
+++ b/pkg/api/handler/helpers.go
@@ -124,11 +124,13 @@ func convertMerkleRootsRequest(beefMerkleRoots []beef.MerkleRootVerificationRequ
 	return merkleRoots
 }
 
-func filterStatusesByTxIDs(txIDs []string, allStatuses []*metamorph.TransactionStatus) []*metamorph.TransactionStatus {
-	if len(txIDs) == 1 && len(allStatuses) == 1 {
-		if allStatuses[0].TxID == txIDs[0] {
-			return allStatuses
+func filterStatusesByTxIDs(txIDs []string, statuses []*metamorph.TransactionStatus) []*metamorph.TransactionStatus {
+	if len(txIDs) == 1 && len(statuses) == 1 { // optimization for a common scenario
+		if statuses[0].TxID == txIDs[0] {
+			return statuses
 		}
+
+		return make([]*metamorph.TransactionStatus, 0)
 	}
 
 	idsMap := make(map[string]struct{})
@@ -137,7 +139,7 @@ func filterStatusesByTxIDs(txIDs []string, allStatuses []*metamorph.TransactionS
 	}
 
 	filteredStatuses := make([]*metamorph.TransactionStatus, 0)
-	for _, txStatus := range allStatuses {
+	for _, txStatus := range statuses {
 		if _, ok := idsMap[txStatus.TxID]; ok {
 			filteredStatuses = append(filteredStatuses, txStatus)
 		}

--- a/pkg/api/handler/helpers.go
+++ b/pkg/api/handler/helpers.go
@@ -124,16 +124,13 @@ func convertMerkleRootsRequest(beefMerkleRoots []beef.MerkleRootVerificationRequ
 	return merkleRoots
 }
 
-func findStatusByTxID(txID string, statuses []*metamorph.TransactionStatus) *metamorph.TransactionStatus {
-	for _, status := range statuses {
-		if status.TxID == txID {
-			return status
+func filterStatusesByTxIDs(txIDs []string, allStatuses []*metamorph.TransactionStatus) []*metamorph.TransactionStatus {
+	if len(txIDs) == 1 && len(allStatuses) == 1 {
+		if allStatuses[0].TxID == txIDs[0] {
+			return allStatuses
 		}
 	}
-	return nil
-}
 
-func filterStatusesByTxIDs(txIDs []string, allStatuses []*metamorph.TransactionStatus) []*metamorph.TransactionStatus {
 	idsMap := make(map[string]struct{})
 	for _, id := range txIDs {
 		idsMap[id] = struct{}{}

--- a/pkg/api/handler/helpers_test.go
+++ b/pkg/api/handler/helpers_test.go
@@ -1,13 +1,16 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/bitcoin-sv/arc/internal/beef"
 	"github.com/bitcoin-sv/arc/pkg/blocktx"
+	"github.com/bitcoin-sv/arc/pkg/metamorph"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
@@ -70,6 +73,94 @@ func TestConvertMerkleRootsRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			request := convertMerkleRootsRequest(tc.request)
 			assert.Equal(t, tc.expectedRequest, request)
+		})
+	}
+}
+
+func TestFilterStatusesByTxIDs(t *testing.T) {
+	tcs := []struct {
+		name     string
+		txIDs    []string
+		statuses []*metamorph.TransactionStatus
+		expected []*metamorph.TransactionStatus
+	}{
+		{
+			name:  "Single txID with matching status",
+			txIDs: []string{"tx1"},
+			statuses: []*metamorph.TransactionStatus{
+				{TxID: "tx1"},
+			},
+			expected: []*metamorph.TransactionStatus{
+				{TxID: "tx1"},
+			},
+		},
+		{
+			name:  "Single txID with non-matching status",
+			txIDs: []string{"tx1"},
+			statuses: []*metamorph.TransactionStatus{
+				{TxID: "tx2"},
+			},
+			expected: []*metamorph.TransactionStatus{},
+		},
+		{
+			name:  "Multiple txIDs with some matching statuses",
+			txIDs: []string{"tx1", "tx3"},
+			statuses: []*metamorph.TransactionStatus{
+				{TxID: "tx1"},
+				{TxID: "tx2"},
+				{TxID: "tx3"},
+			},
+			expected: []*metamorph.TransactionStatus{
+				{TxID: "tx1"},
+				{TxID: "tx3"},
+			},
+		},
+		{
+			name:  "No txIDs",
+			txIDs: []string{},
+			statuses: []*metamorph.TransactionStatus{
+				{TxID: "tx1"},
+				{TxID: "tx2"},
+			},
+			expected: []*metamorph.TransactionStatus{},
+		},
+		{
+			name:     "No statuses",
+			txIDs:    []string{"tx1", "tx2"},
+			statuses: []*metamorph.TransactionStatus{},
+			expected: []*metamorph.TransactionStatus{},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			res := filterStatusesByTxIDs(tc.txIDs, tc.statuses)
+			if !reflect.DeepEqual(res, tc.expected) {
+				t.Errorf("expected %v, got %v", tc.expected, res)
+			}
+		})
+	}
+}
+
+func BenchmarkFilterStatusesByTxIDs(b *testing.B) {
+	bcs := []int{1, 10, 100, 1000, 10000}
+
+	for _, n := range bcs {
+		b.Run(fmt.Sprintf("txIDs-%d", n), func(b *testing.B) {
+			txIDs := make([]string, n)
+			for i := 0; i < n; i++ {
+				txIDs[i] = fmt.Sprintf("tx-%d", i)
+			}
+
+			statuses := make([]*metamorph.TransactionStatus, n)
+			for i := 0; i < n; i++ {
+				statuses[i] = &metamorph.TransactionStatus{TxID: fmt.Sprintf("tx-%d", i)}
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = filterStatusesByTxIDs(txIDs, statuses)
+			}
 		})
 	}
 }

--- a/pkg/api/handler/parsers.go
+++ b/pkg/api/handler/parsers.go
@@ -51,6 +51,10 @@ func parseTransactionFromRequest(request *http.Request) ([]byte, error) {
 		return nil, fmt.Errorf("given content-type %s does not match any of the allowed content-types", contentType)
 	}
 
+	if len(txHex) == 0 {
+		return nil, errEmptyBody
+	}
+
 	return txHex, nil
 }
 


### PR DESCRIPTION
- unify single and batch transaction processing endpoints by removing redundant processing functions.
- fix several errors caused by previously repeated code.
- fix unit tests.

**NOTE:** Due to unification, there is one change in behavior (as noted in unit tests: `default_test.go:359`): in the case of a non-empty JSON without required fields, the system no longer returns `EOF` in the error response. Instead, it returns `error parsing transaction from request: no transaction found - empty request body`.