### PR TITLE
feat(ARCO-296): add blocktx stats collector

### DIFF
--- a/internal/blocktx/processor.go
+++ b/internal/blocktx/processor.go
@@ -60,6 +60,10 @@ type Processor struct {
 	tracingEnabled              bool
 	tracingAttributes           []attribute.KeyValue
 	processGuardsMap            sync.Map
+	stats                       *processorStats
+	statCollectionInterval      time.Duration
+
+	now func() time.Time
 
 	waitGroup *sync.WaitGroup
 	cancelAll context.CancelFunc
@@ -89,6 +93,9 @@ func NewProcessor(
 		registerTxsBatchSize:        registerTxsBatchSizeDefault,
 		registerRequestTxsBatchSize: registerRequestTxBatchSizeDefault,
 		hostname:                    hostname,
+		stats:                       newProcessorStats(),
+		statCollectionInterval:      statCollectionIntervalDefault,
+		now:                         time.Now,
 		waitGroup:                   &sync.WaitGroup{},
 	}
 

--- a/internal/blocktx/stats_collector.go
+++ b/internal/blocktx/stats_collector.go
@@ -1,0 +1,101 @@
+package blocktx
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	statCollectionIntervalDefault = 60 * time.Second
+)
+
+var ErrFailedToRegisterStats = fmt.Errorf("failed to register stats collector")
+
+type processorStats struct {
+	mu                    sync.RWMutex
+	currentNumOfBlockGaps prometheus.Gauge
+}
+
+func newProcessorStats(opts ...func(stats *processorStats)) *processorStats {
+	p := &processorStats{
+		currentNumOfBlockGaps: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "arc_block_gaps_count",
+			Help: "Current number of block gaps",
+		}),
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
+}
+
+func (p *Processor) StartCollectStats() error {
+	ticker := time.NewTicker(p.statCollectionInterval)
+
+	err := registerStats(
+		p.stats.currentNumOfBlockGaps,
+	)
+	if err != nil {
+		return err
+	}
+
+	p.waitGroup.Add(1)
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				p.logger.Error("Recovered from panic", "panic", r, slog.String("stacktrace", string(debug.Stack())))
+			}
+		}()
+		defer func() {
+			unregisterStats(
+				p.stats.currentNumOfBlockGaps,
+			)
+			p.waitGroup.Done()
+		}()
+
+		for {
+			select {
+			case <-p.ctx.Done():
+				return
+			case <-ticker.C:
+				collectedStats, err := p.store.GetStats(p.ctx)
+				if err != nil {
+					p.logger.Error("failed to get stats", slog.String("err", err.Error()))
+					continue
+				}
+
+				p.stats.mu.Lock()
+				p.stats.currentNumOfBlockGaps.Set(float64(collectedStats.CurrentNumOfBlockGaps))
+				p.stats.mu.Unlock()
+			}
+		}
+	}()
+
+	return nil
+}
+
+func registerStats(cs ...prometheus.Collector) error {
+	for _, c := range cs {
+		err := prometheus.Register(c)
+		if err != nil {
+			return errors.Join(ErrFailedToRegisterStats, err)
+		}
+	}
+
+	return nil
+}
+
+func unregisterStats(cs ...prometheus.Collector) {
+	for _, c := range cs {
+		_ = prometheus.Unregister(c)
+	}
+}

--- a/internal/blocktx/store/mocks/blocktx_store_mock.go
+++ b/internal/blocktx/store/mocks/blocktx_store_mock.go
@@ -54,6 +54,9 @@ var _ store.BlocktxStore = &BlocktxStoreMock{}
 //			GetStaleChainBackFromHashFunc: func(ctx context.Context, hash []byte) ([]*blocktx_api.Block, error) {
 //				panic("mock out the GetStaleChainBackFromHash method")
 //			},
+//			GetStatsFunc: func(ctx context.Context) (*store.Stats, error) {
+//				panic("mock out the GetStats method")
+//			},
 //			MarkBlockAsDoneFunc: func(ctx context.Context, hash *chainhash.Hash, size uint64, txCount uint64) error {
 //				panic("mock out the MarkBlockAsDone method")
 //			},
