### PR TITLE
Feature/broadcaster cli config flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ gosec-report.json
 gotest.out
 *.env
 report.xml
+broadcaster-cli.yaml
 coverage-report.html

--- a/cmd/broadcaster-cli/README.md
+++ b/cmd/broadcaster-cli/README.md
@@ -19,16 +19,26 @@ go install ./cmd/broadcaster-cli/
 
 `broadcaster-cli` uses flags for adding context needed to run it. The flags and commands available can be shown by running `broadcaster-cli` with the flag `--help`.
 
-As there can be a lot of flags you can also define them in a `yaml` file. The file [broadcaster-cli-example.yaml](./broadcaster-cli-example.yaml) is an example of the configuration.
+As there can be a lot of flags you can also define them in a configuration file. The file [broadcaster-cli-example.yaml](./broadcaster-cli-example.yaml) is an example of the configuration. The format of the file can be the following: JSON, TOML, YAML, HCL, INI, envfile or Java properties formats.
 
-If file `broadcaster-cli.yaml` is present in either the folder where `broadcaster-cli` is run or the folder `./cmd/broadcaster-cli/`, then these values will be used as flags (if available to the command). You can still provide the flags, in that case the value provided in the flag will override the value provided in `broadcaster-cli.yaml`
+A specific config file can be selected using the `--config` flag. Example:
+```
+broadcaster-cli keyset address -- --config ./cmd/broadcaster-cli/broadcaster-cli-example.yaml
+```
+Note that the config has to be added as a subcommand with a double dash `--` as shown above. The path to the config file has to be separated by a space.
+
+If no config file is given using the `--config` flag, `broadcaster-cli` will search for `broadcaster-cli.yaml` in `.` and `./cmd/broadcaster-cli/` folders.
+
+If a config file was found, then these values will be used as flags (if available to the command). You can still provide the flags, in which case the value provided in the flag will override the value provided in `broadcaster-cli.yaml`.
+
+Note that a configuration file needs to be given at least for the private keys (see [broadcaster-cli-example.yaml](./broadcaster-cli-example.yaml)) as they cannot be passed as flags.
 
 ## How to use broadcaster-cli to send batches of transactions to ARC
 
 These instructions will provide the steps needed in order to use `broadcaster-cli` to send transactions to ARC.
 
 1. Create a new key set by running `broadcaster-cli keyset new`
-    1. The key set displayed has to be added under to config.yaml under `privateKeys`
+    1. The key set displayed has to be added to the configuration file under `privateKeys`
 2. Add funds to the funding address
     1. Show the funding address by running `broadcaster-cli keyset address`
     2. In case of `testnet` (using the `--testnet` flag) funds can be added using the WoC faucet. For that you can use the command `broadcaster-cli keyset topup --testnet`

--- a/cmd/broadcaster-cli/app/root.go
+++ b/cmd/broadcaster-cli/app/root.go
@@ -2,21 +2,27 @@ package app
 
 import (
 	"errors"
-	"log"
-
 	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/app/keyset"
 	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/app/utxos"
+	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/helper"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/sys/unix"
+	"log"
+	"log/slog"
+	"os"
 )
 
-var RootCmd = &cobra.Command{
-	Use:   "broadcaster",
-	Short: "CLI tool to broadcast transactions to ARC",
-}
+var (
+	logger  *slog.Logger
+	RootCmd = &cobra.Command{
+		Use:   "broadcaster",
+		Short: "CLI tool to broadcast transactions to ARC",
+	}
+)
 
 func init() {
+	logger = helper.GetLogger()
 	var err error
 	RootCmd.PersistentFlags().Bool("testnet", false, "Use testnet")
 	err = viper.BindPFlag("testnet", RootCmd.PersistentFlags().Lookup("testnet"))
@@ -36,10 +42,25 @@ func init() {
 		log.Fatal(err)
 	}
 
-	viper.AddConfigPath(".")
-	viper.AddConfigPath("./cmd/broadcaster-cli/")
-	viper.SetConfigName("broadcaster-cli")
-	// Todo: Allow setting alternative config file name with flag: e.g. --config=brc-config.yaml
+	var configFilenameArg string
+	args := os.Args
+	for i, arg := range args {
+		if arg == "-c" || arg == "--config" {
+			configFilenameArg = args[i+1]
+		}
+	}
+
+	if configFilenameArg != "" {
+		viper.SetConfigFile(configFilenameArg)
+	} else {
+		viper.AddConfigPath(".")
+		viper.AddConfigPath("./cmd/broadcaster-cli/")
+		viper.SetConfigName("broadcaster-cli")
+	}
+
+	if viper.ConfigFileUsed() != "" {
+		logger.Info("Config file used", slog.String("filename", viper.ConfigFileUsed()))
+	}
 
 	err = viper.ReadInConfig()
 	if err != nil {

--- a/cmd/broadcaster-cli/main.go
+++ b/cmd/broadcaster-cli/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/app"
 	"log"
 	"os"
+
+	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/app"
 )
 
 func main() {


### PR DESCRIPTION
- Allow to run broadcaster-cli optionally with a configuration file given by flag --config=...
- If this flag is omitted, then broadcaster-cli looks for the broadcaster-cli.yaml file
- Document usage

Example:
```
broadcaster-cli keyset address -- --config ./cmd/broadcaster-cli/broadcaster-cli-example.yaml
```