### PR TITLE
fix(ARCO-293): Fix conflict on mined transaction insert

### DIFF
--- a/internal/blocktx/store/postgresql/postgres_test.go
+++ b/internal/blocktx/store/postgresql/postgres_test.go
@@ -487,6 +487,7 @@ func TestPostgresStore_UpsertBlockTransactions(t *testing.T) {
 
 		expectedErr           error
 		expectedUpdatedResLen int
+		upsertRepeat          bool
 	}{
 		{
 			name: "upsert all registered transactions (updates only)",
@@ -547,9 +548,10 @@ func TestPostgresStore_UpsertBlockTransactions(t *testing.T) {
 			txsWithMerklePaths: []store.TxWithMerklePath{
 				{
 					Hash:       testutils.RevChainhash(t, "8b7d038db4518ac4c665abfc5aeaacbd2124ad8ca70daa8465ed2c4427c41b9b")[:],
-					MerklePath: "test1",
+					MerklePath: "test7",
 				},
 			},
+			upsertRepeat:          true,
 			expectedUpdatedResLen: 1,
 		},
 	}
@@ -568,6 +570,10 @@ func TestPostgresStore_UpsertBlockTransactions(t *testing.T) {
 
 			// when
 			res, err := sut.UpsertBlockTransactions(ctx, testBlockID, tc.txsWithMerklePaths)
+			if tc.upsertRepeat {
+				res, err = sut.UpsertBlockTransactions(ctx, testBlockID, tc.txsWithMerklePaths)
+				require.NoError(t, err)
+			}
 
 			// then
 			if tc.expectedErr != nil {

--- a/internal/blocktx/store/postgresql/postgres_test.go
+++ b/internal/blocktx/store/postgresql/postgres_test.go
@@ -489,6 +489,20 @@ func TestPostgresStore_UpsertBlockTransactions(t *testing.T) {
 		expectedUpdatedResLen int
 	}{
 		{
+			name: "upsert all registered transactions cause conflict with txid and blockid",
+			txsWithMerklePaths: []store.TxWithMerklePath{
+				{
+					Hash:       testutils.RevChainhash(t, "76732b80598326a18d3bf0a86518adbdf95d0ddc6ff6693004440f4776168c3b")[:],
+					MerklePath: "test1",
+				},
+				{
+					Hash:       testutils.RevChainhash(t, "76732b80598326a18d3bf0a86518adbdf95d0ddc6ff6693004440f4776168c3b")[:],
+					MerklePath: "test1",
+				},
+			},
+			expectedUpdatedResLen: 2,
+		},
+		{
 			name: "upsert all registered transactions (updates only)",
 			txsWithMerklePaths: []store.TxWithMerklePath{
 				{

--- a/internal/blocktx/store/postgresql/postgres_test.go
+++ b/internal/blocktx/store/postgresql/postgres_test.go
@@ -550,7 +550,7 @@ func TestPostgresStore_UpsertBlockTransactions(t *testing.T) {
 					MerklePath: "test1",
 				},
 			},
-			expectedUpdatedResLen: 2,
+			expectedUpdatedResLen: 1,
 		},
 	}
 

--- a/internal/blocktx/store/postgresql/postgres_test.go
+++ b/internal/blocktx/store/postgresql/postgres_test.go
@@ -546,11 +546,7 @@ func TestPostgresStore_UpsertBlockTransactions(t *testing.T) {
 			name: "upsert all registered transactions cause conflict with txid and blockid",
 			txsWithMerklePaths: []store.TxWithMerklePath{
 				{
-					Hash:       testutils.RevChainhash(t, "76732b80598326a18d3bf0a86518adbdf95d0ddc6ff6693004440f4776168c3a")[:],
-					MerklePath: "test1",
-				},
-				{
-					Hash:       testutils.RevChainhash(t, "76732b80598326a18d3bf0a86518adbdf95d0ddc6ff6693004440f4776168c3a")[:],
+					Hash:       testutils.RevChainhash(t, "8b7d038db4518ac4c665abfc5aeaacbd2124ad8ca70daa8465ed2c4427c41b9b")[:],
 					MerklePath: "test1",
 				},
 			},

--- a/internal/blocktx/store/postgresql/postgres_test.go
+++ b/internal/blocktx/store/postgresql/postgres_test.go
@@ -489,20 +489,6 @@ func TestPostgresStore_UpsertBlockTransactions(t *testing.T) {
 		expectedUpdatedResLen int
 	}{
 		{
-			name: "upsert all registered transactions cause conflict with txid and blockid",
-			txsWithMerklePaths: []store.TxWithMerklePath{
-				{
-					Hash:       testutils.RevChainhash(t, "76732b80598326a18d3bf0a86518adbdf95d0ddc6ff6693004440f4776168c3b")[:],
-					MerklePath: "test1",
-				},
-				{
-					Hash:       testutils.RevChainhash(t, "76732b80598326a18d3bf0a86518adbdf95d0ddc6ff6693004440f4776168c3b")[:],
-					MerklePath: "test1",
-				},
-			},
-			expectedUpdatedResLen: 2,
-		},
-		{
 			name: "upsert all registered transactions (updates only)",
 			txsWithMerklePaths: []store.TxWithMerklePath{
 				{
@@ -555,6 +541,20 @@ func TestPostgresStore_UpsertBlockTransactions(t *testing.T) {
 				},
 			},
 			expectedUpdatedResLen: 6,
+		},
+		{
+			name: "upsert all registered transactions cause conflict with txid and blockid",
+			txsWithMerklePaths: []store.TxWithMerklePath{
+				{
+					Hash:       testutils.RevChainhash(t, "76732b80598326a18d3bf0a86518adbdf95d0ddc6ff6693004440f4776168c3a")[:],
+					MerklePath: "test1",
+				},
+				{
+					Hash:       testutils.RevChainhash(t, "76732b80598326a18d3bf0a86518adbdf95d0ddc6ff6693004440f4776168c3a")[:],
+					MerklePath: "test1",
+				},
+			},
+			expectedUpdatedResLen: 2,
 		},
 	}
 

--- a/internal/blocktx/store/postgresql/upsert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/upsert_block_transactions.go
@@ -30,7 +30,7 @@ func (p *PostgreSQL) UpsertBlockTransactions(ctx context.Context, blockID uint64
 				INSERT INTO blocktx.transactions (hash)
 				SELECT UNNEST($2::BYTEA[])
 				ON CONFLICT (hash)
-				DO UPDATE SET hash = EXCLUDED.hash
+				DO NOTHING
 				RETURNING id, hash
 		)
 

--- a/internal/blocktx/store/postgresql/upsert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/upsert_block_transactions.go
@@ -40,10 +40,7 @@ func (p *PostgreSQL) UpsertBlockTransactions(ctx context.Context, blockID uint64
 				it.id,
 				t.merkle_path
 		FROM inserted_transactions it
-		JOIN LATERAL (
-			SELECT DISTINCT hash, merkle_path
-			FROM UNNEST($2::BYTEA[], $3::TEXT[]) AS u(hash, merkle_path)
-		) AS t ON it.hash = t.hash
+		JOIN LATERAL UNNEST($2::BYTEA[], $3::TEXT[]) AS t(hash, merkle_path) ON it.hash = t.hash
 		ON CONFLICT(blockid, txid) DO NOTHING;
 	`
 

--- a/internal/blocktx/store/postgresql/upsert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/upsert_block_transactions.go
@@ -28,7 +28,7 @@ func (p *PostgreSQL) UpsertBlockTransactions(ctx context.Context, blockID uint64
 	qUpsertTransactions := `
 		WITH inserted_transactions AS (
 				INSERT INTO blocktx.transactions (hash)
-				SELECT DISTINCT UNNEST($2::BYTEA[])
+				SELECT UNNEST($2::BYTEA[])
 				ON CONFLICT (hash)
 				DO UPDATE SET hash = EXCLUDED.hash
 				RETURNING id, hash

--- a/internal/blocktx/store/postgresql/upsert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/upsert_block_transactions.go
@@ -30,7 +30,7 @@ func (p *PostgreSQL) UpsertBlockTransactions(ctx context.Context, blockID uint64
 				INSERT INTO blocktx.transactions (hash)
 				SELECT UNNEST($2::BYTEA[])
 				ON CONFLICT (hash)
-				DO NOTHING
+				DO NOTHING SET hash = EXCLUDED.hash
 				RETURNING id, hash
 		)
 

--- a/internal/blocktx/store/postgresql/upsert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/upsert_block_transactions.go
@@ -30,7 +30,7 @@ func (p *PostgreSQL) UpsertBlockTransactions(ctx context.Context, blockID uint64
 				INSERT INTO blocktx.transactions (hash)
 				SELECT UNNEST($2::BYTEA[])
 				ON CONFLICT (hash)
-				SET hash = EXCLUDED.hash
+				DO UPDATE SET hash = EXCLUDED.hash
 				RETURNING id, hash
 		)
 

--- a/internal/blocktx/store/postgresql/upsert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/upsert_block_transactions.go
@@ -30,7 +30,7 @@ func (p *PostgreSQL) UpsertBlockTransactions(ctx context.Context, blockID uint64
 				INSERT INTO blocktx.transactions (hash)
 				SELECT UNNEST($2::BYTEA[])
 				ON CONFLICT (hash)
-				DO NOTHING SET hash = EXCLUDED.hash
+				SET hash = EXCLUDED.hash
 				RETURNING id, hash
 		)
 

--- a/internal/blocktx/store/postgresql/upsert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/upsert_block_transactions.go
@@ -43,7 +43,7 @@ func (p *PostgreSQL) UpsertBlockTransactions(ctx context.Context, blockID uint64
 		JOIN LATERAL (
 			SELECT DISTINCT hash, merkle_path
 			FROM UNNEST($2::BYTEA[], $3::TEXT[]) AS u(hash, merkle_path)
-		) AS t ON it.hash = t.hash;
+		) AS t ON it.hash = t.hash
 		ON CONFLICT(blockid, txid) DO NOTHING;
 	`
 

--- a/internal/blocktx/store/postgresql/upsert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/upsert_block_transactions.go
@@ -40,7 +40,10 @@ func (p *PostgreSQL) UpsertBlockTransactions(ctx context.Context, blockID uint64
 				it.id,
 				t.merkle_path
 		FROM inserted_transactions it
-		JOIN LATERAL UNNEST($2::BYTEA[], $3::TEXT[]) AS t(hash, merkle_path) ON it.hash = t.hash
+		JOIN LATERAL (
+			SELECT DISTINCT hash, merkle_path
+			FROM UNNEST($2::BYTEA[], $3::TEXT[]) AS u(hash, merkle_path)
+		) AS t ON it.hash = t.hash;
 		ON CONFLICT(blockid, txid) DO NOTHING;
 	`
 

--- a/internal/blocktx/store/postgresql/upsert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/upsert_block_transactions.go
@@ -28,7 +28,7 @@ func (p *PostgreSQL) UpsertBlockTransactions(ctx context.Context, blockID uint64
 	qUpsertTransactions := `
 		WITH inserted_transactions AS (
 				INSERT INTO blocktx.transactions (hash)
-				SELECT UNNEST($2::BYTEA[])
+				SELECT DISTINCT UNNEST($2::BYTEA[])
 				ON CONFLICT (hash)
 				DO UPDATE SET hash = EXCLUDED.hash
 				RETURNING id, hash

--- a/internal/blocktx/store/postgresql/upsert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/upsert_block_transactions.go
@@ -40,7 +40,8 @@ func (p *PostgreSQL) UpsertBlockTransactions(ctx context.Context, blockID uint64
 				it.id,
 				t.merkle_path
 		FROM inserted_transactions it
-		JOIN LATERAL UNNEST($2::BYTEA[], $3::TEXT[]) AS t(hash, merkle_path) ON it.hash = t.hash;
+		JOIN LATERAL UNNEST($2::BYTEA[], $3::TEXT[]) AS t(hash, merkle_path) ON it.hash = t.hash
+		ON CONFLICT(blockid, txid) DO NOTHING;
 	`
 
 	qRegisteredTransactions := `


### PR DESCRIPTION
## Description of Changes

We don't need to insert the transaction with the same txid and blockid as the pair must be unique. No need to update merkle path either as it shouldn't change. 

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
