### PR TITLE
fix: address potential memory leak in zqm

### DIFF
--- a/cmd/arc/services/metamorph.go
+++ b/cmd/arc/services/metamorph.go
@@ -225,7 +225,8 @@ func StartMetamorph(logger *slog.Logger, arcConfig *config.ArcConfig, cacheStore
 		}
 		logger.Info("Listening to ZMQ", slog.String("host", zmqURL.Hostname()), slog.String("port", zmqURL.Port()))
 
-		err = zmq.Start()
+		cleanup, err := zmq.Start()
+		shutdownFns = append(shutdownFns, cleanup)
 		if err != nil {
 			stopFn()
 			return nil, fmt.Errorf("failed to start ZMQ: %v", err)

--- a/internal/metamorph/integration_test/double_spend_integration_test.go
+++ b/internal/metamorph/integration_test/double_spend_integration_test.go
@@ -143,8 +143,9 @@ func TestDoubleSpendDetection(t *testing.T) {
 
 	zmq, err := metamorph.NewZMQ(zmqURL, statusMessageChannel, mockedZMQ, logger)
 	require.NoError(t, err)
-	err = zmq.Start()
+	cleanup, err := zmq.Start()
 	require.NoError(t, err)
+	defer cleanup()
 
 	// give metamorph time to parse ZMQ message
 	time.Sleep(500 * time.Millisecond)

--- a/internal/metamorph/zmq_handler.go
+++ b/internal/metamorph/zmq_handler.go
@@ -111,8 +111,7 @@ func (zmqHandler *ZMQHandler) start(ctx context.Context) {
 					zmqHandler.logger.Info("ZMQ: Connection observed", slog.String("address", zmqHandler.address))
 				}
 
-				topic := string(msg.Frames[0])
-				subscribers := zmqHandler.subscriptions[topic]
+				subscribers := zmqHandler.subscriptions[string(msg.Frames[0])]
 
 				sequence := "N/A"
 

--- a/internal/metamorph/zmq_handler.go
+++ b/internal/metamorph/zmq_handler.go
@@ -6,11 +6,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/go-zeromq/zmq4"
 	"log/slog"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/go-zeromq/zmq4"
 )
 
 type ZMQHandler struct {
@@ -103,24 +104,25 @@ func (zmqHandler *ZMQHandler) start(ctx context.Context) {
 					}
 					zmqHandler.logger.Error("zmqHandler.socket.Recv()", slog.String("error", err.Error()))
 					break OUT
-				} else {
-					if !zmqHandler.connected {
-						zmqHandler.connected = true
-						zmqHandler.logger.Info("ZMQ: Connection observed", slog.String("address", zmqHandler.address))
-					}
+				}
 
-					subscribers := zmqHandler.subscriptions[string(msg.Frames[0])]
+				if !zmqHandler.connected {
+					zmqHandler.connected = true
+					zmqHandler.logger.Info("ZMQ: Connection observed", slog.String("address", zmqHandler.address))
+				}
 
-					sequence := "N/A"
+				topic := string(msg.Frames[0])
+				subscribers := zmqHandler.subscriptions[topic]
 
-					if len(msg.Frames) > 2 && len(msg.Frames[2]) == 4 {
-						s := binary.LittleEndian.Uint32(msg.Frames[2])
-						sequence = strconv.FormatInt(int64(s), 10)
-					}
+				sequence := "N/A"
 
-					for _, subscriber := range subscribers {
-						subscriber <- []string{string(msg.Frames[0]), hex.EncodeToString(msg.Frames[1]), sequence}
-					}
+				if len(msg.Frames) > 2 && len(msg.Frames[2]) == 4 {
+					s := binary.LittleEndian.Uint32(msg.Frames[2])
+					sequence = strconv.FormatInt(int64(s), 10)
+				}
+
+				for _, subscriber := range subscribers {
+					subscriber <- []string{string(msg.Frames[0]), hex.EncodeToString(msg.Frames[1]), sequence}
 				}
 			}
 		}

--- a/internal/metamorph/zmq_test.go
+++ b/internal/metamorph/zmq_test.go
@@ -79,8 +79,9 @@ func TestZMQ(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		err = sut.Start()
+		cleanup, err := sut.Start()
 		require.NoError(t, err)
+		defer cleanup()
 
 		// then
 		var status *metamorph.TxStatusMessage
@@ -128,8 +129,9 @@ func TestZMQDoubleSpend(t *testing.T) {
 	require.NoError(t, err)
 
 	// when
-	err = sut.Start()
+	cleanup, err := sut.Start()
 	require.NoError(t, err)
+	defer cleanup()
 
 	// then
 	var status *metamorph.TxStatusMessage


### PR DESCRIPTION
## Description of Changes

- Because we're ranging over a channel in a goroutine, in `/internal/metamorph/zmq.go`, we need to close that channel, otherwise it will stay forever open, causing potential memory leaks.
- Added buffer to the zmq channel, although it seems that ZMQ itself will queue some amount of messages and will not drop them even if we're blocking on that channel.

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
