### PR TITLE
refactor: Fix custom tx status metrics

### DIFF
--- a/cmd/arc/services/metamorph.go
+++ b/cmd/arc/services/metamorph.go
@@ -138,7 +138,7 @@ func StartMetamorph(logger *slog.Logger, arcConfig *config.ArcConfig, cacheStore
 		metamorph.WithSubmittedTxsChan(submittedTxsChan),
 		metamorph.WithProcessStatusUpdatesInterval(mtmConfig.ProcessStatusUpdateInterval),
 		metamorph.WithCallbackSender(callbacker),
-		metamorph.WithStatTimeLimits(mtmConfig.Stats.NotSeenTimeLimit, mtmConfig.Stats.NotMinedTimeLimit),
+		metamorph.WithStatTimeLimits(mtmConfig.Stats.NotSeenTimeLimit, mtmConfig.Stats.NotFinalTimeLimit),
 		metamorph.WithMaxRetries(mtmConfig.MaxRetries),
 		metamorph.WithMinimumHealthyConnections(mtmConfig.Health.MinimumHealthyConnections))
 

--- a/config/config.go
+++ b/config/config.go
@@ -159,7 +159,7 @@ type HealthConfig struct {
 
 type StatsConfig struct {
 	NotSeenTimeLimit  time.Duration `mapstructure:"notSeenTimeLimit"`
-	NotMinedTimeLimit time.Duration `mapstructure:"notMinedTimeLimit"`
+	NotFinalTimeLimit time.Duration `mapstructure:"notFinalTimeLimit"`
 }
 
 type APIConfig struct {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -101,7 +101,7 @@ func getMetamorphConfig() *MetamorphConfig {
 		RejectCallbackContaining: []string{"http://localhost", "https://localhost"},
 		Stats: &StatsConfig{
 			NotSeenTimeLimit:  10 * time.Minute,
-			NotMinedTimeLimit: 20 * time.Minute,
+			NotFinalTimeLimit: 20 * time.Minute,
 		},
 	}
 }

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -84,7 +84,7 @@ metamorph:
   rejectCallbackContaining: [ "http://localhost", "https://localhost" ]
   stats:
     notSeenTimeLimit: 10m # amount of time after storing at which a non-seen tx will be counted towards not seen stat
-    notMinedTimeLimit: 20m # amount of time after storing at which a seen but not mined tx will be counted towards not mined stat
+    notFinalTimeLimit: 20m # amount of time after storing at which a seen but not mined tx will be counted towards not mined stat
 
 blocktx:
   listenAddr: localhost:8011 # address space for blocktx to listen on. Can be for example localhost:8011 or :8011 for listening on all addresses

--- a/internal/metamorph/processor_options.go
+++ b/internal/metamorph/processor_options.go
@@ -11,9 +11,9 @@ import (
 	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
 )
 
-func WithStatTimeLimits(notSeenLimit time.Duration, notMinedLimit time.Duration) func(*Processor) {
+func WithStatTimeLimits(notSeenLimit time.Duration, notFinalLimit time.Duration) func(*Processor) {
 	return func(p *Processor) {
-		p.stats = newProcessorStats(WithLimits(notSeenLimit, notMinedLimit))
+		p.stats = newProcessorStats(WithLimits(notSeenLimit, notFinalLimit))
 	}
 }
 

--- a/internal/metamorph/store/postgresql/postgres_test.go
+++ b/internal/metamorph/store/postgresql/postgres_test.go
@@ -10,16 +10,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bitcoin-sv/arc/internal/blocktx/blocktx_api"
-	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
-	"github.com/bitcoin-sv/arc/internal/metamorph/store"
-	testutils "github.com/bitcoin-sv/arc/internal/test_utils"
-	"github.com/bitcoin-sv/arc/internal/testdata"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	_ "github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bitcoin-sv/arc/internal/blocktx/blocktx_api"
+	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
+	"github.com/bitcoin-sv/arc/internal/metamorph/store"
+	testutils "github.com/bitcoin-sv/arc/internal/test_utils"
+	"github.com/bitcoin-sv/arc/internal/testdata"
 )
 
 const (
@@ -714,7 +715,7 @@ func TestPostgresDB(t *testing.T) {
 		require.Equal(t, int64(1), res.StatusRejected)
 		require.Equal(t, int64(0), res.StatusSeenInOrphanMempool)
 		require.Equal(t, int64(1), res.StatusDoubleSpendAttempted)
-		require.Equal(t, int64(1), res.StatusNotMined)
+		require.Equal(t, int64(2), res.StatusNotFinal)
 		require.Equal(t, int64(2), res.StatusNotSeen)
 		require.Equal(t, int64(6), res.StatusMinedTotal)
 		require.Equal(t, int64(2), res.StatusSeenOnNetworkTotal)

--- a/internal/metamorph/store/store.go
+++ b/internal/metamorph/store/store.go
@@ -6,9 +6,10 @@ import (
 	"errors"
 	"time"
 
+	"github.com/libsv/go-p2p/chaincfg/chainhash"
+
 	"github.com/bitcoin-sv/arc/internal/blocktx/blocktx_api"
 	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
-	"github.com/libsv/go-p2p/chaincfg/chainhash"
 )
 
 var ErrNotFound = errors.New("key could not be found")
@@ -56,7 +57,7 @@ type Stats struct {
 	StatusRejected             int64
 	StatusMined                int64
 	StatusNotSeen              int64
-	StatusNotMined             int64
+	StatusNotFinal             int64
 	StatusSeenOnNetworkTotal   int64
 	StatusMinedTotal           int64
 }

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -74,7 +74,7 @@ metamorph:
   rejectCallbackContaining: [ "http://localhost", "https://localhost" ]
   stats:
     notSeenTimeLimit: 10m
-    notMinedTimeLimit: 20m
+    notFinalTimeLimit: 20m
 
 blocktx:
   listenAddr: 0.0.0.0:8011


### PR DESCRIPTION
## Description of Changes

- Replace `not mined` metric by `not final` metric as rejected is also a final status
- Exclude `SEEN_IN_ORPHAN_MEMPOOL` from not seen metric

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [X] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
