### PR TITLE
Upgrade otel schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/oapi-codegen/echo-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/ordishs/go-bitcoin v1.0.86
-	github.com/ordishs/go-utils v1.0.51
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
@@ -110,6 +109,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 // indirect
 	github.com/opencontainers/runc v1.1.10 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/ordishs/go-utils v1.0.51 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/paulmach/orb v0.9.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect

--- a/internal/metamorph/callbacker.go
+++ b/internal/metamorph/callbacker.go
@@ -141,7 +141,9 @@ func (p *Callbacker) SendCallback(logger *slog.Logger, tx *store.StoreData) {
 	}
 
 	for _, callback := range tx.Callbacks {
-		p.sendCallback(logger, tx, callback, status, sleepDuration)
+		if callback.CallbackURL != "" {
+			p.sendCallback(logger, tx, callback, status, sleepDuration)
+		}
 	}
 }
 

--- a/internal/tracing/init.go
+++ b/internal/tracing/init.go
@@ -6,7 +6,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/semconv/v1.24.0"
+	"go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 func NewExporter(ctx context.Context, endpointURL string) (trace.SpanExporter, error) {


### PR DESCRIPTION
- Upgrade open telemetry schema to v1.26.0
- Only send callback if there is a callback URL