### PR TITLE
ARCO-147: Refactor WoC client

### DIFF
--- a/cmd/broadcaster-cli/app/keyset/balance/balance.go
+++ b/cmd/broadcaster-cli/app/keyset/balance/balance.go
@@ -27,7 +27,7 @@ var Cmd = &cobra.Command{
 
 		logger := helper.GetLogger()
 
-		wocClient := woc_client.New(woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
+		wocClient := woc_client.New(!isTestnet, woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
 
 		keySets, err := helper.GetKeySets()
 		if err != nil {
@@ -39,7 +39,7 @@ var Cmd = &cobra.Command{
 			if wocApiKey == "" {
 				time.Sleep(500 * time.Millisecond)
 			}
-			confirmed, unconfirmed, err := wocClient.GetBalanceWithRetries(context.Background(), !isTestnet, keySet.Address(!isTestnet), 1*time.Second, 5)
+			confirmed, unconfirmed, err := wocClient.GetBalanceWithRetries(context.Background(), keySet.Address(!isTestnet), 1*time.Second, 5)
 			if err != nil {
 				return err
 			}

--- a/cmd/broadcaster-cli/app/keyset/topup/topup.go
+++ b/cmd/broadcaster-cli/app/keyset/topup/topup.go
@@ -26,7 +26,7 @@ var Cmd = &cobra.Command{
 
 		logger := helper.GetLogger()
 
-		wocClient := woc_client.New(woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
+		wocClient := woc_client.New(!isTestnet, woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
 
 		keySets, err := helper.GetKeySets()
 		if err != nil {
@@ -38,7 +38,7 @@ var Cmd = &cobra.Command{
 			if wocApiKey == "" {
 				time.Sleep(500 * time.Millisecond)
 			}
-			err = wocClient.TopUp(context.Background(), !isTestnet, keySet.Address(!isTestnet))
+			err = wocClient.TopUp(context.Background(), keySet.Address(!isTestnet))
 
 			if err != nil {
 				return err

--- a/cmd/broadcaster-cli/app/keyset/utxos/utxos.go
+++ b/cmd/broadcaster-cli/app/keyset/utxos/utxos.go
@@ -34,7 +34,7 @@ var Cmd = &cobra.Command{
 		}
 
 		logger := helper.GetLogger()
-		wocClient := woc_client.New(woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
+		wocClient := woc_client.New(!isTestnet, woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
 
 		keySets, err := helper.GetKeySets()
 		if err != nil {
@@ -57,7 +57,7 @@ var Cmd = &cobra.Command{
 			headerRow = append(headerRow, "Sat", "Outputs")
 			keyHeaderRow = append(keyHeaderRow, "key-"+strconv.Itoa(i), "")
 
-			utxos, err := wocClient.GetUTXOsWithRetries(context.Background(), !isTestnet, keyset.Script, keyset.Address(!isTestnet), 1*time.Second, 5)
+			utxos, err := wocClient.GetUTXOsWithRetries(context.Background(), keyset.Script, keyset.Address(!isTestnet), 1*time.Second, 5)
 			if err != nil {
 				return fmt.Errorf("failed to get utxos from WoC: %v", err)
 			}

--- a/cmd/broadcaster-cli/app/utxos/broadcast/broadcast.go
+++ b/cmd/broadcaster-cli/app/utxos/broadcast/broadcast.go
@@ -108,7 +108,7 @@ var Cmd = &cobra.Command{
 			return fmt.Errorf("failed to create client: %v", err)
 		}
 
-		wocClient := woc_client.New(woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
+		wocClient := woc_client.New(!isTestnet, woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
 
 		opts := []func(p *broadcaster.Broadcaster){
 			broadcaster.WithFees(miningFeeSat),

--- a/cmd/broadcaster-cli/app/utxos/consolidate/consolidate.go
+++ b/cmd/broadcaster-cli/app/utxos/consolidate/consolidate.go
@@ -73,7 +73,7 @@ var Cmd = &cobra.Command{
 			return fmt.Errorf("failed to create client: %v", err)
 		}
 
-		wocClient := woc_client.New(woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
+		wocClient := woc_client.New(!isTestnet, woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
 
 		rateBroadcaster, err := broadcaster.NewUTXOConsolidator(logger, client, keySets, wocClient, isTestnet,
 			broadcaster.WithFees(miningFeeSat),

--- a/cmd/broadcaster-cli/app/utxos/create/create.go
+++ b/cmd/broadcaster-cli/app/utxos/create/create.go
@@ -92,7 +92,7 @@ var Cmd = &cobra.Command{
 			return fmt.Errorf("failed to create client: %v", err)
 		}
 
-		wocClient := woc_client.New(woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
+		wocClient := woc_client.New(!isTestnet, woc_client.WithAuth(wocApiKey), woc_client.WithLogger(logger))
 
 		rateBroadcaster, err := broadcaster.NewUTXOCreator(logger, client, keySets, wocClient, isTestnet,
 			broadcaster.WithFees(miningFeeSat),

--- a/config/config.go
+++ b/config/config.go
@@ -113,6 +113,7 @@ type StatsConfig struct {
 type ApiConfig struct {
 	Address       string            `mapstructure:"address"`
 	WocApiKey     string            `mapstructure:"wocApiKey"`
+	WocMainnet    bool              `mapstructure:"wocMainnet"`
 	DefaultPolicy *bitcoin.Settings `mapstructure:"defaultPolicy"`
 }
 

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -85,6 +85,7 @@ blocktx:
 api:
   address: localhost:9090 # address to start api server on
   wocApiKey: "mainnet_XXXXXXXXXXXXXXXXXXXX" # api key for www.whatsonchain.com
+  wocMainnet: false # query main or test net on www.whatsonchain.com
   defaultPolicy: # default policy of bitcoin node
     excessiveblocksize: 2000000000
     blockmaxsize: 512000000

--- a/internal/broadcaster/broadcaster.go
+++ b/internal/broadcaster/broadcaster.go
@@ -19,13 +19,13 @@ const (
 )
 
 type UtxoClient interface {
-	GetUTXOs(ctx context.Context, mainnet bool, lockingScript *bscript.Script, address string) ([]*bt.UTXO, error)
-	GetUTXOsWithRetries(ctx context.Context, mainnet bool, lockingScript *bscript.Script, address string, constantBackoff time.Duration, retries uint64) ([]*bt.UTXO, error)
-	GetUTXOsList(ctx context.Context, mainnet bool, lockingScript *bscript.Script, address string) (*list.List, error)
-	GetUTXOsListWithRetries(ctx context.Context, mainnet bool, lockingScript *bscript.Script, address string, constantBackoff time.Duration, retries uint64) (*list.List, error)
-	GetBalance(ctx context.Context, mainnet bool, address string) (int64, int64, error)
-	GetBalanceWithRetries(ctx context.Context, mainnet bool, address string, constantBackoff time.Duration, retries uint64) (int64, int64, error)
-	TopUp(ctx context.Context, mainnet bool, address string) error
+	GetUTXOs(ctx context.Context, lockingScript *bscript.Script, address string) ([]*bt.UTXO, error)
+	GetUTXOsWithRetries(ctx context.Context, lockingScript *bscript.Script, address string, constantBackoff time.Duration, retries uint64) ([]*bt.UTXO, error)
+	GetUTXOsList(ctx context.Context, lockingScript *bscript.Script, address string) (*list.List, error)
+	GetUTXOsListWithRetries(ctx context.Context, lockingScript *bscript.Script, address string, constantBackoff time.Duration, retries uint64) (*list.List, error)
+	GetBalance(ctx context.Context, address string) (int64, int64, error)
+	GetBalanceWithRetries(ctx context.Context, address string, constantBackoff time.Duration, retries uint64) (int64, int64, error)
+	TopUp(ctx context.Context, address string) error
 }
 
 type Broadcaster struct {

--- a/internal/broadcaster/rate_broadcaster.go
+++ b/internal/broadcaster/rate_broadcaster.go
@@ -84,7 +84,7 @@ func (b *RateBroadcaster) Start(rateTxsPerSecond int, limit int64) error {
 		}
 	}()
 
-	_, unconfirmed, err := b.utxoClient.GetBalanceWithRetries(b.ctx, !b.isTestnet, b.ks.Address(!b.isTestnet), 1*time.Second, 5)
+	_, unconfirmed, err := b.utxoClient.GetBalanceWithRetries(b.ctx, b.ks.Address(!b.isTestnet), 1*time.Second, 5)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (b *RateBroadcaster) Start(rateTxsPerSecond int, limit int64) error {
 	}
 	b.logger.Info("Start broadcasting", slog.String("wait for status", b.waitForStatus.String()))
 
-	utxoSet, err := b.utxoClient.GetUTXOsWithRetries(b.ctx, !b.isTestnet, b.ks.Script, b.ks.Address(!b.isTestnet), 1*time.Second, 5)
+	utxoSet, err := b.utxoClient.GetUTXOsWithRetries(b.ctx, b.ks.Script, b.ks.Address(!b.isTestnet), 1*time.Second, 5)
 	if err != nil {
 		return fmt.Errorf("failed to get utxos: %v", err)
 	}

--- a/internal/broadcaster/utxo_consolidator.go
+++ b/internal/broadcaster/utxo_consolidator.go
@@ -38,7 +38,7 @@ func NewUTXOConsolidator(logger *slog.Logger, client ArcClient, keySets []*keyse
 func (b *UTXOConsolidator) Consolidate() error {
 	for _, ks := range b.keySets {
 		b.logger.Info("consolidating utxos", slog.String("address", ks.Address(!b.isTestnet)))
-		_, unconfirmed, err := b.utxoClient.GetBalanceWithRetries(b.ctx, !b.isTestnet, ks.Address(!b.isTestnet), 1*time.Second, 5)
+		_, unconfirmed, err := b.utxoClient.GetBalanceWithRetries(b.ctx, ks.Address(!b.isTestnet), 1*time.Second, 5)
 		if err != nil {
 			return err
 		}
@@ -46,7 +46,7 @@ func (b *UTXOConsolidator) Consolidate() error {
 			return fmt.Errorf("key with address %s balance has unconfirmed amount %d sat", ks.Address(!b.isTestnet), unconfirmed)
 		}
 
-		utxoSet, err := b.utxoClient.GetUTXOsListWithRetries(b.ctx, !b.isTestnet, ks.Script, ks.Address(!b.isTestnet), 1*time.Second, 5)
+		utxoSet, err := b.utxoClient.GetUTXOsListWithRetries(b.ctx, ks.Script, ks.Address(!b.isTestnet), 1*time.Second, 5)
 		if err != nil {
 			return fmt.Errorf("failed to get utxos: %v", err)
 		}

--- a/internal/broadcaster/utxo_creator.go
+++ b/internal/broadcaster/utxo_creator.go
@@ -40,7 +40,7 @@ func (b *UTXOCreator) CreateUtxos(requestedOutputs int, requestedSatoshisPerOutp
 
 		requestedOutputsSatoshis := int64(requestedOutputs) * int64(requestedSatoshisPerOutput)
 
-		confirmed, unconfirmed, err := b.utxoClient.GetBalanceWithRetries(b.ctx, !b.isTestnet, ks.Address(!b.isTestnet), 1*time.Second, 5)
+		confirmed, unconfirmed, err := b.utxoClient.GetBalanceWithRetries(b.ctx, ks.Address(!b.isTestnet), 1*time.Second, 5)
 		if err != nil {
 			return err
 		}
@@ -55,7 +55,7 @@ func (b *UTXOCreator) CreateUtxos(requestedOutputs int, requestedSatoshisPerOutp
 			return fmt.Errorf("requested total of satoshis %d exceeds balance on funding keyset %d", requestedOutputsSatoshis, balance)
 		}
 
-		utxos, err := b.utxoClient.GetUTXOsWithRetries(b.ctx, !b.isTestnet, ks.Script, ks.Address(!b.isTestnet), 1*time.Second, 5)
+		utxos, err := b.utxoClient.GetUTXOsWithRetries(b.ctx, ks.Script, ks.Address(!b.isTestnet), 1*time.Second, 5)
 		if err != nil {
 			return err
 		}
@@ -171,7 +171,7 @@ func (b *UTXOCreator) splitOutputs(requestedOutputs int, requestedSatoshisPerOut
 	for front := utxoSet.Front(); front != nil; front = next {
 		next = front.Next()
 
-		if front == nil || outputs >= requestedOutputs {
+		if outputs >= requestedOutputs {
 			break
 		}
 

--- a/internal/woc_client/woc_client.go
+++ b/internal/woc_client/woc_client.go
@@ -241,13 +241,9 @@ func (w *WocClient) TopUp(ctx context.Context, address string) error {
 		return errors.New("top up can only be done on testnet")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api-test.whatsonchain.com/v1/bsv/test/faucet/send/%s", address), nil)
+	req, err := w.httpRequest(ctx, "GET", fmt.Sprintf("faucet/send/%s", address), nil)
 	if err != nil {
-		return fmt.Errorf("failed to crreate request: %v", err)
-	}
-
-	if w.authorization != "" {
-		req.Header.Set("Authorization", w.authorization)
+		return err
 	}
 
 	resp, err := w.client.Do(req)

--- a/internal/woc_client/woc_client.go
+++ b/internal/woc_client/woc_client.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -20,6 +21,7 @@ import (
 type WocClient struct {
 	client        http.Client
 	authorization string
+	net           string
 	logger        *slog.Logger
 }
 
@@ -35,9 +37,15 @@ func WithAuth(authorization string) func(*WocClient) {
 	}
 }
 
-func New(opts ...func(client *WocClient)) *WocClient {
+func New(mainnet bool, opts ...func(client *WocClient)) *WocClient {
+	net := "test"
+	if mainnet {
+		net = "main"
+	}
+
 	w := &WocClient{
 		client: http.Client{Timeout: 10 * time.Second},
+		net:    net,
 	}
 
 	for _, opt := range opts {
@@ -68,13 +76,13 @@ type wocRawTx struct {
 	Confirmations uint64 `json:"confirmations"`
 }
 
-func (w *WocClient) GetUTXOsWithRetries(ctx context.Context, mainnet bool, lockingScript *bscript.Script, address string, constantBackoff time.Duration, retries uint64) ([]*bt.UTXO, error) {
+func (w *WocClient) GetUTXOsWithRetries(ctx context.Context, lockingScript *bscript.Script, address string, constantBackoff time.Duration, retries uint64) ([]*bt.UTXO, error) {
 	policy := backoff.WithMaxRetries(backoff.NewConstantBackOff(constantBackoff), retries)
 
 	policyContext := backoff.WithContext(policy, ctx)
 
 	operation := func() ([]*bt.UTXO, error) {
-		wocUtxos, err := w.getUTXOs(ctx, mainnet, lockingScript, address)
+		wocUtxos, err := w.GetUTXOs(ctx, lockingScript, address)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get utxos from WoC: %v", err)
 		}
@@ -93,19 +101,11 @@ func (w *WocClient) GetUTXOsWithRetries(ctx context.Context, mainnet bool, locki
 	return utxos, nil
 }
 
-func (w *WocClient) getUTXOs(ctx context.Context, mainnet bool, lockingScript *bscript.Script, address string) ([]*bt.UTXO, error) {
-	net := "test"
-	if mainnet {
-		net = "main"
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api.whatsonchain.com/v1/bsv/%s/address/%s/unspent", net, address), nil)
+// GetUTXOs Get UTXOs from WhatsOnChain
+func (w *WocClient) GetUTXOs(ctx context.Context, lockingScript *bscript.Script, address string) ([]*bt.UTXO, error) {
+	req, err := w.httpRequest(ctx, "GET", fmt.Sprintf("address/%s/unspent", address), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to crreate request: %v", err)
-	}
-
-	if w.authorization != "" {
-		req.Header.Set("Authorization", w.authorization)
+		return nil, err
 	}
 
 	resp, err := w.client.Do(req)
@@ -142,13 +142,9 @@ func (w *WocClient) getUTXOs(ctx context.Context, mainnet bool, lockingScript *b
 	return unspent, nil
 }
 
-// GetUTXOs Get UTXOs from WhatsOnChain
-func (w *WocClient) GetUTXOs(ctx context.Context, mainnet bool, lockingScript *bscript.Script, address string) ([]*bt.UTXO, error) {
-	return w.getUTXOs(ctx, mainnet, lockingScript, address)
-}
-
-func (w *WocClient) getUTXOsList(ctx context.Context, mainnet bool, lockingScript *bscript.Script, address string) (*list.List, error) {
-	utxos, err := w.getUTXOs(ctx, mainnet, lockingScript, address)
+// GetUTXOsList Get UTXOs from WhatsOnChain as a list
+func (w *WocClient) GetUTXOsList(ctx context.Context, lockingScript *bscript.Script, address string) (*list.List, error) {
+	utxos, err := w.GetUTXOs(ctx, lockingScript, address)
 	if err != nil {
 		return nil, err
 	}
@@ -161,18 +157,13 @@ func (w *WocClient) getUTXOsList(ctx context.Context, mainnet bool, lockingScrip
 	return values, nil
 }
 
-// GetUTXOsList Get UTXOs from WhatsOnChain as a list
-func (w *WocClient) GetUTXOsList(ctx context.Context, mainnet bool, lockingScript *bscript.Script, address string) (*list.List, error) {
-	return w.getUTXOsList(ctx, mainnet, lockingScript, address)
-}
-
-func (w *WocClient) GetUTXOsListWithRetries(ctx context.Context, mainnet bool, lockingScript *bscript.Script, address string, constantBackoff time.Duration, retries uint64) (*list.List, error) {
+func (w *WocClient) GetUTXOsListWithRetries(ctx context.Context, lockingScript *bscript.Script, address string, constantBackoff time.Duration, retries uint64) (*list.List, error) {
 	policy := backoff.WithMaxRetries(backoff.NewConstantBackOff(constantBackoff), retries)
 
 	policyContext := backoff.WithContext(policy, ctx)
 
 	operation := func() (*list.List, error) {
-		wocUtxos, err := w.getUTXOsList(ctx, mainnet, lockingScript, address)
+		wocUtxos, err := w.GetUTXOsList(ctx, lockingScript, address)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get utxos from WoC: %v", err)
 		}
@@ -190,20 +181,10 @@ func (w *WocClient) GetUTXOsListWithRetries(ctx context.Context, mainnet bool, l
 
 	return utxos, nil
 }
-
-func (w *WocClient) getBalance(ctx context.Context, mainnet bool, address string) (int64, int64, error) {
-	net := "test"
-	if mainnet {
-		net = "main"
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api.whatsonchain.com/v1/bsv/%s/address/%s/balance", net, address), nil)
+func (w *WocClient) GetBalance(ctx context.Context, address string) (int64, int64, error) {
+	req, err := w.httpRequest(ctx, "GET", fmt.Sprintf("address/%s/balance", address), nil)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to crreate request: %v", err)
-	}
-
-	if w.authorization != "" {
-		req.Header.Set("Authorization", w.authorization)
+		return 0, 0, err
 	}
 
 	resp, err := w.client.Do(req)
@@ -225,11 +206,7 @@ func (w *WocClient) getBalance(ctx context.Context, mainnet bool, address string
 	return balance.Confirmed, balance.Unconfirmed, nil
 }
 
-func (w *WocClient) GetBalance(ctx context.Context, mainnet bool, address string) (int64, int64, error) {
-	return w.getBalance(ctx, mainnet, address)
-}
-
-func (w *WocClient) GetBalanceWithRetries(ctx context.Context, mainnet bool, address string, constantBackoff time.Duration, retries uint64) (int64, int64, error) {
+func (w *WocClient) GetBalanceWithRetries(ctx context.Context, address string, constantBackoff time.Duration, retries uint64) (int64, int64, error) {
 	policy := backoff.WithMaxRetries(backoff.NewConstantBackOff(constantBackoff), retries)
 
 	policyContext := backoff.WithContext(policy, ctx)
@@ -240,7 +217,7 @@ func (w *WocClient) GetBalanceWithRetries(ctx context.Context, mainnet bool, add
 	}
 
 	operation := func() (balanceResult, error) {
-		confirmed, unconfirmed, err := w.getBalance(ctx, mainnet, address)
+		confirmed, unconfirmed, err := w.GetBalance(ctx, address)
 		if err != nil {
 			return balanceResult{}, fmt.Errorf("failed to get utxos from WoC: %v", err)
 		}
@@ -259,13 +236,12 @@ func (w *WocClient) GetBalanceWithRetries(ctx context.Context, mainnet bool, add
 	return balanceRes.confirmed, balanceRes.unconfirmed, nil
 }
 
-func (w *WocClient) TopUp(ctx context.Context, mainnet bool, address string) error {
-	net := "test"
-	if mainnet {
+func (w *WocClient) TopUp(ctx context.Context, address string) error {
+	if w.net != "test" {
 		return errors.New("top up can only be done on testnet")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api-test.whatsonchain.com/v1/bsv/%s/faucet/send/%s", net, address), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api-test.whatsonchain.com/v1/bsv/test/faucet/send/%s", address), nil)
 	if err != nil {
 		return fmt.Errorf("failed to crreate request: %v", err)
 	}
@@ -287,21 +263,16 @@ func (w *WocClient) TopUp(ctx context.Context, mainnet bool, address string) err
 	return nil
 }
 
-func (w *WocClient) GetRawTxs(ctx context.Context, mainnet bool, ids []string) ([]*wocRawTx, error) {
+func (w *WocClient) GetRawTxs(ctx context.Context, ids []string) ([]*wocRawTx, error) {
 	const maxIDsNum = 20 // value from doc
 
 	var result []*wocRawTx
-
-	net := "test"
-	if mainnet {
-		net = "main"
-	}
 
 	for len(ids) > 0 {
 		bsize := min(maxIDsNum, len(ids))
 		batch := ids[:bsize]
 
-		txs, err := w.getRawTxs(ctx, net, batch)
+		txs, err := w.getRawTxs(ctx, batch)
 		if err != nil {
 			return nil, err
 		}
@@ -313,17 +284,13 @@ func (w *WocClient) GetRawTxs(ctx context.Context, mainnet bool, ids []string) (
 	return result, nil
 }
 
-func (w *WocClient) getRawTxs(ctx context.Context, net string, batch []string) ([]*wocRawTx, error) {
+func (w *WocClient) getRawTxs(ctx context.Context, batch []string) ([]*wocRawTx, error) {
 	payload := map[string][]string{"txids": batch}
 	body, _ := json.Marshal(payload)
 
-	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("https://api.whatsonchain.com/v1/bsv/%s/txs/hex", net), bytes.NewBuffer(body))
+	req, err := w.httpRequest(ctx, "POST", "txs/hex", body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to crreate request: %v", err)
-	}
-
-	if w.authorization != "" {
-		req.Header.Set("Authorization", w.authorization)
+		return nil, err
 	}
 
 	resp, err := w.client.Do(req)
@@ -343,4 +310,24 @@ func (w *WocClient) getRawTxs(ctx context.Context, net string, batch []string) (
 	}
 
 	return res, nil
+}
+
+func (w WocClient) httpRequest(ctx context.Context, method string, endpoint string, payload []byte) (*http.Request, error) {
+	const apiUrl = "https://api.whatsonchain.com/v1/bsv"
+
+	var body io.Reader
+	if len(payload) > 0 {
+		body = bytes.NewBuffer(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("%s/%s/%s", apiUrl, w.net, endpoint), body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to crreate request: %v", err)
+	}
+
+	if w.authorization != "" {
+		req.Header.Set("Authorization", w.authorization)
+	}
+
+	return req, nil
 }

--- a/internal/woc_client/woc_client_test.go
+++ b/internal/woc_client/woc_client_test.go
@@ -1,0 +1,150 @@
+package woc_client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testnet_addr = "miGidJu3HrpGuFxhF7gCg1yV13AJzANz4P"
+
+func Test_New(t *testing.T) {
+	tcs := []struct {
+		name                string
+		useMainnet          bool
+		expectedRequestPath string
+	}{
+		{
+			name:                "client for mainnet",
+			useMainnet:          true,
+			expectedRequestPath: "/v1/bsv/main/",
+		},
+		{
+			name:                "clietn for testnet",
+			useMainnet:          false,
+			expectedRequestPath: "/v1/bsv/test/",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			//when
+			sut := New(tc.useMainnet)
+
+			//then
+			httpReq, err := sut.httpRequest(context.TODO(), "GET", "", nil)
+
+			// assert
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedRequestPath, httpReq.URL.Path)
+
+		})
+	}
+}
+
+func Test_WithAuth(t *testing.T) {
+	tcs := []struct {
+		name   string
+		apiKey string
+	}{
+		{
+			name:   "client with api key",
+			apiKey: "test-api-key",
+		},
+		{
+			name: "client without api key",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			sut := New(false, WithAuth(tc.apiKey))
+
+			// then
+			httpReq, err := sut.httpRequest(context.TODO(), "GET", "", nil)
+
+			// assert
+			require.NoError(t, err)
+
+			authHeader, found := httpReq.Header["Authorization"]
+			if tc.apiKey != "" {
+				require.True(t, found)
+				require.Equal(t, tc.apiKey, authHeader[0])
+			} else {
+				require.False(t, found)
+			}
+		})
+	}
+}
+
+func Test_GetUTXOs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// when
+	sut := New(false)
+
+	// then
+	res, err := sut.GetUTXOs(context.TODO(), nil, testnet_addr)
+
+	// assert
+	require.NoError(t, err)
+	require.NotNil(t, res)
+}
+
+func Test_GetBalance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// when
+	sut := New(false)
+
+	// then
+	_, _, err := sut.GetBalance(context.TODO(), testnet_addr)
+
+	// assert
+	require.NoError(t, err)
+}
+
+func Test_TopUp(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// when
+	sut := New(false)
+
+	// then
+	err := sut.TopUp(context.TODO(), testnet_addr)
+
+	// assert
+	require.NoError(t, err)
+}
+
+func Test_GetRawTxs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// when
+	sut := New(false)
+
+	const idsCount = 37
+	ids := make([]string, idsCount)
+	for i := 0; i < idsCount; i++ {
+		ids[i] = fmt.Sprintf("id%d", i)
+	}
+
+	// then
+	res, err := sut.GetRawTxs(context.TODO(), ids)
+
+	// assert
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+}

--- a/internal/woc_client/woc_client_test.go
+++ b/internal/woc_client/woc_client_test.go
@@ -22,7 +22,7 @@ func Test_New(t *testing.T) {
 			expectedRequestPath: "/v1/bsv/main/",
 		},
 		{
-			name:                "clietn for testnet",
+			name:                "client for testnet",
 			useMainnet:          false,
 			expectedRequestPath: "/v1/bsv/test/",
 		},
@@ -116,14 +116,29 @@ func Test_TopUp(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	// when
-	sut := New(false)
+	t.Run("use on testnet", func(t *testing.T) {
+		// when
+		sut := New(false)
 
-	// then
-	err := sut.TopUp(context.TODO(), testnet_addr)
+		// then
+		err := sut.TopUp(context.TODO(), testnet_addr)
 
-	// assert
-	require.NoError(t, err)
+		// assert
+		require.NoError(t, err)
+	})
+
+	t.Run("try use on mainnet - should fail", func(t *testing.T) {
+		// when
+		const useOnMainnet = true
+		sut := New(useOnMainnet)
+
+		// then
+		err := sut.TopUp(context.TODO(), testnet_addr)
+
+		// assert
+		require.Error(t, err)
+		require.ErrorContains(t, err, "top up can only be done on testnet")
+	})
 }
 
 func Test_GetRawTxs(t *testing.T) {

--- a/pkg/api/handler/default.go
+++ b/pkg/api/handler/default.go
@@ -68,17 +68,16 @@ func NewDefault(
 
 	var wocClient *woc_client.WocClient
 	if apiConfig != nil {
-		wocClient = woc_client.New(woc_client.WithAuth(apiConfig.WocApiKey))
+		wocClient = woc_client.New(apiConfig.WocMainnet, woc_client.WithAuth(apiConfig.WocApiKey))
 	} else {
-		wocClient = woc_client.New()
+		wocClient = woc_client.New(false)
 	}
 
 	finder := txFinder{
-		th:         transactionHandler,
-		pc:         peerRpcConfig,
-		l:          logger,
-		w:          wocClient,
-		useMainnet: true, // TODO: refactor in scope of ARCO-147
+		th: transactionHandler,
+		pc: peerRpcConfig,
+		l:  logger,
+		w:  wocClient,
 	}
 
 	mr := merkleVerifier{

--- a/pkg/api/handler/tx_finder.go
+++ b/pkg/api/handler/tx_finder.go
@@ -15,11 +15,10 @@ import (
 )
 
 type txFinder struct {
-	th         metamorph.TransactionHandler
-	pc         *config.PeerRpcConfig
-	l          *slog.Logger
-	w          *woc_client.WocClient
-	useMainnet bool
+	th metamorph.TransactionHandler
+	pc *config.PeerRpcConfig
+	l  *slog.Logger
+	w  *woc_client.WocClient
 }
 
 func (f txFinder) GetRawTxs(ctx context.Context, source validator.FindSourceFlag, ids []string) ([]validator.RawTx, error) {
@@ -83,7 +82,7 @@ func (f txFinder) GetRawTxs(ctx context.Context, source validator.FindSourceFlag
 
 	// at last try the WoC
 	if source.Has(validator.SourceWoC) && len(remainingIDs) > 0 {
-		wocTxs, _ := f.w.GetRawTxs(ctx, f.useMainnet, remainingIDs)
+		wocTxs, _ := f.w.GetRawTxs(ctx, remainingIDs)
 		for _, wTx := range wocTxs {
 			rt, e := newRawTx(wTx.TxID, wTx.Hex, wTx.BlockHeight)
 			if e != nil {


### PR DESCRIPTION
- use only the WoC client throughout the entire codebase to communicate with WoC.
- simplify the interface.
- add tests.