### PR TITLE
feat(ARCO-295): new log level in p2p

### DIFF
--- a/cmd/arc/services/blocktx.go
+++ b/cmd/arc/services/blocktx.go
@@ -164,6 +164,10 @@ func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), err
 		peerOpts = append(peerOpts, p2p.WithUserAgent("ARC", version.Version))
 	}
 
+	if arcConfig.LogLevel != arcConfig.PeerLogLevel {
+		peerOpts = append(peerOpts, p2p.WithLogLevel(arcConfig.PeerLogLevel, arcConfig.LogFormat))
+	}
+
 	for i, peerSetting := range arcConfig.Broadcasting.Unicast.Peers {
 		peerURL, err := peerSetting.GetP2PUrl()
 		if err != nil {

--- a/cmd/arc/services/metamorph.go
+++ b/cmd/arc/services/metamorph.go
@@ -296,6 +296,10 @@ func initPeerManager(logger *slog.Logger, s store.MetamorphStore, arcConfig *con
 		peerOpts = append(peerOpts, p2p.WithUserAgent("ARC", version.Version))
 	}
 
+	if arcConfig.LogLevel != arcConfig.PeerLogLevel {
+		peerOpts = append(peerOpts, p2p.WithLogLevel(arcConfig.PeerLogLevel, arcConfig.LogFormat))
+	}
+
 	l := logger.With(slog.String("module", "peer"))
 	for _, peerSetting := range arcConfig.Broadcasting.Unicast.Peers {
 		peerURL, err := peerSetting.GetP2PUrl()

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ const (
 type ArcConfig struct {
 	LogFormat          string              `mapstructure:"logFormat"`
 	LogLevel           string              `mapstructure:"logLevel"`
-	PeerLogLevel       string              `mapstructure:"peeLogFormat"`
+	PeerLogLevel       string              `mapstructure:"peerLogLevel"`
 	ProfilerAddr       string              `mapstructure:"profilerAddr"`
 	PrometheusEndpoint string              `mapstructure:"prometheusEndpoint"`
 	PrometheusAddr     string              `mapstructure:"prometheusAddr"`

--- a/config/config.go
+++ b/config/config.go
@@ -13,8 +13,9 @@ const (
 )
 
 type ArcConfig struct {
-	LogLevel           string              `mapstructure:"logLevel"`
 	LogFormat          string              `mapstructure:"logFormat"`
+	LogLevel           string              `mapstructure:"logLevel"`
+	PeerLogLevel       string              `mapstructure:"peeLogFormat"`
 	ProfilerAddr       string              `mapstructure:"profilerAddr"`
 	PrometheusEndpoint string              `mapstructure:"prometheusEndpoint"`
 	PrometheusAddr     string              `mapstructure:"prometheusAddr"`

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -8,8 +8,9 @@ import (
 
 func getDefaultArcConfig() *ArcConfig {
 	return &ArcConfig{
-		LogLevel:           "DEBUG",
 		LogFormat:          "text",
+		LogLevel:           "DEBUG",
+		PeerLogLevel:       "DEBUG",
 		ProfilerAddr:       "", // optional
 		PrometheusEndpoint: "", // optional
 		PrometheusAddr:     "", // optional

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -1,6 +1,7 @@
 ---
-logLevel: DEBUG # mode of logging. Value can be one of DEBUG | INFO | WARN | ERROR
 logFormat: text # format of logging. Value can be one of text | json | tint
+logLevel: DEBUG # mode of logging. Value can be one of DEBUG | INFO | WARN | ERROR
+peerLogLevel: DEBUG # mode of logging for peer. Value can be one of TRACE | DEBUG | INFO | WARN | ERROR
 profilerAddr: localhost:9999 # address to start profiler server on (optional)
 prometheusEndpoint: /metrics # endpoint for prometheus metrics (optional)
 prometheusAddr: :2112 # port for serving prometheus metrics
@@ -149,7 +150,7 @@ callbacker:
   dialAddr: localhost:8021 # address for other services to dial callbacker service
   health:
     serverDialAddr: localhost:8025 # address at which the grpc health server is exposed
-  delay: 0s # delay before the callback (or batch of callbacks) is actually sent 
+  delay: 0s # delay before the callback (or batch of callbacks) is actually sent
   pause: 0s # pause between sending next callback to the same receiver
   batchSendInterval: 5s # interval at witch batched callbacks are send (default 5s)
   db:

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -47,6 +47,8 @@ func getSlogLevel(logLevel string) (slog.Level, error) {
 		return slog.LevelError, nil
 	case "DEBUG":
 		return slog.LevelDebug, nil
+	case "TRACE":
+		return slog.LevelDebug - 4, nil // simulate trace level
 	}
 
 	return slog.LevelInfo, errors.Join(ErrLoggerInvalidLogLevel, fmt.Errorf("log level: %s", logLevel))

--- a/internal/p2p/peer.go
+++ b/internal/p2p/peer.go
@@ -59,16 +59,9 @@ type Peer struct {
 }
 
 func NewPeer(logger *slog.Logger, msgHandler MessageHandlerI, address string, network wire.BitcoinNet, options ...PeerOptions) *Peer {
-	l := logger.With(
-		slog.Group("peer",
-			slog.String("network", network.String()),
-			slog.String("address", address),
-		),
-	)
-
 	p := &Peer{
 		dial: net.Dial,
-		l:    l,
+		l:    logger,
 		mh:   msgHandler,
 
 		address:      address,
@@ -87,6 +80,13 @@ func NewPeer(logger *slog.Logger, msgHandler MessageHandlerI, address string, ne
 	for _, opt := range options {
 		opt(p)
 	}
+
+	p.l = p.l.With(
+		slog.Group("peer",
+			slog.String("network", network.String()),
+			slog.String("address", address),
+		),
+	)
 
 	if p.writeCh == nil {
 		p.writeCh = make(chan wire.Message, 128)

--- a/internal/p2p/peer_options.go
+++ b/internal/p2p/peer_options.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/bitcoin-sv/arc/internal/logger"
 	"github.com/libsv/go-p2p/wire"
 )
 
@@ -44,5 +45,15 @@ func WithServiceFlag(flag wire.ServiceFlag) PeerOptions {
 func WithDialer(dial func(network, address string) (net.Conn, error)) PeerOptions {
 	return func(p *Peer) {
 		p.dial = dial
+	}
+}
+
+func WithLogLevel(level, logFormat string) PeerOptions {
+	return func(p *Peer) {
+		l, err := logger.NewLogger(level, logFormat)
+		if err != nil {
+			l, _ = logger.NewLogger("DEBUG", "json")
+		}
+		p.l = l
 	}
 }

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -1,7 +1,7 @@
 ---
 logFormat: tint
 logLevel: INFO
-peerLogLevel: INFO
+peerLogLevel: DEBUG
 profilerAddr: localhost:9999
 prometheusEndpoint: /metrics
 prometheusAddr: :2112

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -1,6 +1,7 @@
 ---
-logLevel: INFO
 logFormat: tint
+logLevel: INFO
+peerLogLevel: INFO
 profilerAddr: localhost:9999
 prometheusEndpoint: /metrics
 prometheusAddr: :2112


### PR DESCRIPTION
## Description of Changes

Add option to provide different log level for peers. Added TRACE level for even more descriptive logs.

Example:
```
blocktx-2     | Dec  6 08:30:25.096 DBG-4 Received peer.network=TestNet peer.address=node2:18333 cmd=AUTHCH
blocktx-2     | Dec  6 08:30:25.096 DBG-4 Received peer.network=TestNet peer.address=node2:18333 cmd=SENDHEADERS
blocktx-2     | Dec  6 08:30:25.096 DBG-4 Received peer.network=TestNet peer.address=node2:18333 cmd=SENDCMPCT
blocktx-2     | Dec  6 08:30:25.096 DBG-4 Received peer.network=TestNet peer.address=node2:18333 cmd=PING
blocktx-2     | Dec  6 08:30:25.096 DBG-4 Sent peer.network=TestNet peer.address=node2:18333 instance=0 cmd=PONG
```

> NOTE: Requires #686 to be merged first

## Linked Issues / Tickets

ARCO-295

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
