### PR TITLE
Feature/broadcaster cli config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ gosec-report.json
 gotest.out
 *.env
 report.xml
+broadcaster-cli.yaml

--- a/cmd/broadcaster-cli/README.md
+++ b/cmd/broadcaster-cli/README.md
@@ -21,7 +21,14 @@ go install ./cmd/broadcaster-cli/
 
 As there can be a lot of flags you can also define them in a `yaml` file. The file [broadcaster-cli-example.yaml](./broadcaster-cli-example.yaml) is an example of the configuration.
 
-If file `broadcaster-cli.yaml` is present in either the folder where `broadcaster-cli` is run or the folder `./cmd/broadcaster-cli/`, then these values will be used as flags (if available to the command). You can still provide the flags, in that case the value provided in the flag will override the value provided in `broadcaster-cli.yaml`
+A specific config file can be selected using the `--config` flag. Example:
+```
+broadcaster-cli keyset address --config=./cmd/broadcaster-cli/broadcaster-cli-example.yaml
+```
+
+If no config file is given using the `--config` flag, `broadcaster-cli` will search for `broadcaster-cli.yaml` in `.` and `./cmd/broadcaster-cli/` folders.
+
+If a config file was found, then these values will be used as flags (if available to the command). You can still provide the flags, in which case the value provided in the flag will override the value provided in `broadcaster-cli.yaml`.
 
 ## How to use broadcaster-cli to send batches of transactions to ARC
 

--- a/cmd/broadcaster-cli/app/root.go
+++ b/cmd/broadcaster-cli/app/root.go
@@ -53,7 +53,7 @@ func Execute() error {
 		log.Fatalf("config file extension needs to be yaml but is %s", extension)
 	}
 
-	fmt.Println("Config name: ", filename)
+	fmt.Println("Config file: ", filename)
 
 	viper.AddConfigPath(".")
 	viper.AddConfigPath("./cmd/broadcaster-cli/")

--- a/cmd/broadcaster-cli/app/root.go
+++ b/cmd/broadcaster-cli/app/root.go
@@ -43,6 +43,15 @@ func Execute() error {
 
 	fp := filepath.Dir(ConfigFileName)
 	filename := filepath.Base(ConfigFileName)
+	extension := filepath.Ext(filename)
+
+	if extension == "" {
+		log.Fatal("config file extension missing")
+	}
+
+	if extension != ".yaml" {
+		log.Fatalf("config file extension needs to be yaml but is %s", extension)
+	}
 
 	fmt.Println("Config name: ", filename)
 
@@ -52,7 +61,7 @@ func Execute() error {
 		viper.AddConfigPath(fp)
 	}
 
-	viper.SetConfigName(filename)
+	viper.SetConfigName(filename[:len(filename)-len(extension)])
 
 	err = viper.ReadInConfig()
 	if err != nil {

--- a/cmd/broadcaster-cli/main.go
+++ b/cmd/broadcaster-cli/main.go
@@ -1,9 +1,20 @@
 package main
 
 import (
-	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/app"
+	"fmt"
 	"log"
 	"os"
+
+	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/app"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	RootCmd = &cobra.Command{
+		Use:   "broadcaster",
+		Short: "CLI tool to broadcast transactions to ARC",
+	}
 )
 
 func main() {
@@ -16,10 +27,30 @@ func main() {
 }
 
 func run() error {
+	var err error
 
-	err := app.Execute()
+	RootCmd.PersistentFlags().Bool("testnet", false, "[IS NOT DISPLAYED]")
+	RootCmd.PersistentFlags().StringSlice("keys", []string{}, "[IS NOT DISPLAYED]")
+	RootCmd.PersistentFlags().String("wocAPIKey", "", "[IS NOT DISPLAYED]")
+
+	RootCmd.PersistentFlags().String("config", "broadcaster-cli", "[IS NOT DISPLAYED]")
+	err = viper.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
 	if err != nil {
-		return err
+		log.Fatalf("failed to get config: %v", err)
+	}
+
+	err = RootCmd.Execute()
+	if err != nil {
+		return fmt.Errorf("failed to execute root command: %w", err)
+	}
+
+	app.ConfigFileName = viper.GetString("config")
+	app.RootCmd.Use = RootCmd.Use
+	app.RootCmd.Short = RootCmd.Short
+
+	err = app.Execute()
+	if err != nil {
+		return fmt.Errorf("failed to execute application command: %w", err)
 	}
 
 	return nil

--- a/cmd/broadcaster-cli/main.go
+++ b/cmd/broadcaster-cli/main.go
@@ -29,11 +29,11 @@ func main() {
 func run() error {
 	var err error
 
-	RootCmd.PersistentFlags().Bool("testnet", false, "[IS NOT DISPLAYED]")
-	RootCmd.PersistentFlags().StringSlice("keys", []string{}, "[IS NOT DISPLAYED]")
-	RootCmd.PersistentFlags().String("wocAPIKey", "", "[IS NOT DISPLAYED]")
+	RootCmd.PersistentFlags().Bool("testnet", false, "Use testnet")
+	RootCmd.PersistentFlags().StringSlice("keys", []string{}, "List of selected private keys")
+	RootCmd.PersistentFlags().String("wocAPIKey", "", "Optional WhatsOnChain API key for allowing for higher request rates")
 
-	RootCmd.PersistentFlags().String("config", "broadcaster-cli.yaml", "[IS NOT DISPLAYED]")
+	RootCmd.PersistentFlags().String("config", "broadcaster-cli.yaml", "Path to the config file to be used")
 	err = viper.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
 	if err != nil {
 		log.Fatalf("failed to get config: %v", err)

--- a/cmd/broadcaster-cli/main.go
+++ b/cmd/broadcaster-cli/main.go
@@ -33,7 +33,7 @@ func run() error {
 	RootCmd.PersistentFlags().StringSlice("keys", []string{}, "[IS NOT DISPLAYED]")
 	RootCmd.PersistentFlags().String("wocAPIKey", "", "[IS NOT DISPLAYED]")
 
-	RootCmd.PersistentFlags().String("config", "broadcaster-cli", "[IS NOT DISPLAYED]")
+	RootCmd.PersistentFlags().String("config", "broadcaster-cli.yaml", "[IS NOT DISPLAYED]")
 	err = viper.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
 	if err != nil {
 		log.Fatalf("failed to get config: %v", err)


### PR DESCRIPTION
- Allow to run `broadcaster-cli` optionally with a configuration file given by flag `--config=...`
- If this flag is omitted, then `broadcaster-cli` looks for the `broadcaster-cli.yaml` file

Example

```
broadcaster-cli keyset address --config=./cmd/broadcaster-cli/broadcaster-cli-example.yaml
```

