### PR TITLE
fix(ARCO-298): buffered callbacker channels

### DIFF
--- a/internal/callbacker/send_manager.go
+++ b/internal/callbacker/send_manager.go
@@ -71,11 +71,12 @@ const (
 	entriesBufferSize = 10000
 )
 
-func runNewSendManager(url string, sender SenderI, store store.CallbackerStore, logger *slog.Logger, quarantinePolicy *quarantinePolicy,
-	sendDelay, singleSendSleep, batchSendInterval time.Duration) *sendManager {
-	const defaultBatchSendInterval = time.Duration(5 * time.Second)
-	if batchSendInterval == 0 {
-		batchSendInterval = defaultBatchSendInterval
+func runNewSendManager(url string, sender SenderI, store store.CallbackerStore, logger *slog.Logger, quarantinePolicy *quarantinePolicy, sendingConfig *SendConfig) *sendManager {
+	const defaultBatchSendInterval = 5 * time.Second
+
+	batchSendInterval := defaultBatchSendInterval
+	if sendingConfig.BatchSendInterval != 0 {
+		batchSendInterval = sendingConfig.BatchSendInterval
 	}
 
 	m := &sendManager{
@@ -85,8 +86,8 @@ func runNewSendManager(url string, sender SenderI, store store.CallbackerStore, 
 		logger:           logger,
 		quarantinePolicy: quarantinePolicy,
 
-		sendDelay:         sendDelay,
-		singleSendSleep:   singleSendSleep,
+		sendDelay:         sendingConfig.Delay,
+		singleSendSleep:   sendingConfig.PauseAfterSingleModeSuccessfulSend,
 		batchSendInterval: batchSendInterval,
 
 		entries:      make(chan *CallbackEntry, entriesBufferSize),

--- a/internal/callbacker/send_manager.go
+++ b/internal/callbacker/send_manager.go
@@ -46,7 +46,6 @@ type sendManager struct {
 	quarantinePolicy *quarantinePolicy
 
 	// internal state
-	entriesWg    sync.WaitGroup
 	entries      chan *CallbackEntry
 	batchEntries chan *CallbackEntry
 
@@ -150,7 +149,6 @@ func (m *sendManager) storeToDB(entry *CallbackEntry, postponeUntil *time.Time) 
 
 func (m *sendManager) GracefulStop() {
 	m.setMode(StoppingMode) // signal the `run` goroutine to stop sending callbacks
-	m.entriesWg.Wait()      // wait for all accepted callbacks to be consumed
 
 	// signal the `run` goroutine to exit
 	close(m.entries)

--- a/internal/callbacker/send_manager_test.go
+++ b/internal/callbacker/send_manager_test.go
@@ -106,12 +106,12 @@ func TestSendManager(t *testing.T) {
 				BatchSendInterval:                  time.Millisecond,
 			}
 
-			sut := runNewSendManager("", cMq, sMq, slog.Default(), nil, sendConfig)
-
+			var opts []func(manager *sendManager)
 			if tc.setEntriesBufferSize > 0 {
-				sut.entries = make(chan *CallbackEntry, tc.setEntriesBufferSize)
-				sut.batchEntries = make(chan *CallbackEntry, tc.setEntriesBufferSize)
+				opts = append(opts, WithBufferSize(tc.setEntriesBufferSize))
 			}
+
+			sut := runNewSendManager("", cMq, sMq, slog.Default(), nil, sendConfig, opts...)
 
 			// add callbacks before starting the manager to queue them
 			for range tc.numOfSingleCallbacks {

--- a/internal/callbacker/send_manager_test.go
+++ b/internal/callbacker/send_manager_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/bitcoin-sv/arc/internal/callbacker/store"
 	"github.com/bitcoin-sv/arc/internal/callbacker/store/mocks"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSendManager(t *testing.T) {
@@ -78,7 +79,7 @@ func TestSendManager(t *testing.T) {
 			sut := &sendManager{
 				url:               "",
 				sender:            cMq,
-				s:                 sMq,
+				store:             sMq,
 				singleSendSleep:   tc.singleSendInterval,
 				batchSendInterval: 5 * time.Millisecond,
 

--- a/internal/callbacker/sender.go
+++ b/internal/callbacker/sender.go
@@ -24,6 +24,11 @@ type CallbackSender struct {
 
 type SenderOption func(s *CallbackSender)
 
+const (
+	retriesDefault                = 5
+	initRetrySleepDurationDefault = 5 * time.Second
+)
+
 func WithInitRetrySleepDuration(d time.Duration) func(*CallbackSender) {
 	return func(s *CallbackSender) {
 		s.initRetrySleepDuration = d
@@ -56,8 +61,8 @@ func NewSender(httpClient *http.Client, logger *slog.Logger, opts ...SenderOptio
 		httpClient:             httpClient,
 		stats:                  stats,
 		logger:                 logger.With(slog.String("module", "sender")),
-		retries:                5,
-		initRetrySleepDuration: 5 * time.Second,
+		retries:                retriesDefault,
+		initRetrySleepDuration: initRetrySleepDurationDefault,
 	}
 
 	// apply options to processor

--- a/internal/callbacker/sender_test.go
+++ b/internal/callbacker/sender_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bitcoin-sv/arc/internal/callbacker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bitcoin-sv/arc/internal/callbacker"
 )
 
 func TestCallbackSender_Send(t *testing.T) {


### PR DESCRIPTION
## Description of Changes

- Make entries channels buffered. 
- Store entries on DB in case of full channels
- Rename single letter variables
- Pass send configuration to send manager

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [X] I have added new unit tests
- [X] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
