### PR TITLE
Feature/broadcaster cli split

### DIFF
--- a/cmd/broadcaster-cli/README.md
+++ b/cmd/broadcaster-cli/README.md
@@ -39,10 +39,21 @@ These instructions will provide the steps needed in order to use `broadcaster-cl
 
 1. Create a new key set by running `broadcaster-cli keyset new`
     1. The key set displayed has to be added to the configuration file under `privateKeys`
-2. Add funds to the funding address
-    1. Show the funding address by running `broadcaster-cli keyset address`
-    2. In case of `testnet` (using the `--testnet` flag) funds can be added using the WoC faucet. For that you can use the command `broadcaster-cli keyset topup --testnet`
-    3. You can view the balance of the key set using the command `broadcaster-cli keyset balance`
+2. Add funds to the funding addresses
+    1. Show the funding addresses by running `broadcaster-cli keyset address`
+       1. In case of `testnet` (using the `--testnet` flag) funds can be added using the WoC faucet. For that you can use the command `broadcaster-cli keyset topup --testnet`
+       2. In case of `mainnet` funds could be added to one of the addresses.
+   2. The funds can be spread to the other keys using the `utxos split` command.
+      1. The following command will split funds of a given UTXO from `key-01` to keys: `key-01`, `key-02`, `key-03`, `key-04`
+          ```
+           broadcaster-cli utxos split --txid=cf111f19bcfb6baab7fc200f0f8fb669dd6c66fd9de212becb0950c92a0b6c40 --satoshis=21953 --vout=0 --from=key-01 --keys=key-01,key-02,key-03,key-04
+          ```
+      2. The same command can be used to move all funds from one UTXO from one to another key. The following example shows how to send all funds of the given UTXO from `key-01` to `key-02`
+          ```
+           broadcaster-cli utxos split --txid=cf111f19bcfb6baab7fc200f0f8fb669dd6c66fd9de212becb0950c92a0b6c40 --satoshis=21953 --vout=0 --from=key-01 --keys=key-02
+          ```
+      3. In order to just create print the transaction without submitting it, the `--dryrun` flag can be added
+   3. You can view the balance of the key set using the command `broadcaster-cli keyset balance`
 3. Create UTXO set
     1. There must be a certain UTXO set available so that `broadcaster-cli` can broadcast a reasonable number of transactions in batches
     2. First look at the existing UTXO set using `broadcaster-cli keyset utxos`

--- a/cmd/broadcaster-cli/app/utxos/create/create.go
+++ b/cmd/broadcaster-cli/app/utxos/create/create.go
@@ -127,10 +127,4 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	Cmd.Flags().Int("satoshis", 0, "Nr of satoshis per output outputs")
-	err = viper.BindPFlag("satoshis", Cmd.Flags().Lookup("satoshis"))
-	if err != nil {
-		log.Fatal(err)
-	}
 }

--- a/cmd/broadcaster-cli/app/utxos/split/split.go
+++ b/cmd/broadcaster-cli/app/utxos/split/split.go
@@ -1,0 +1,174 @@
+package split
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/helper"
+	"github.com/bitcoin-sv/arc/internal/broadcaster"
+	"github.com/bitcoin-sv/arc/pkg/keyset"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "split",
+	Short: "Split a UTXO",
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		txid, err := helper.GetString("txid")
+		if err != nil {
+			return err
+		}
+		if txid == "" {
+			return errors.New("txid is required")
+		}
+
+		from, err := helper.GetString("from")
+		if err != nil {
+			return err
+		}
+		if from == "" {
+			return errors.New("from is required")
+		}
+
+		satoshis, err := helper.GetUint64("satoshis")
+		if err != nil {
+			return err
+		}
+		if satoshis == 0 {
+			return errors.New("satoshis is required")
+		}
+
+		vout, err := helper.GetUint32("vout")
+		if err != nil {
+			return err
+		}
+
+		dryrun, err := helper.GetBool("dryrun")
+		if err != nil {
+			return err
+		}
+
+		isTestnet, err := helper.GetBool("testnet")
+		if err != nil {
+			return err
+		}
+
+		authorization, err := helper.GetString("authorization")
+		if err != nil {
+			return err
+		}
+
+		miningFeeSat, err := helper.GetInt("miningFeeSatPerKb")
+		if err != nil {
+			return err
+		}
+
+		arcServer, err := helper.GetString("apiURL")
+		if err != nil {
+			return err
+		}
+		if arcServer == "" {
+			return errors.New("no api URL was given")
+		}
+
+		allKeysMap, err := helper.GetAllKeySets()
+		if err != nil {
+			return err
+		}
+
+		keySetsMap, err := helper.GetKeySets()
+		if err != nil {
+			return err
+		}
+
+		logger := helper.GetLogger()
+
+		client, err := helper.CreateClient(&broadcaster.Auth{
+			Authorization: authorization,
+		}, arcServer)
+		if err != nil {
+			return fmt.Errorf("failed to create client: %v", err)
+		}
+
+		ks := make([]*keyset.KeySet, len(keySetsMap))
+		counter := 0
+		for _, keySet := range keySetsMap {
+			ks[counter] = keySet
+			counter++
+		}
+		fromKs, ok := allKeysMap[from]
+		if !ok {
+			return fmt.Errorf("from not found in keySetsMap: %v", from)
+		}
+
+		splitter, err := broadcaster.NewUTXOSplitter(logger, client, fromKs, ks, isTestnet,
+			broadcaster.WithFees(miningFeeSat),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create broadcaster: %v", err)
+		}
+
+		err = splitter.SplitUtxo(txid, satoshis, vout, dryrun)
+		if err != nil {
+			return fmt.Errorf("failed to create utxos: %v", err)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+
+	logger := helper.GetLogger()
+	Cmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		// Hide unused persistent flags
+		err := command.Flags().MarkHidden("fullStatusUpdates")
+		if err != nil {
+			logger.Error("failed to mark flag hidden", slog.String("err", err.Error()))
+		}
+		err = command.Flags().MarkHidden("callback")
+		if err != nil {
+			logger.Error("failed to mark flag hidden", slog.String("err", err.Error()))
+		}
+		err = command.Flags().MarkHidden("callbackToken")
+		if err != nil {
+			logger.Error("failed to mark flag hidden", slog.String("err", err.Error()))
+		}
+		err = command.Flags().MarkHidden("fullStatusUpdates")
+		if err != nil {
+			logger.Error("failed to mark flag hidden", slog.String("err", err.Error()))
+		}
+		// Call parent help func
+		command.Parent().HelpFunc()(command, strings)
+	})
+
+	var err error
+	Cmd.Flags().String("from", "", "Key from which to split")
+	err = viper.BindPFlag("from", Cmd.Flags().Lookup("from"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	Cmd.Flags().String("txid", "", "TX ID of UTXO to split")
+	err = viper.BindPFlag("txid", Cmd.Flags().Lookup("txid"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	Cmd.Flags().Uint32("vout", 0, "UTXO position")
+	err = viper.BindPFlag("vout", Cmd.Flags().Lookup("vout"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	Cmd.Flags().Bool("dryrun", false, "Whether or not to submit the splitting tx")
+	err = viper.BindPFlag("dryrun", Cmd.Flags().Lookup("dryrun"))
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/broadcaster-cli/app/utxos/utxos.go
+++ b/cmd/broadcaster-cli/app/utxos/utxos.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/app/utxos/broadcast"
 	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/app/utxos/consolidate"
 	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/app/utxos/create"
+	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/app/utxos/split"
 	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var Cmd = &cobra.Command{
@@ -56,7 +58,14 @@ func init() {
 		log.Fatal(err)
 	}
 
+	Cmd.PersistentFlags().Int("satoshis", 0, "Nr of satoshis per output outputs")
+	err = viper.BindPFlag("satoshis", Cmd.PersistentFlags().Lookup("satoshis"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	Cmd.AddCommand(create.Cmd)
 	Cmd.AddCommand(broadcast.Cmd)
 	Cmd.AddCommand(consolidate.Cmd)
+	Cmd.AddCommand(split.Cmd)
 }

--- a/cmd/broadcaster-cli/helper/functions.go
+++ b/cmd/broadcaster-cli/helper/functions.go
@@ -78,6 +78,16 @@ func GetUint64(settingName string) (uint64, error) {
 	return getSettingFromEnvFile[uint64](settingName)
 }
 
+func GetUint32(settingName string) (uint32, error) {
+
+	setting := viper.GetUint32(settingName)
+	if setting != 0 {
+		return setting, nil
+	}
+
+	return getSettingFromEnvFile[uint32](settingName)
+}
+
 func GetInt64(settingName string) (int64, error) {
 
 	setting := viper.GetInt64(settingName)
@@ -205,6 +215,28 @@ func GetKeySets() (map[string]*keyset.KeySet, error) {
 	}
 
 	return GetKeySetsFor(keys, selectedKeys)
+}
+
+func GetAllKeySets() (map[string]*keyset.KeySet, error) {
+	keys, err := GetPrivateKeys()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get private keys: %v", err)
+	}
+
+	if len(keys) == 0 {
+		return nil, errors.New("no keys given in configuration")
+	}
+	keySets := map[string]*keyset.KeySet{}
+
+	for name, key := range keys {
+		fundingKeySet, _, err := GetKeySetsXpriv(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get key set with name %s and value %s: %v", name, key, err)
+		}
+		keySets[name] = fundingKeySet
+	}
+
+	return keySets, nil
 }
 
 func GetOrderedKeys[T any](keysMap map[string]T) []string {

--- a/internal/broadcaster/rate_broadcaster.go
+++ b/internal/broadcaster/rate_broadcaster.go
@@ -11,9 +11,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	sdkTx "github.com/bitcoin-sv/go-sdk/transaction"
+
 	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
 	"github.com/bitcoin-sv/arc/pkg/keyset"
-	sdkTx "github.com/bitcoin-sv/go-sdk/transaction"
 )
 
 type UTXORateBroadcaster struct {
@@ -161,6 +162,10 @@ utxoLoop:
 			if utxo.Satoshis <= fee {
 				if len(b.utxoCh) == 0 {
 					return nil, errors.New("no utxos with sufficient funds left")
+				}
+
+				if len(b.utxoCh) < b.batchSize {
+					return nil, errors.New("not enough utxos with sufficient funds left for another batch")
 				}
 
 				continue

--- a/internal/broadcaster/utxo_consolidator.go
+++ b/internal/broadcaster/utxo_consolidator.go
@@ -11,9 +11,10 @@ import (
 	"sync"
 	"time"
 
+	sdkTx "github.com/bitcoin-sv/go-sdk/transaction"
+
 	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
 	"github.com/bitcoin-sv/arc/pkg/keyset"
-	sdkTx "github.com/bitcoin-sv/go-sdk/transaction"
 )
 
 type UTXOConsolidator struct {

--- a/internal/broadcaster/utxo_splitter.go
+++ b/internal/broadcaster/utxo_splitter.go
@@ -1,0 +1,108 @@
+package broadcaster
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+
+	sdkTx "github.com/bitcoin-sv/go-sdk/transaction"
+
+	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
+	"github.com/bitcoin-sv/arc/pkg/keyset"
+)
+
+type UTXOSplitter struct {
+	Broadcaster
+	fromKeySet *keyset.KeySet
+	toKeySets  []*keyset.KeySet
+}
+
+func NewUTXOSplitter(logger *slog.Logger, client ArcClient, fromKeySet *keyset.KeySet, toKeySets []*keyset.KeySet, isTestnet bool, opts ...func(p *Broadcaster)) (*UTXOSplitter, error) {
+	b, err := NewBroadcaster(logger, client, nil, isTestnet, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	creator := &UTXOSplitter{
+		Broadcaster: b,
+		toKeySets:   toKeySets,
+		fromKeySet:  fromKeySet,
+	}
+
+	return creator, nil
+}
+
+func (b *UTXOSplitter) SplitUtxo(txid string, satoshis uint64, vout uint32, dryrun bool) error {
+
+	toAddresses := make([]string, len(b.toKeySets))
+	for i, key := range b.toKeySets {
+		toAddresses[i] = key.Address(!b.isTestnet)
+	}
+
+	b.logger.Info("Splitting utxo", slog.String("txid", txid), slog.String("from", b.fromKeySet.Address(!b.isTestnet)), "to", toAddresses)
+
+	var err error
+	txIDBytes, err := hex.DecodeString(txid)
+	if err != nil {
+		return fmt.Errorf("failed to decode txid: %w", err)
+	}
+
+	utxo := &sdkTx.UTXO{
+		TxID:          txIDBytes,
+		Vout:          vout,
+		LockingScript: b.fromKeySet.Script,
+		Satoshis:      satoshis,
+	}
+
+	tx := sdkTx.NewTransaction()
+	err = tx.AddInputsFromUTXOs(utxo)
+	if err != nil {
+		return err
+	}
+
+	totalLength := len(b.toKeySets)
+	payPerKeyset := satoshis / uint64(totalLength)
+
+	var fee uint64
+	for i, toKs := range b.toKeySets {
+
+		if i == len(b.toKeySets)-1 {
+			fee, err = b.feeModel.ComputeFee(tx)
+			if err != nil {
+				return err
+			}
+
+			err = PayTo(tx, toKs.Script, payPerKeyset-fee)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		err = PayTo(tx, toKs.Script, payPerKeyset)
+		if err != nil {
+			return fmt.Errorf("failed to pay keyset address %s: %w", toKs.Address(!b.isTestnet), err)
+		}
+	}
+
+	err = SignAllInputs(tx, b.fromKeySet.PrivateKey)
+	if err != nil {
+		return err
+	}
+
+	b.logger.Info("Splitting tx", slog.String("txid", tx.TxID()), slog.String("rawTx", tx.String()))
+	if dryrun {
+		return nil
+	}
+
+	b.logger.Info("Submit splitting tx", slog.String("txid", tx.TxID()))
+
+	resp, err := b.client.BroadcastTransaction(b.ctx, tx, metamorph_api.Status_SEEN_ON_NETWORK, "")
+	if err != nil {
+		return fmt.Errorf("failed to broadcast transaction: %w", err)
+	}
+
+	b.logger.Info("Splitting tx submitted", slog.String("txid", tx.TxID()), slog.String("status", resp.Status.String()))
+
+	return nil
+}

--- a/internal/broadcaster/utxo_splitter_test.go
+++ b/internal/broadcaster/utxo_splitter_test.go
@@ -1,0 +1,103 @@
+package broadcaster_test
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	sdkTx "github.com/bitcoin-sv/go-sdk/transaction"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitcoin-sv/arc/internal/broadcaster"
+	"github.com/bitcoin-sv/arc/internal/broadcaster/mocks"
+	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
+	"github.com/bitcoin-sv/arc/pkg/keyset"
+)
+
+func TestSplitUtxo(t *testing.T) {
+
+	tt := []struct {
+		name                     string
+		broadcastTransactionsErr error
+		dryRun                   bool
+
+		expectedErrorStr                  string
+		expectedBroadcastTransactionCalls int
+	}{
+		{
+			name: "success",
+
+			expectedBroadcastTransactionCalls: 1,
+		},
+		{
+			name:   "success - dry run",
+			dryRun: true,
+
+			expectedBroadcastTransactionCalls: 0,
+		},
+		{
+			name:                     "error - failed to broadcast transaction",
+			broadcastTransactionsErr: errors.New("error"),
+
+			expectedBroadcastTransactionCalls: 0,
+			expectedErrorStr:                  "failed to broadcast transaction",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			fromKs, err := keyset.New()
+			require.NoError(t, err)
+
+			toKs1, err := keyset.New()
+			require.NoError(t, err)
+			toKs2, err := keyset.New()
+			require.NoError(t, err)
+			toKs3, err := keyset.New()
+			require.NoError(t, err)
+
+			logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			client := &mocks.ArcClientMock{
+				BroadcastTransactionFunc: func(ctx context.Context, tx *sdkTx.Transaction, waitForStatus metamorph_api.Status, callbackURL string) (*metamorph_api.TransactionStatus, error) {
+
+					require.Len(t, tx.Outputs, 3)
+					require.Equal(t, uint64(500), tx.Outputs[0].Satoshis)
+					require.Equal(t, uint64(500), tx.Outputs[1].Satoshis)
+					require.Equal(t, uint64(499), tx.Outputs[2].Satoshis)
+					require.Equal(t, toKs1.Script, tx.Outputs[0].LockingScript)
+					require.Equal(t, toKs2.Script, tx.Outputs[1].LockingScript)
+					require.Equal(t, toKs3.Script, tx.Outputs[2].LockingScript)
+
+					require.Len(t, tx.Inputs, 1)
+
+					txIDBytes, err := hex.DecodeString("842f1acda7a169f388765af73733dd3188e8c1cc52baa78fdac4279d53d98911")
+					require.NoError(t, err)
+					require.Equal(t, txIDBytes, tx.Inputs[0].SourceTXID)
+
+					return &metamorph_api.TransactionStatus{
+						Txid:   tx.TxID(),
+						Status: metamorph_api.Status_SEEN_ON_NETWORK,
+					}, tc.broadcastTransactionsErr
+				},
+			}
+
+			toKeySets := []*keyset.KeySet{toKs1, toKs2, toKs3}
+
+			splitter, err := broadcaster.NewUTXOSplitter(logger, client, fromKs, toKeySets, false)
+			require.NoError(t, err)
+
+			err = splitter.SplitUtxo("842f1acda7a169f388765af73733dd3188e8c1cc52baa78fdac4279d53d98911", 1500, 0, tc.dryRun)
+			if tc.expectedErrorStr != "" || err != nil {
+				require.ErrorContains(t, err, tc.expectedErrorStr)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expectedBroadcastTransactionCalls, len(client.BroadcastTransactionCalls()))
+		})
+	}
+}


### PR DESCRIPTION
## Description of Changes

- Add feature to broadcaster-cli which allows to split satoshis from one key to other keys for further performance testing

## Testing Procedure

How to run
e.g.
```
broadcaster-cli utxos split --txid=cf111f19bcfb6baab7fc200f0f8fb669dd6c66fd9de212becb0950c92a0b6c40 --satoshis=21953 --vout=0 --from=key-20 --keys=key-28 --dryrun
```

- [X] I have added new unit tests
- [X] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
