### PR TITLE
ARCO-174: add size-jitter flag

### DIFF
--- a/cmd/broadcaster-cli/app/utxos/broadcast/broadcast.go
+++ b/cmd/broadcaster-cli/app/utxos/broadcast/broadcast.go
@@ -105,6 +105,11 @@ var Cmd = &cobra.Command{
 			return err
 		}
 
+		maxSize, err := helper.GetInt("size-jitter")
+		if err != nil {
+			return err
+		}
+
 		logger := helper.GetLogger()
 
 		client, err := helper.CreateClient(&broadcaster.Auth{
@@ -122,6 +127,7 @@ var Cmd = &cobra.Command{
 			broadcaster.WithFullstatusUpdates(fullStatusUpdates),
 			broadcaster.WithBatchSize(batchSize),
 			broadcaster.WithOpReturn(opReturn),
+			broadcaster.WithSizeJitter(maxSize),
 		}
 
 		if waitForStatus > 0 {
@@ -208,6 +214,12 @@ func init() {
 
 	Cmd.Flags().String("opReturn", "", "Text which will be added to an OP_RETURN output. If empty, no OP_RETURN output will be added")
 	err = viper.BindPFlag("opReturn", Cmd.Flags().Lookup("opReturn"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	Cmd.Flags().Int("size-jitter", 0, "Enable the option to randomise the transaction size, the parameter specifies the maximum size of bytes that will be added to OP_RETURN")
+	err = viper.BindPFlag("size-jitter", Cmd.Flags().Lookup("size-jitter"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/broadcaster/broadcaster.go
+++ b/internal/broadcaster/broadcaster.go
@@ -41,6 +41,7 @@ type Broadcaster struct {
 	batchSize         int
 	waitForStatus     metamorph_api.Status
 	opReturn          string
+	maxSize           int
 }
 
 func WithBatchSize(batchSize int) func(broadcaster *Broadcaster) {
@@ -83,6 +84,12 @@ func WithFees(miningFeeSatPerKb int) func(broadcaster *Broadcaster) {
 func WithOpReturn(opReturn string) func(broadcaster *Broadcaster) {
 	return func(broadcaster *Broadcaster) {
 		broadcaster.opReturn = opReturn
+	}
+}
+
+func WithSizeJitter(maxSize int) func(broadcaster *Broadcaster) {
+	return func(broadcaster *Broadcaster) {
+		broadcaster.maxSize = maxSize
 	}
 }
 


### PR DESCRIPTION
## Description of Changes

Added new `size-jitter` flag which will  change the transactions size. This flag requires the max size parameter and then each transaction will have OP_RETURN added with random bytes in a random size (the maximum size is set by the parameter).

## Linked Issues / Tickets

ARCO-174

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
