### PR TITLE
fix: fix e2e tests

### DIFF
--- a/cmd/arc/services/blocktx.go
+++ b/cmd/arc/services/blocktx.go
@@ -27,6 +27,7 @@ const (
 )
 
 func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), error) {
+	logger = logger.With(slog.String("service", "blocktx"))
 	tracingEnabled := arcConfig.Tracing != nil
 	btxConfig := arcConfig.Blocktx
 
@@ -106,7 +107,7 @@ func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), err
 		pmOpts = append(pmOpts, p2p.WithRestartUnhealthyPeers())
 	}
 
-	pm := p2p.NewPeerManager(logger, network, pmOpts...)
+	pm := p2p.NewPeerManager(logger.With(slog.String("module", "peer-mng")), network, pmOpts...)
 	peers := make([]p2p.PeerI, len(arcConfig.Peers))
 
 	peerHandler := blocktx.NewPeerHandler(logger, blockRequestCh, blockProcessCh)
@@ -116,7 +117,8 @@ func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), err
 		if err != nil {
 			return nil, fmt.Errorf("error getting peer url: %v", err)
 		}
-		peer, err := p2p.NewPeer(logger, peerURL, peerHandler, network, peerOpts...)
+
+		peer, err := p2p.NewPeer(logger.With(slog.String("module", "peer")), peerURL, peerHandler, network, peerOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("error creating peer %s: %v", peerURL, err)
 		}

--- a/cmd/arc/services/metamorph.go
+++ b/cmd/arc/services/metamorph.go
@@ -245,8 +245,6 @@ func NewMetamorphStore(dbConfig *config.DbConfig) (s store.MetamorphStore, err e
 }
 
 func initPeerManager(logger *slog.Logger, s store.MetamorphStore, arcConfig *config.ArcConfig) (p2p.PeerManagerI, *metamorph.PeerHandler, chan *metamorph.PeerTxMessage, error) {
-	logger = logger.With(slog.String("module", "mtm-peer-handler"))
-
 	network, err := config.GetNetwork(arcConfig.Network)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get network: %v", err)
@@ -260,7 +258,7 @@ func initPeerManager(logger *slog.Logger, s store.MetamorphStore, arcConfig *con
 		pmOpts = append(pmOpts, p2p.WithRestartUnhealthyPeers())
 	}
 
-	pm := p2p.NewPeerManager(logger, network, pmOpts...)
+	pm := p2p.NewPeerManager(logger.With(slog.String("module", "peer-handler")), network, pmOpts...)
 
 	peerHandler := metamorph.NewPeerHandler(s, messageCh)
 
@@ -279,7 +277,7 @@ func initPeerManager(logger *slog.Logger, s store.MetamorphStore, arcConfig *con
 		}
 
 		var peer *p2p.Peer
-		peer, err = p2p.NewPeer(logger, peerUrl, peerHandler, network, peerOpts...)
+		peer, err = p2p.NewPeer(logger.With(slog.String("module", "peer")), peerUrl, peerHandler, network, peerOpts...)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("error creating peer %s: %v", peerUrl, err)
 		}

--- a/test/config/bitcoin.conf
+++ b/test/config/bitcoin.conf
@@ -83,7 +83,7 @@ blockreconstructionextratxn=100000
 #par=<n>
 
 #Threshold for disconnecting misbehaving peers (default: 100)
-#banscore=<n>
+banscore=10000
 
 #Number of seconds to keep misbehaving peers from reconnecting (default: 86400)
 #bantime=<n>

--- a/test/submit_single_test.go
+++ b/test/submit_single_test.go
@@ -86,7 +86,7 @@ func TestSubmitSingle(t *testing.T) {
 
 			t.Logf("Transaction status: %s", statusResponse.TxStatus)
 
-			generate(t, 10)
+			generate(t, 1)
 
 			statusResponse = getRequest[TransactionResponse](t, statusUrl)
 			require.Equal(t, Status_MINED, statusResponse.TxStatus)
@@ -191,7 +191,7 @@ func TestSubmitQueued(t *testing.T) {
 			}
 		}
 
-		generate(t, 10)
+		generate(t, 1)
 
 	checkMinedLoop:
 		for {
@@ -307,7 +307,7 @@ func TestCallback(t *testing.T) {
 			}
 
 			// mine trasactions
-			generate(t, 2)
+			generate(t, 1)
 
 			// then
 


### PR DESCRIPTION
## Description of Changes

Fix e2e tests.
1. fixing misleading logs in `blocktx` and `metamorph` services that lead to confusion during analysis. The logs are now more precise and readable
eg.:
<img width="1628" alt="image" src="https://github.com/user-attachments/assets/c88c7dea-9106-4185-8c50-e8240bb29f81">
vs.
<img width="1298" alt="image" src="https://github.com/user-attachments/assets/6d2e11c4-d291-4e56-bce9-84c6b9ccde17">

2. standardizing logs in the `blocktx` service

3. resolved an issue with incorrect transaction statuses in tests, which was caused by the `metamorph` services being banned by the test nodes:
![image](https://github.com/user-attachments/assets/4b71073e-6ec9-4f00-9a3a-c82b865ce868)

4. fixing sporadic hazard behavior issues in tests that sometimes caused unpredictable behavior in e2e tests. The tests should now run more stably and deterministically

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
