### PR TITLE
fix: Announce an expired transaction first before requesting it

### DIFF
--- a/internal/metamorph/processor.go
+++ b/internal/metamorph/processor.go
@@ -625,7 +625,7 @@ func (p *Processor) StartProcessExpiredTransactions() {
 						}
 
 						// every second time request tx, every other time announce tx
-						if tx.Retries%2 == 0 {
+						if tx.Retries%2 != 0 {
 							// Send GETDATA to peers to see if they have it
 							p.logger.Debug("Re-getting expired tx", slog.String("hash", tx.Hash.String()))
 							p.pm.RequestTransaction(tx.Hash)


### PR DESCRIPTION
## Description of Changes

Announce an expired transaction first before requesting it

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
