### PR TITLE
feat(ARCO-169): refactor ResponseProcessor and competingTxs string to NullString

### DIFF
--- a/internal/metamorph/response_processor_test.go
+++ b/internal/metamorph/response_processor_test.go
@@ -94,7 +94,7 @@ func TestResponseProcessor(t *testing.T) {
 
 		rpMap := rp.getMap()
 
-		require.Len(t, rp.responseMap, 3)
+		require.Len(t, rpMap, 3)
 		require.Equal(t, metamorph_api.Status_RECEIVED, rpMap[*testdata.TX1Hash].Status)
 		require.Nil(t, rpMap[*testdata.TX1Hash].Err)
 		require.Equal(t, metamorph_api.Status_RECEIVED, rpMap[*testdata.TX2Hash].Status)

--- a/internal/metamorph/store/postgresql/migrations/000017_competing_txs_default.down.sql
+++ b/internal/metamorph/store/postgresql/migrations/000017_competing_txs_default.down.sql
@@ -1,0 +1,2 @@
+-- Down Migration: Revert the default value of 'competing_txs' to an empty string ''
+ALTER TABLE metamorph.transactions ALTER COLUMN competing_txs SET DEFAULT '';

--- a/internal/metamorph/store/postgresql/migrations/000017_competing_txs_default.up.sql
+++ b/internal/metamorph/store/postgresql/migrations/000017_competing_txs_default.up.sql
@@ -1,0 +1,2 @@
+-- Up Migration: Change the default value of 'competing_txs' to NULL
+ALTER TABLE metamorph.transactions ALTER COLUMN competing_txs SET DEFAULT NULL;

--- a/internal/metamorph/store/postgresql/postgres.go
+++ b/internal/metamorph/store/postgresql/postgres.go
@@ -100,7 +100,7 @@ func (p *PostgreSQL) Get(ctx context.Context, hash []byte) (*store.StoreData, er
 	var callbacksData []byte
 	var fullStatusUpdates bool
 	var rejectReason sql.NullString
-	var competingTxs string
+	var competingTxs sql.NullString
 	var rawTx []byte
 	var lockedBy string
 	var merklePath sql.NullString
@@ -173,25 +173,18 @@ func (p *PostgreSQL) Get(ctx context.Context, hash []byte) (*store.StoreData, er
 		data.Callbacks = callbacks
 	}
 
-	data.FullStatusUpdates = fullStatusUpdates
-
-	if rejectReason.Valid {
-		data.RejectReason = rejectReason.String
-	}
-
-	if competingTxs != "" {
-		data.CompetingTxs = strings.Split(competingTxs, ",")
-	}
-
-	data.LockedBy = lockedBy
-
-	if merklePath.Valid {
-		data.MerklePath = merklePath.String
-	}
-
 	if retries.Valid {
 		data.Retries = int(retries.Int32)
 	}
+
+	if competingTxs.String != "" {
+		data.CompetingTxs = strings.Split(competingTxs.String, ",")
+	}
+
+	data.FullStatusUpdates = fullStatusUpdates
+	data.RejectReason = rejectReason.String
+	data.LockedBy = lockedBy
+	data.MerklePath = merklePath.String
 
 	return data, nil
 }

--- a/internal/metamorph/store/postgresql/postgres.go
+++ b/internal/metamorph/store/postgresql/postgres.go
@@ -635,7 +635,8 @@ func (p *PostgreSQL) UpdateDoubleSpend(ctx context.Context, updates []store.Upda
 			) AS bulk_query
 			WHERE metamorph.transactions.hash=bulk_query.hash
 				AND metamorph.transactions.status <= bulk_query.status
-				AND LENGTH(metamorph.transactions.competing_txs) < LENGTH(bulk_query.competing_txs)
+				AND (metamorph.transactions.competing_txs IS NULL
+						OR LENGTH(metamorph.transactions.competing_txs) < LENGTH(bulk_query.competing_txs))
 		RETURNING metamorph.transactions.stored_at
 		,metamorph.transactions.announced_at
 		,metamorph.transactions.mined_at

--- a/internal/metamorph/store/postgresql/postgres_helpers.go
+++ b/internal/metamorph/store/postgresql/postgres_helpers.go
@@ -53,7 +53,7 @@ func getStoreDataFromRows(rows *sql.Rows) ([]*store.StoreData, error) {
 
 		var callbacksData []byte
 		var rejectReason sql.NullString
-		var competingTxs string
+		var competingTxs sql.NullString
 		var merklePath sql.NullString
 		var retries sql.NullInt32
 
@@ -116,21 +116,16 @@ func getStoreDataFromRows(rows *sql.Rows) ([]*store.StoreData, error) {
 			data.Callbacks = callbacks
 		}
 
-		if rejectReason.Valid {
-			data.RejectReason = rejectReason.String
-		}
-
-		if competingTxs != "" {
-			data.CompetingTxs = strings.Split(competingTxs, ",")
-		}
-
-		if merklePath.Valid {
-			data.MerklePath = merklePath.String
-		}
-
 		if retries.Valid {
 			data.Retries = int(retries.Int32)
 		}
+
+		if competingTxs.String != "" {
+			data.CompetingTxs = strings.Split(competingTxs.String, ",")
+		}
+
+		data.RejectReason = rejectReason.String
+		data.MerklePath = merklePath.String
 
 		storeData = append(storeData, data)
 	}
@@ -145,7 +140,7 @@ func getCompetingTxsFromRows(rows *sql.Rows) []competingTxsData {
 		data := competingTxsData{}
 
 		var hash []byte
-		var competingTxs string
+		var competingTxs sql.NullString
 
 		err := rows.Scan(
 			&hash,
@@ -157,8 +152,8 @@ func getCompetingTxsFromRows(rows *sql.Rows) []competingTxsData {
 
 		data.hash = hash
 
-		if competingTxs != "" {
-			data.competingTxs = strings.Split(competingTxs, ",")
+		if competingTxs.String != "" {
+			data.competingTxs = strings.Split(competingTxs.String, ",")
 		}
 
 		dbData = append(dbData, data)

--- a/internal/metamorph/store/postgresql/postgres_test.go
+++ b/internal/metamorph/store/postgresql/postgres_test.go
@@ -286,7 +286,6 @@ func TestPostgresDB(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.Len(t, res, len(keys))
-
 	})
 
 	t.Run("set bulk", func(t *testing.T) {
@@ -526,7 +525,7 @@ func TestPostgresDB(t *testing.T) {
 				Hash:         *revChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f"), // update expected - old status < new status
 				Status:       metamorph_api.Status_REJECTED,
 				CompetingTxs: []string{"1234"},
-				Error:        errors.New("txn-mempool-conflict"),
+				Error:        errors.New("double spend attempted"),
 			},
 			{
 				Hash:         *revChainhash(t, "3ce1e0c6cbbbe2118c3f80d2e6899d2d487f319ef0923feb61f3d26335b2225c"), // update not expected - hash non-existent in db
@@ -560,7 +559,7 @@ func TestPostgresDB(t *testing.T) {
 		require.Equal(t, metamorph_api.Status_REJECTED, statusUpdates[3].Status)
 		require.Equal(t, *revChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f"), *statusUpdates[3].Hash)
 		require.Equal(t, []string{"1234"}, statusUpdates[3].CompetingTxs)
-		require.Equal(t, "txn-mempool-conflict", statusUpdates[3].RejectReason)
+		require.Equal(t, "double spend attempted", statusUpdates[3].RejectReason)
 
 		statusUpdates, err = postgresDB.UpdateDoubleSpend(ctx, updates)
 		require.NoError(t, err)


### PR DESCRIPTION
### What's been done
1. Switch from `map` to `sync.Map` in `ResponseProcessor` to avoid accidental race conditions.
2. Better handling of null and empty string values when retrieving `competing_txs` from database.