### PR TITLE
refactor: Set log level for zmq hashtx2 topic to TRACE

### DIFF
--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -1,5 +1,5 @@
 ---
-logLevel: DEBUG # mode of logging. Value can be one of DEBUG | INFO | WARN | ERROR
+logLevel: DEBUG # mode of logging. Value can be one of TRACE | DEBUG | INFO | WARN | ERROR
 logFormat: text # format of logging. Value can be one of text | json | tint
 profilerAddr: localhost:9999 # address to start profiler server on (optional)
 prometheus:

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -78,7 +78,7 @@ func replaceAttr(_ []string, a slog.Attr) slog.Attr {
 
 	// Customize the name of the level key
 	if a.Key == slog.LevelKey {
-		level := a.Value.Any().(slog.Level)
+		level := a.Value.Any().(slog.Level) //nolint:errcheck,revive
 		if level == LevelTrace {
 			a.Value = slog.StringValue("TRACE")
 		}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -17,7 +17,30 @@ var (
 
 const (
 	EventIDField = "arc-event"
+
+	LevelTrace   = slog.LevelDebug - 4
+	LevelDebug   = slog.LevelDebug
+	LevelInfo    = slog.LevelInfo
+	LevelWarning = slog.LevelWarn
+	LevelError   = slog.LevelError
 )
+
+func getSlogLevel(logLevel string) (slog.Level, error) {
+	switch logLevel {
+	case "INFO":
+		return LevelInfo, nil
+	case "WARN":
+		return LevelWarning, nil
+	case "ERROR":
+		return LevelError, nil
+	case "DEBUG":
+		return LevelDebug, nil
+	case "TRACE":
+		return LevelTrace, nil // simulate trace level
+	}
+
+	return 0, errors.Join(ErrLoggerInvalidLogLevel, fmt.Errorf("log level: %s", logLevel))
+}
 
 func NewLogger(logLevel, logFormat string) (*slog.Logger, error) {
 	slogLevel, err := getSlogLevel(logLevel)
@@ -27,29 +50,41 @@ func NewLogger(logLevel, logFormat string) (*slog.Logger, error) {
 
 	switch logFormat {
 	case "json":
-		return slog.New(&ArcContextHandler{slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slogLevel})}), nil
+		return slog.New(&ArcContextHandler{slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level:       slogLevel,
+			ReplaceAttr: replaceAttr,
+		},
+		)}), nil
 	case "text":
-		return slog.New(&ArcContextHandler{slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slogLevel})}), nil
+		return slog.New(&ArcContextHandler{slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level:       slogLevel,
+			ReplaceAttr: replaceAttr,
+		})}), nil
 	case "tint":
-		return slog.New(&ArcContextHandler{tint.NewHandler(os.Stdout, &tint.Options{Level: slogLevel})}), nil
+		return slog.New(&ArcContextHandler{tint.NewHandler(os.Stdout, &tint.Options{
+			Level:       slogLevel,
+			ReplaceAttr: replaceAttr,
+		})}), nil
 	}
 
 	return nil, errors.Join(ErrLoggerInvalidLogFormat, fmt.Errorf("log format: %s", logFormat))
 }
 
-func getSlogLevel(logLevel string) (slog.Level, error) {
-	switch logLevel {
-	case "INFO":
-		return slog.LevelInfo, nil
-	case "WARN":
-		return slog.LevelWarn, nil
-	case "ERROR":
-		return slog.LevelError, nil
-	case "DEBUG":
-		return slog.LevelDebug, nil
+// replaceAttr inspired by https://go.dev/src/log/slog/example_custom_levels_test.go
+func replaceAttr(_ []string, a slog.Attr) slog.Attr {
+	if a.Key == slog.TimeKey {
+		return slog.Attr{}
 	}
 
-	return slog.LevelInfo, errors.Join(ErrLoggerInvalidLogLevel, fmt.Errorf("log level: %s", logLevel))
+	// Customize the name of the level key
+	if a.Key == slog.LevelKey {
+		level := a.Value.Any().(slog.Level)
+		if level == LevelTrace {
+			a.Value = slog.StringValue("TRACE")
+		}
+	}
+
+	return a
 }
 
 type ArcContextHandler struct {

--- a/internal/metamorph/zmq.go
+++ b/internal/metamorph/zmq.go
@@ -1,6 +1,7 @@
 package metamorph
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -10,8 +11,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
 	"github.com/libsv/go-p2p/chaincfg/chainhash"
+
+	"github.com/bitcoin-sv/arc/internal/logger"
+	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
 )
 
 var allowedTopics = []string{
@@ -111,8 +114,7 @@ func (z *ZMQ) Start() (func(), error) {
 		for c := range ch {
 			switch c[0] {
 			case hashtxTopic:
-				z.logger.Debug(hashtxTopic, slog.String("hash", c[1]))
-
+				z.logger.Log(context.Background(), logger.LevelTrace, hashtxTopic, slog.String("hash", c[1]))
 				hash, err := chainhash.NewHashFromStr(c[1])
 				if err != nil {
 					z.logger.Error("failed to get hash from string", slog.String("topic", hashtxTopic), slog.String("err", err.Error()))
@@ -261,7 +263,7 @@ func (z *ZMQ) prepareCompetingTxMsgs(hash *chainhash.Hash, competingTxs []string
 	for _, tx := range competingTxs {
 		competingHash, err := chainhash.NewHashFromStr(tx)
 		if err != nil {
-			z.logger.Debug("could not parse competing tx hash",
+			z.logger.Warn("could not parse competing tx hash",
 				slog.String("reportingTxHash", hash.String()),
 				slog.String("err", err.Error()),
 				slog.String("competingTxID", tx))

--- a/internal/metamorph/zmq_test.go
+++ b/internal/metamorph/zmq_test.go
@@ -3,16 +3,16 @@ package metamorph_test
 import (
 	"log/slog"
 	"net/url"
-	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/bitcoin-sv/arc/internal/metamorph"
 	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
 	"github.com/bitcoin-sv/arc/internal/metamorph/mocks"
 	"github.com/bitcoin-sv/arc/internal/testdata"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -52,8 +52,6 @@ func TestZMQ(t *testing.T) {
 		},
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
-
 	for _, tc := range testCases {
 		// given
 		mockedZMQ := &mocks.ZMQIMock{
@@ -75,7 +73,7 @@ func TestZMQ(t *testing.T) {
 		zmqURL, err := url.Parse("https://some-url.com")
 		require.NoError(t, err)
 
-		sut, err := metamorph.NewZMQ(zmqURL, statuses, mockedZMQ, logger)
+		sut, err := metamorph.NewZMQ(zmqURL, statuses, mockedZMQ, slog.Default())
 		require.NoError(t, err)
 
 		// when
@@ -124,8 +122,7 @@ func TestZMQDoubleSpend(t *testing.T) {
 	zmqURL, err := url.Parse("https://some-url.com")
 	require.NoError(t, err)
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	sut, err := metamorph.NewZMQ(zmqURL, statuses, mockedZMQ, logger)
+	sut, err := metamorph.NewZMQ(zmqURL, statuses, mockedZMQ, slog.Default())
 	require.NoError(t, err)
 
 	// when


### PR DESCRIPTION
## Description of Changes

- Add custom log level TRACE - partly taken from https://github.com/bitcoin-sv/arc/pull/686
- Use log level TRACE in zmq

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
