### PR TITLE
Callback object documentation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -99,19 +99,7 @@ Metamorph is a microservice that is responsible for processing transactions sent
 
 The Callbacker is a microservice responsible for handling all registered callbacks. It sends a `POST` request to the specified URL, including a `Bearer token` in the `Authorization` header when required.
 
-Below is an example of a callback request body:
-
-```json
-{
-  "blockHash": "0000000000000000064cbaac5cedf71a5447771573ba585501952c023873817b",
-  "blockHeight": 837394,
-  "extraInfo": null,
-  "merklePath": "fe12c70c000c020a008d1c719355d718dad0ccc...",
-  "timestamp": "2024-03-26T16:02:29.655390092Z",
-  "txStatus": "MINED",
-  "txid": "48ccf56b16ec11ddd9cfafc4f28492fb7e989d58594a0acd150a1592570ccd13"
-}
-```
+The specification of the callback object with different examples can be found [here](https://github.com/bitcoin-sv/arc/blob/main/doc/api.md#callback)
 
 To prevent DDoS attacks on callback receivers, the Callbacker service instance sends callbacks to the specified URLs in a serial (sequential) manner, ensuring only one request is sent at a time.
 
@@ -541,7 +529,7 @@ The "Cumulative Fee Validation" feature is designed to check if the chain of unm
 
 ### Usage
 
-To use the "Cumulative Fee Validation" feature, you need to send the `X-CumulativeFeeValidation` header with the value set to `true`. 
+To use the "Cumulative Fee Validation" feature, you need to send the `X-CumulativeFeeValidation` header with the value set to `true`.
 
 Example usage:
 ```

--- a/doc/api.md
+++ b/doc/api.md
@@ -1103,6 +1103,67 @@ BearerAuth, None, None
 
 # Schemas
 
+<h2 id="tocS_Callback">Callback</h2>
+<!-- backwards compatibility -->
+<a id="schemacallback"></a>
+<a id="schema_Callback"></a>
+<a id="tocScallback"></a>
+<a id="tocscallback"></a>
+
+```json
+[
+  {
+    "mined": null,
+    "summary": "Transaction mined",
+    "value": {
+      "timestamp": "2024-03-26T16:02:29.655390092Z",
+      "txid": "48ccf56b16ec11ddd9cfafc4f28492fb7e989d58594a0acd150a1592570ccd13",
+      "txStatus": "MINED",
+      "merklePath": "fe12c70c000c020a008d1c719355d718dad0ccc...",
+      "blockHash": "0000000000000000064cbaac5cedf71a5447771573ba585501952c023873817b",
+      "blockHeight": 837394
+    }
+  },
+  {
+    "seen on network": null,
+    "summary": "Transaction seen on network",
+    "value": {
+      "timestamp": "2024-03-26T16:02:29.655390092Z",
+      "txid": "507e8fb791d37c5da9c6f37a66524d6c8237d9e05d55b6cfa2bed74234d68deb",
+      "txStatus": "SEEN_ON_NETWORK"
+    }
+  },
+  {
+    "double spend attempted": null,
+    "summary": "Transaction with one or more competing transactions",
+    "value": {
+      "timestamp": "2024-03-26T16:02:29.655390092Z",
+      "competingTxs": [
+        "505097ba93702491a8a8e5c195a3d2706baf9d43af5e8898aeace0e251f240d2"
+      ],
+      "txid": "3d7770a2c3bbf890fe69ad33faadd3efb470b60d05b071eaa86e6597d480e111",
+      "txStatus": "DOUBLE_SPEND_ATTEMPTED"
+    }
+  }
+]
+
+```
+
+callback object
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|timestamp|string|true|none|none|
+|txid|string|true|none|none|
+|txStatus|string|true|none|none|
+|extraInfo|string¦null|false|none|none|
+|competingTxs|[string]|false|none|none|
+|merklePath|string¦null|false|none|none|
+|blockHash|string¦null|false|none|none|
+|blockHeight|integer¦null|false|none|none|
+
 <h2 id="tocS_CommonResponse">CommonResponse</h2>
 <!-- backwards compatibility -->
 <a id="schemacommonresponse"></a>

--- a/doc/arc.json
+++ b/doc/arc.json
@@ -625,6 +625,85 @@
   },
   "components": {
     "schemas": {
+      "Callback": {
+        "type": "object",
+        "description": "callback object",
+        "required": [
+          "timestamp",
+          "txid",
+          "txStatus"
+        ],
+        "properties": {
+          "timestamp": {
+            "type": "string"
+          },
+          "txid": {
+            "type": "string",
+            "nullable": false
+          },
+          "txStatus": {
+            "type": "string",
+            "nullable": false
+          },
+          "extraInfo": {
+            "type": "string",
+            "nullable": true
+          },
+          "competingTxs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "merklePath": {
+            "type": "string",
+            "nullable": true
+          },
+          "blockHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "blockHeight": {
+            "type": "integer",
+            "nullable": true
+          }
+        },
+        "example": [
+          {
+            "mined": null,
+            "summary": "Transaction mined",
+            "value": {
+              "timestamp": "2024-03-26T16:02:29.655390092Z",
+              "txid": "48ccf56b16ec11ddd9cfafc4f28492fb7e989d58594a0acd150a1592570ccd13",
+              "txStatus": "MINED",
+              "merklePath": "fe12c70c000c020a008d1c719355d718dad0ccc...",
+              "blockHash": "0000000000000000064cbaac5cedf71a5447771573ba585501952c023873817b",
+              "blockHeight": 837394
+            }
+          },
+          {
+            "seen on network": null,
+            "summary": "Transaction seen on network",
+            "value": {
+              "timestamp": "2024-03-26T16:02:29.655390092Z",
+              "txid": "507e8fb791d37c5da9c6f37a66524d6c8237d9e05d55b6cfa2bed74234d68deb",
+              "txStatus": "SEEN_ON_NETWORK"
+            }
+          },
+          {
+            "double spend attempted": null,
+            "summary": "Transaction with one or more competing transactions",
+            "value": {
+              "timestamp": "2024-03-26T16:02:29.655390092Z",
+              "competingTxs": [
+                "505097ba93702491a8a8e5c195a3d2706baf9d43af5e8898aeace0e251f240d2"
+              ],
+              "txid": "3d7770a2c3bbf890fe69ad33faadd3efb470b60d05b071eaa86e6597d480e111",
+              "txStatus": "DOUBLE_SPEND_ATTEMPTED"
+            }
+          }
+        ]
+      },
       "CommonResponse": {
         "type": "object",
         "required": [

--- a/internal/callbacker/store/postgresql/postgres_test.go
+++ b/internal/callbacker/store/postgresql/postgres_test.go
@@ -10,15 +10,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bitcoin-sv/arc/internal/callbacker/store"
-	testutils "github.com/bitcoin-sv/arc/internal/test_utils"
-	"github.com/bitcoin-sv/arc/internal/testdata"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
 
-	_ "github.com/golang-migrate/migrate/v4/source/file"
-
+	"github.com/bitcoin-sv/arc/internal/callbacker/store"
 	tutils "github.com/bitcoin-sv/arc/internal/callbacker/store/postgresql/internal/tests"
+	testutils "github.com/bitcoin-sv/arc/internal/test_utils"
+	"github.com/bitcoin-sv/arc/internal/testdata"
 )
 
 const (
@@ -216,7 +215,8 @@ func TestPostgresDBt(t *testing.T) {
 			records, ok := rm.Load(i)
 			require.True(t, ok)
 
-			callbacks := records.([]*store.CallbackData)
+			callbacks, ok := records.([]*store.CallbackData)
+			require.True(t, ok)
 			require.Equal(t, popLimit, len(callbacks))
 		}
 	})

--- a/internal/woc_client/woc_client_test.go
+++ b/internal/woc_client/woc_client_test.go
@@ -2,13 +2,18 @@ package woc_client
 
 import (
 	"context"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	sdkTx "github.com/bitcoin-sv/go-sdk/transaction"
 	"github.com/stretchr/testify/require"
 )
 
-const testnet_addr = "miGidJu3HrpGuFxhF7gCg1yV13AJzANz4P"
+const testnetAddr = "miGidJu3HrpGuFxhF7gCg1yV13AJzANz4P"
 
 func Test_New(t *testing.T) {
 	tcs := []struct {
@@ -19,19 +24,24 @@ func Test_New(t *testing.T) {
 		{
 			name:                "client for mainnet",
 			useMainnet:          true,
-			expectedRequestPath: "/v1/bsv/main/",
+			expectedRequestPath: "/main/",
 		},
 		{
 			name:                "client for testnet",
 			useMainnet:          false,
-			expectedRequestPath: "/v1/bsv/test/",
+			expectedRequestPath: "/test/",
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer svr.Close()
+
 			// given
-			sut := New(tc.useMainnet)
+			sut := New(tc.useMainnet, WithURL(svr.URL))
 
 			// when
 			httpReq, err := sut.httpRequest(context.TODO(), "GET", "", nil)
@@ -60,8 +70,13 @@ func Test_WithAuth(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer svr.Close()
+
 			// given
-			sut := New(false, WithAuth(tc.apiKey))
+			sut := New(false, WithURL(svr.URL), WithAuth(tc.apiKey))
 
 			// when
 			httpReq, err := sut.httpRequest(context.TODO(), "GET", "", nil)
@@ -85,15 +100,83 @@ func Test_GetUTXOs(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	// given
-	sut := New(false)
-
-	// when
-	res, err := sut.GetUTXOs(context.TODO(), nil, testnet_addr)
-
-	// then
+	txIDbytes, err := hex.DecodeString("4a2992fa3af9eb7ff6b94dc9e27e44f29a54ab351ee6377455409b0ebbe1f00c")
 	require.NoError(t, err)
-	require.NotNil(t, res)
+
+	tt := []struct {
+		name         string
+		responseOk   bool
+		responseBody any
+
+		expectedError error
+		expected      sdkTx.UTXOs
+	}{
+		{
+			name:       "response OK",
+			responseOk: true,
+			responseBody: []*wocUtxo{
+				{
+					Txid:     "4a2992fa3af9eb7ff6b94dc9e27e44f29a54ab351ee6377455409b0ebbe1f00c",
+					Vout:     1,
+					Height:   2,
+					Satoshis: 4,
+				},
+			},
+
+			expected: sdkTx.UTXOs{{
+				TxID:     txIDbytes,
+				Vout:     1,
+				Satoshis: 4,
+			}},
+		},
+		{
+			name:       "response not OK",
+			responseOk: false,
+
+			expectedError: ErrWOCResponseNotOK,
+		},
+		{
+			name:         "response not OK",
+			responseOk:   true,
+			responseBody: "not a WoC UTXO",
+
+			expectedError: ErrWOCFailedToDecodeResponse,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.responseOk {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusBadRequest)
+				}
+
+				jsonResp, err := json.Marshal(tc.responseBody)
+				require.NoError(t, err)
+				_, err = w.Write(jsonResp)
+				require.NoError(t, err)
+			}))
+			defer svr.Close()
+
+			// given
+			sut := New(false, WithURL(svr.URL))
+
+			// when
+			actual, err := sut.GetUTXOs(context.TODO(), nil, testnetAddr)
+
+			// then
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expected, actual)
+		})
+	}
 }
 
 func Test_GetBalance(t *testing.T) {
@@ -101,14 +184,63 @@ func Test_GetBalance(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	// given
-	sut := New(false)
+	tt := []struct {
+		name       string
+		responseOk bool
 
-	// when
-	_, _, err := sut.GetBalance(context.TODO(), testnet_addr)
+		expectedError error
+	}{
+		{
+			name:       "response OK",
+			responseOk: true,
+		},
+		{
+			name:       "response not OK",
+			responseOk: false,
 
-	// then
-	require.NoError(t, err)
+			expectedError: ErrWOCResponseNotOK,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				resp := make(map[string]any)
+				if tc.responseOk {
+					w.WriteHeader(http.StatusOK)
+					resp["confirmed"] = 1
+					resp["unconfirmed"] = 2
+				} else {
+					w.WriteHeader(http.StatusBadRequest)
+				}
+
+				jsonResp, err := json.Marshal(resp)
+				require.NoError(t, err)
+				_, err = w.Write(jsonResp)
+				require.NoError(t, err)
+			}))
+			defer svr.Close()
+
+			// given
+			sut := New(false, WithURL(svr.URL))
+
+			// when
+			actualConfirmed, actualUnconfirmed, err := sut.GetBalance(context.TODO(), testnetAddr)
+
+			// then
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, int64(1), actualConfirmed)
+			require.Equal(t, int64(2), actualUnconfirmed)
+
+		})
+	}
 }
 
 func Test_TopUp(t *testing.T) {
@@ -116,29 +248,66 @@ func Test_TopUp(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	t.Run("use on testnet", func(t *testing.T) {
-		// given
-		sut := New(false)
+	tt := []struct {
+		name       string
+		responseOk bool
+		mainnet    bool
 
-		// when
-		err := sut.TopUp(context.TODO(), testnet_addr)
+		expectedError error
+	}{
+		{
+			name:       "response OK",
+			responseOk: true,
+		},
+		{
+			name:       "response not OK",
+			responseOk: false,
 
-		// then
-		require.NoError(t, err)
-	})
+			expectedError: ErrWOCResponseNotOK,
+		},
+		{
+			name:       "not testnet",
+			mainnet:    true,
+			responseOk: true,
 
-	t.Run("try use on mainnet - should fail", func(t *testing.T) {
-		// given
-		const useOnMainnet = true
-		sut := New(useOnMainnet)
+			expectedError: ErrWOCFailedToTopUp,
+		},
+	}
 
-		// when
-		err := sut.TopUp(context.TODO(), testnet_addr)
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				resp := make(map[string]any)
+				if tc.responseOk {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusBadRequest)
+				}
 
-		// then
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrWOCFailedToTopUp)
-	})
+				jsonResp, err := json.Marshal(resp)
+				require.NoError(t, err)
+
+				_, err = w.Write(jsonResp)
+				require.NoError(t, err)
+
+			}))
+			defer svr.Close()
+
+			// given
+			sut := New(tc.mainnet, WithURL(svr.URL))
+
+			// when
+			err := sut.TopUp(context.TODO(), testnetAddr)
+
+			// then
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func Test_GetRawTxs(t *testing.T) {
@@ -146,20 +315,84 @@ func Test_GetRawTxs(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
-	// given
-	sut := New(false)
-
-	const idsCount = 37
-	ids := make([]string, idsCount)
-	for i := 0; i < idsCount; i++ {
-		ids[i] = fmt.Sprintf("id%d", i)
+	rawTx := &wocRawTx{
+		TxID:          "2d5d5def1dcf8304fdd44ecc6e645997b67dc4c5e6310df4bf5286f960c6afb3",
+		BlockHash:     "0000000000000aac89fbed163ed60061ba33bc0ab9de8e7fd8b34ad94c2414cd",
+		BlockHeight:   10,
+		Confirmations: 5,
 	}
 
-	// when
-	res, err := sut.GetRawTxs(context.TODO(), ids)
+	tt := []struct {
+		name         string
+		responseOk   bool
+		responseBody any
 
-	// then
-	require.NoError(t, err)
-	require.NotNil(t, res)
+		expectedError error
+		expected      []*wocRawTx
+	}{
+		{
+			name:       "response OK",
+			responseOk: true,
+			responseBody: []*wocRawTx{
+				rawTx, rawTx, rawTx, rawTx,
+			},
+
+			expected: []*wocRawTx{rawTx, rawTx, rawTx, rawTx, rawTx, rawTx, rawTx, rawTx},
+		},
+		{
+			name:       "response not OK",
+			responseOk: false,
+
+			expectedError: ErrWOCResponseNotOK,
+		},
+		{
+			name:         "response not OK",
+			responseOk:   true,
+			responseBody: "not a WoC raw TX",
+
+			expectedError: ErrWOCFailedToDecodeRawTxs,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.responseOk {
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusBadRequest)
+				}
+
+				jsonResp, err := json.Marshal(tc.responseBody)
+				require.NoError(t, err)
+
+				_, err = w.Write(jsonResp)
+				require.NoError(t, err)
+
+			}))
+			defer svr.Close()
+
+			// given
+			sut := New(false, WithURL(svr.URL), WithMaxNumIDs(4))
+
+			const idsCount = 8
+			ids := make([]string, idsCount)
+			for i := 0; i < idsCount; i++ {
+				ids[i] = fmt.Sprintf("id%d", i)
+			}
+
+			// when
+			actual, err := sut.GetRawTxs(context.TODO(), ids)
+
+			// then
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expected, actual)
+		})
+	}
 
 }

--- a/pkg/api/arc.json
+++ b/pkg/api/arc.json
@@ -625,6 +625,85 @@
   },
   "components": {
     "schemas": {
+      "Callback": {
+        "type": "object",
+        "description": "callback object",
+        "required": [
+          "timestamp",
+          "txid",
+          "txStatus"
+        ],
+        "properties": {
+          "timestamp": {
+            "type": "string"
+          },
+          "txid": {
+            "type": "string",
+            "nullable": false
+          },
+          "txStatus": {
+            "type": "string",
+            "nullable": false
+          },
+          "extraInfo": {
+            "type": "string",
+            "nullable": true
+          },
+          "competingTxs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "merklePath": {
+            "type": "string",
+            "nullable": true
+          },
+          "blockHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "blockHeight": {
+            "type": "integer",
+            "nullable": true
+          }
+        },
+        "example": [
+          {
+            "mined": null,
+            "summary": "Transaction mined",
+            "value": {
+              "timestamp": "2024-03-26T16:02:29.655390092Z",
+              "txid": "48ccf56b16ec11ddd9cfafc4f28492fb7e989d58594a0acd150a1592570ccd13",
+              "txStatus": "MINED",
+              "merklePath": "fe12c70c000c020a008d1c719355d718dad0ccc...",
+              "blockHash": "0000000000000000064cbaac5cedf71a5447771573ba585501952c023873817b",
+              "blockHeight": 837394
+            }
+          },
+          {
+            "seen on network": null,
+            "summary": "Transaction seen on network",
+            "value": {
+              "timestamp": "2024-03-26T16:02:29.655390092Z",
+              "txid": "507e8fb791d37c5da9c6f37a66524d6c8237d9e05d55b6cfa2bed74234d68deb",
+              "txStatus": "SEEN_ON_NETWORK"
+            }
+          },
+          {
+            "double spend attempted": null,
+            "summary": "Transaction with one or more competing transactions",
+            "value": {
+              "timestamp": "2024-03-26T16:02:29.655390092Z",
+              "competingTxs": [
+                "505097ba93702491a8a8e5c195a3d2706baf9d43af5e8898aeace0e251f240d2"
+              ],
+              "txid": "3d7770a2c3bbf890fe69ad33faadd3efb470b60d05b071eaa86e6597d480e111",
+              "txStatus": "DOUBLE_SPEND_ATTEMPTED"
+            }
+          }
+        ]
+      },
       "CommonResponse": {
         "type": "object",
         "required": [

--- a/pkg/api/arc.yaml
+++ b/pkg/api/arc.yaml
@@ -409,6 +409,69 @@ paths:
 
 components:
   schemas:
+    Callback:
+      type: object
+      description: callback object
+      required:
+        - timestamp
+        - txid
+        - txStatus
+      properties:
+        timestamp:
+          type: string
+        txid:
+          type: string
+          nullable: false
+        txStatus:
+          type: string
+          nullable: false
+        extraInfo:
+          type: string
+          nullable: true
+        competingTxs:
+          type: array
+          items:
+            type: string
+        merklePath:
+          type: string
+          nullable: true
+        blockHash:
+          type: string
+          nullable: true
+        blockHeight:
+          type: integer
+          nullable: true
+      example:
+        - mined:
+          summary: Transaction mined
+          value:
+            {
+              "timestamp": "2024-03-26T16:02:29.655390092Z",
+              "txid": "48ccf56b16ec11ddd9cfafc4f28492fb7e989d58594a0acd150a1592570ccd13",
+              "txStatus": "MINED",
+              "merklePath": "fe12c70c000c020a008d1c719355d718dad0ccc...",
+              "blockHash": "0000000000000000064cbaac5cedf71a5447771573ba585501952c023873817b",
+              "blockHeight": 837394
+            }
+        - seen on network:
+          summary: Transaction seen on network
+          value:
+            {
+              "timestamp": "2024-03-26T16:02:29.655390092Z",
+              "txid": "507e8fb791d37c5da9c6f37a66524d6c8237d9e05d55b6cfa2bed74234d68deb",
+              "txStatus": "SEEN_ON_NETWORK"
+            }
+        - double spend attempted:
+          summary: Transaction with one or more competing transactions
+          value:
+            {
+              "timestamp": "2024-03-26T16:02:29.655390092Z",
+              "competingTxs": [
+                "505097ba93702491a8a8e5c195a3d2706baf9d43af5e8898aeace0e251f240d2"
+              ],
+              "txid": "3d7770a2c3bbf890fe69ad33faadd3efb470b60d05b071eaa86e6597d480e111",
+              "txStatus": "DOUBLE_SPEND_ATTEMPTED"
+            }
     # Common response object
     CommonResponse:
       type: object


### PR DESCRIPTION
## Description of Changes

- Add callback object specification with examples to `arc.yaml`
- Reference this specification in `README.md`
- Unrelated change: Use `httptest` for test of WoC client `TopUp` function as the previous test failed repeatedly

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
