### PR TITLE
fix(ARCO-294): Remove additional timeout context

### DIFF
--- a/pkg/api/handler/default.go
+++ b/pkg/api/handler/default.go
@@ -492,11 +492,8 @@ func (m ArcDefaultHandler) processTransactions(ctx context.Context, txsHex []byt
 		return nil, nil, fails, nil
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(options.MaxTimeout+2)*time.Second)
-	defer cancel()
-
 	// submit valid transactions to metamorph
-	txStatuses, e := m.submitTransactions(timeoutCtx, submittedTxs, options)
+	txStatuses, e := m.submitTransactions(ctx, submittedTxs, options)
 	if e != nil {
 		return nil, nil, nil, e
 	}


### PR DESCRIPTION
## Description of Changes

Remove additional timeout context which could lead to context deadline exceeded errors

- [ ] I have added new unit tests
- [X] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