@@ -117,6 +120,9 @@ type BlocktxStoreMock struct {
 
 	// GetStaleChainBackFromHashFunc mocks the GetStaleChainBackFromHash method.
 	GetStaleChainBackFromHashFunc func(ctx context.Context, hash []byte) ([]*blocktx_api.Block, error)
+
+	// GetStatsFunc mocks the GetStats method.
+	GetStatsFunc func(ctx context.Context) (*store.Stats, error)
 
 	// MarkBlockAsDoneFunc mocks the MarkBlockAsDone method.
 	MarkBlockAsDoneFunc func(ctx context.Context, hash *chainhash.Hash, size uint64, txCount uint64) error
@@ -221,6 +227,11 @@ type BlocktxStoreMock struct {
 			// Hash is the hash argument value.
 			Hash []byte
 		}
+		// GetStats holds details about calls to the GetStats method.
+		GetStats []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
 		// MarkBlockAsDone holds details about calls to the MarkBlockAsDone method.
 		MarkBlockAsDone []struct {
 			// Ctx is the ctx argument value.
@@ -297,6 +308,7 @@ type BlocktxStoreMock struct {
 	lockGetLongestChainFromHeight          sync.RWMutex
 	lockGetMinedTransactions               sync.RWMutex
 	lockGetStaleChainBackFromHash          sync.RWMutex
+	lockGetStats                           sync.RWMutex
 	lockMarkBlockAsDone                    sync.RWMutex
 	lockPing                               sync.RWMutex
 	lockRegisterTransactions               sync.RWMutex
@@ -699,6 +711,38 @@ func (mock *BlocktxStoreMock) GetStaleChainBackFromHashCalls() []struct {
 	mock.lockGetStaleChainBackFromHash.RLock()
 	calls = mock.calls.GetStaleChainBackFromHash
 	mock.lockGetStaleChainBackFromHash.RUnlock()
+	return calls
+}
+
+// GetStats calls GetStatsFunc.
+func (mock *BlocktxStoreMock) GetStats(ctx context.Context) (*store.Stats, error) {
+	if mock.GetStatsFunc == nil {
+		panic("BlocktxStoreMock.GetStatsFunc: method is nil but BlocktxStore.GetStats was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockGetStats.Lock()
+	mock.calls.GetStats = append(mock.calls.GetStats, callInfo)
+	mock.lockGetStats.Unlock()
+	return mock.GetStatsFunc(ctx)
+}
+
+// GetStatsCalls gets all the calls that were made to GetStats.
+// Check the length with:
+//
+//	len(mockedBlocktxStore.GetStatsCalls())
+func (mock *BlocktxStoreMock) GetStatsCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockGetStats.RLock()
+	calls = mock.calls.GetStats
+	mock.lockGetStats.RUnlock()
 	return calls
 }
 

--- a/internal/blocktx/store/postgresql/postgres_test.go
+++ b/internal/blocktx/store/postgresql/postgres_test.go
@@ -224,6 +224,19 @@ func TestPostgresDB(t *testing.T) {
 		require.ElementsMatch(t, expectedBlockGaps, actualBlockGaps)
 	})
 
+	t.Run("get stats for block geps", func(t *testing.T) {
+		// given
+		prepareDb(t, postgresDB.db, "fixtures/get_block_gaps")
+
+		// when
+		actualBlockGaps, err := postgresDB.GetStats(ctx)
+
+		// then
+		require.NoError(t, err)
+		// as we have 6 blocks in the range only it should return remaining 2006 (BlockDistance) - 6
+		require.Equal(t, int64(2010), actualBlockGaps.CurrentNumOfBlockGaps)
+	})
+
 	t.Run("get longest chain from height", func(t *testing.T) {
 		// given
 		prepareDb(t, postgresDB.db, "fixtures/get_longest_chain")

--- a/internal/blocktx/store/postgresql/stats.go
+++ b/internal/blocktx/store/postgresql/stats.go
@@ -1,0 +1,32 @@
+package postgresql
+
+import (
+	"context"
+
+	"github.com/bitcoin-sv/arc/internal/blocktx/store"
+)
+
+const BlockDistance = 2016
+
+func (p *PostgreSQL) GetStats(ctx context.Context) (*store.Stats, error) {
+	q := `
+	SELECT count(*) FROM (
+	SELECT unnest(ARRAY(
+			SELECT a.n	
+			FROM generate_series((SELECT max(height) - $1 AS block_height FROM blocktx.blocks b), (SELECT max(height) AS block_height FROM blocktx.blocks b)) AS a(n)
+		)) AS block_heights) AS bl
+	LEFT JOIN blocktx.blocks blks ON blks.height = bl.block_heights
+	WHERE blks.height IS NULL;
+	`
+
+	stats := &store.Stats{}
+
+	err := p.db.QueryRowContext(ctx, q, BlockDistance).Scan(
+		&stats.CurrentNumOfBlockGaps,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}

--- a/internal/blocktx/store/store.go
+++ b/internal/blocktx/store/store.go
@@ -23,6 +23,10 @@ var (
 	ErrMismatchedTxsAndMerklePathLength = errors.New("mismatched transactions and merkle path length")
 )
 
+type Stats struct {
+	CurrentNumOfBlockGaps int64
+}
+
 type BlocktxStore interface {
 	RegisterTransactions(ctx context.Context, txHashes [][]byte) (updatedTxs []*chainhash.Hash, err error)
 	GetBlock(ctx context.Context, hash *chainhash.Hash) (*blocktx_api.Block, error)
@@ -37,6 +41,7 @@ type BlocktxStore interface {
 	GetLongestChainFromHeight(ctx context.Context, height uint64) ([]*blocktx_api.Block, error)
 	GetStaleChainBackFromHash(ctx context.Context, hash []byte) ([]*blocktx_api.Block, error)
 	UpdateBlocksStatuses(ctx context.Context, blockStatusUpdates []BlockStatusUpdate) error
+	GetStats(ctx context.Context) (*Stats, error)
 
 	SetBlockProcessing(ctx context.Context, hash *chainhash.Hash, processedBy string) (string, error)
 	GetBlockHashesProcessingInProgress(ctx context.Context, processedBy string) ([]*chainhash.Hash, error)


### PR DESCRIPTION
## Description of Changes

We are adding a new Prometheus custom metric e.g. arc_block_gaps_count

The value of this metric should be the number of block gaps which can be found

## Linked Issues / Tickets


## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
