### PR TITLE
fix: handle io.EOF error on p2p.read

### DIFF
--- a/internal/blocktx/blockchain_communication/p2p/message_handler.go
+++ b/internal/blocktx/blockchain_communication/p2p/message_handler.go
@@ -45,17 +45,19 @@ func (h *MsgHandler) OnReceive(msg wire.Message, peer p2p.PeerI) {
 			return
 		}
 
-		for _, iv := range invMsg.InvList {
-			if iv.Type == wire.InvTypeBlock {
-				req := BlockRequest{
-					Hash: &iv.Hash,
-					Peer: peer,
-				}
+		go func() {
+			for _, iv := range invMsg.InvList {
+				if iv.Type == wire.InvTypeBlock {
+					req := BlockRequest{
+						Hash: &iv.Hash,
+						Peer: peer,
+					}
 
-				h.blockRequestingCh <- req
+					h.blockRequestingCh <- req
+				}
+				// ignore INV with transaction or error
 			}
-			// ignore INV with transaction or error
-		}
+		}()
 
 	case wire.CmdBlock:
 		blockMsg, ok := msg.(*blockchain.BlockMessage)

--- a/internal/p2p/tests/peer_test.go
+++ b/internal/p2p/tests/peer_test.go
@@ -284,7 +284,7 @@ func Test_listenMessages(t *testing.T) {
 }
 
 func Test_ErrorOnRead(t *testing.T) {
-	t.Run("Error while reading message from node - should not disconnect", func(t *testing.T) {
+	t.Run("Error while reading message from node - should disconnect", func(t *testing.T) {
 		// given
 		mhMq := &mocks.MessageHandlerIMock{}
 		sut, _, fromPeerConn := connectedPeer(t, mhMq)
@@ -308,9 +308,9 @@ func Test_ErrorOnRead(t *testing.T) {
 		require.NoError(t, writeErr)
 		require.Equal(t, len(invalidPayload), n)
 
-		// peer should not disconnect on invalid message or signal it's unhealthy
-		require.True(t, sut.Connected(), "Peer disconnect on error on reading message")
-		require.False(t, sutUnhealthy.Load(), "Peer send signal it's unhealthy on error on reading message")
+		// peer should disconnect on invalid message and signal it's unhealthy
+		require.False(t, sut.Connected(), "Peer didn't disconnect on error on reading message")
+		require.True(t, sutUnhealthy.Load(), "Peer didn't signal it's unhealthy on error on reading message")
 	})
 }
 


### PR DESCRIPTION
## Description of Changes

* ignore 'unhandled message' error on read
* handle `io.EOF` on read:
** tolerate 10 consecutive `io.EOF`
** sleep for 1s after `io.EOF`
* handle INV msg in new goroutine in blocktx

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
