### PR TITLE
fix: get unmined ancestors

### DIFF
--- a/internal/metamorph/processor.go
+++ b/internal/metamorph/processor.go
@@ -395,8 +395,6 @@ func (p *Processor) StartSendStatusUpdate() {
 					Err:          msg.Err,
 					CompetingTxs: msg.CompetingTxs,
 				})
-
-				p.logger.Debug("Status reported for tx", slog.String("status", msg.Status.String()), slog.String("hash", msg.Hash.String()))
 			}
 		}
 	}()
@@ -495,6 +493,8 @@ func (p *Processor) statusUpdateWithCallback(ctx context.Context, statusUpdates,
 	}
 
 	for _, data := range updatedData {
+		p.logger.Debug("Status updated for tx", slog.String("status", data.Status.String()), slog.String("hash", data.Hash.String()))
+
 		sendCallback := false
 		if data.FullStatusUpdates {
 			sendCallback = data.Status >= metamorph_api.Status_SEEN_IN_ORPHAN_MEMPOOL

--- a/internal/metamorph/server.go
+++ b/internal/metamorph/server.go
@@ -237,7 +237,7 @@ func (s *Server) processTransaction(ctx context.Context, waitForStatus metamorph
 	}
 	defer func() {
 		if span != nil {
-			span.SetAttributes(attribute.String("final-status", returnedStatus.Status.String()), attribute.String("TxID", returnedStatus.Txid), attribute.Bool("time-out", returnedStatus.TimedOut))
+			span.SetAttributes(attribute.String("final-status", returnedStatus.Status.String()), attribute.String("txID", returnedStatus.Txid), attribute.Bool("time-out", returnedStatus.TimedOut))
 		}
 		tracing.EndTracing(span, err)
 	}()

--- a/internal/node_client/node_client.go
+++ b/internal/node_client/node_client.go
@@ -86,6 +86,8 @@ func (n NodeClient) GetMempoolAncestors(ctx context.Context, ids []string) (allT
 		for _, txID := range txIDs {
 			uniqueIDs[txID] = struct{}{}
 		}
+
+		uniqueIDs[id] = struct{}{}
 	}
 
 	allTxIDs = make([]string, len(uniqueIDs))

--- a/internal/node_client/node_client_test.go
+++ b/internal/node_client/node_client_test.go
@@ -127,12 +127,12 @@ func TestNodeClient(t *testing.T) {
 		txs, err := node_client.CreateTxChain(privateKey, utxos[0], 20)
 		require.NoError(t, err)
 
-		expectedTxIDs := make([]string, len(txs)-1)
+		expectedTxIDs := make([]string, len(txs))
 		for i, tx := range txs {
 			_, err := bitcoind.SendRawTransaction(tx.String())
 			require.NoError(t, err)
 
-			if i != len(txs)-1 {
+			if i != len(txs) {
 				expectedTxIDs[i] = tx.TxID()
 			}
 		}
@@ -142,7 +142,7 @@ func TestNodeClient(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		require.Len(t, ancestorTxIDs, len(txs)-1)
+		require.Len(t, ancestorTxIDs, len(txs))
 
 		// compare expected and actual ancestor tx IDs while ignoring the order
 		less := func(a, b string) bool { return a < b }

--- a/pkg/metamorph/client.go
+++ b/pkg/metamorph/client.go
@@ -233,7 +233,7 @@ func (m *Metamorph) Health(ctx context.Context) (err error) {
 
 // SubmitTransaction submits a transaction to the bitcoin network and returns the transaction in raw format.
 func (m *Metamorph) SubmitTransaction(ctx context.Context, tx *sdkTx.Transaction, options *TransactionOptions) (txStatus *TransactionStatus, err error) {
-	ctx, span := tracing.StartTracing(ctx, "SubmitTransaction", m.tracingEnabled, m.tracingAttributes...)
+	ctx, span := tracing.StartTracing(ctx, "SubmitTransaction", m.tracingEnabled, append(m.tracingAttributes, attribute.String("txID", tx.TxID()))...)
 	defer func() {
 		tracing.EndTracing(span, err)
 	}()


### PR DESCRIPTION
## Description of Changes

- Include only unmined parents in mempool ancestors
- Add hostname to trace attributes
- Add tx id to submit transaction trace
- Move status updated log

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
