### PR TITLE
fix(ARCO-311): Speed upsert block transactions

### DIFF
--- a/internal/blocktx/processor.go
+++ b/internal/blocktx/processor.go
@@ -37,7 +37,7 @@ var (
 )
 
 const (
-	transactionStoringBatchsizeDefault = 8192 // power of 2 for easier memory allocation
+	transactionStoringBatchsizeDefault = 10000
 	maxRequestBlocks                   = 10
 	maxBlocksInProgress                = 1
 	registerTxsIntervalDefault         = time.Second * 10

--- a/internal/blocktx/store/postgresql/upsert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/upsert_block_transactions.go
@@ -11,42 +11,63 @@ import (
 	"github.com/bitcoin-sv/arc/internal/tracing"
 )
 
-// UpsertBlockTransactions upserts the transaction hashes for a given block hash.
+// UpsertBlockTransactions upserts the transaction hashes for a given block hash and returns updated registered transactions hashes.
 func (p *PostgreSQL) UpsertBlockTransactions(ctx context.Context, blockID uint64, txsWithMerklePaths []store.TxWithMerklePath) (err error) {
 	ctx, span := tracing.StartTracing(ctx, "UpsertBlockTransactions", p.tracingEnabled, append(p.tracingAttributes, attribute.Int("updates", len(txsWithMerklePaths)))...)
 	defer func() {
 		tracing.EndTracing(span, err)
 	}()
 
-	txHashesBytes := make([][]byte, len(txsWithMerklePaths))
+	txHashes := make([][]byte, len(txsWithMerklePaths))
+	blockIDs := make([]uint64, len(txsWithMerklePaths))
 	merklePaths := make([]string, len(txsWithMerklePaths))
-	for i, tx := range txsWithMerklePaths {
-		txHashesBytes[i] = tx.Hash
-		merklePaths[i] = tx.MerklePath
+	for pos, tx := range txsWithMerklePaths {
+		txHashes[pos] = tx.Hash
+		merklePaths[pos] = tx.MerklePath
+		blockIDs[pos] = blockID
 	}
 
-	qUpsertTransactions := `
-		WITH inserted_transactions AS (
-				INSERT INTO blocktx.transactions (hash)
-				SELECT UNNEST($2::BYTEA[])
-				ON CONFLICT (hash)
-				DO UPDATE SET hash = EXCLUDED.hash
-				RETURNING id, hash
-		)
+	qBulkUpsert := `
+		INSERT INTO blocktx.transactions (hash)
+			SELECT UNNEST($1::BYTEA[])
+			ON CONFLICT (hash)
+			DO UPDATE SET hash = EXCLUDED.hash
+		RETURNING id`
 
-		INSERT INTO blocktx.block_transactions_map (blockid, txid, merkle_path)
-		SELECT
-				$1::BIGINT,
-				it.id,
-				t.merkle_path
-		FROM inserted_transactions it
-		JOIN LATERAL UNNEST($2::BYTEA[], $3::TEXT[]) AS t(hash, merkle_path) ON it.hash = t.hash
-		ON CONFLICT(blockid, txid) DO NOTHING;
-	`
-
-	_, err = p.db.ExecContext(ctx, qUpsertTransactions, blockID, pq.Array(txHashesBytes), pq.Array(merklePaths))
+	rows, err := p.db.QueryContext(ctx, qBulkUpsert, pq.Array(txHashes))
 	if err != nil {
-		return errors.Join(store.ErrFailedToExecuteTxUpdateQuery, err)
+		return errors.Join(store.ErrFailedToUpsertTransactions, err)
+	}
+
+	counter := 0
+	txIDs := make([]uint64, len(txsWithMerklePaths))
+	for rows.Next() {
+		var txID uint64
+		err = rows.Scan(&txID)
+		if err != nil {
+			return errors.Join(store.ErrFailedToGetRows, err)
+		}
+
+		txIDs[counter] = txID
+		counter++
+	}
+
+	if len(txIDs) != len(txsWithMerklePaths) {
+		return errors.Join(store.ErrMismatchedTxIDsAndMerklePathLength, err)
+	}
+
+	const qMapInsert = `
+		INSERT INTO blocktx.block_transactions_map (
+			 blockid
+			,txid
+			,merkle_path
+			)
+		SELECT * FROM UNNEST($1::INT[], $2::INT[], $3::TEXT[])
+		ON CONFLICT DO NOTHING
+		`
+	_, err = p.db.ExecContext(ctx, qMapInsert, pq.Array(blockIDs), pq.Array(txIDs), pq.Array(merklePaths))
+	if err != nil {
+		return errors.Join(store.ErrFailedToUpsertBlockTransactionsMap, err)
 	}
 
 	return nil

--- a/internal/blocktx/store/store.go
+++ b/internal/blocktx/store/store.go
@@ -4,24 +4,26 @@ import (
 	"context"
 	"errors"
 
-	"github.com/bitcoin-sv/arc/internal/blocktx/blocktx_api"
 	"github.com/libsv/go-p2p/chaincfg/chainhash"
+
+	"github.com/bitcoin-sv/arc/internal/blocktx/blocktx_api"
 )
 
 var (
-	ErrNotFound                         = errors.New("not found")
-	ErrBlockProcessingDuplicateKey      = errors.New("block hash already exists")
-	ErrBlockNotFound                    = errors.New("block not found")
-	ErrUnableToPrepareStatement         = errors.New("unable to prepare statement")
-	ErrUnableToDeleteRows               = errors.New("unable to delete rows")
-	ErrFailedToInsertBlock              = errors.New("failed to insert block")
-	ErrFailedToUpdateBlockStatuses      = errors.New("failed to update block statuses")
-	ErrFailedToOpenDB                   = errors.New("failed to open postgres database")
-	ErrFailedToInsertTransactions       = errors.New("failed to bulk insert transactions")
-	ErrFailedToGetRows                  = errors.New("failed to get rows")
-	ErrFailedToSetBlockProcessing       = errors.New("failed to set block processing")
-	ErrFailedToExecuteTxUpdateQuery     = errors.New("failed to execute transaction update query")
-	ErrMismatchedTxsAndMerklePathLength = errors.New("mismatched transactions and merkle path length")
+	ErrNotFound                           = errors.New("not found")
+	ErrBlockProcessingDuplicateKey        = errors.New("block hash already exists")
+	ErrBlockNotFound                      = errors.New("block not found")
+	ErrUnableToPrepareStatement           = errors.New("unable to prepare statement")
+	ErrUnableToDeleteRows                 = errors.New("unable to delete rows")
+	ErrFailedToInsertBlock                = errors.New("failed to insert block")
+	ErrFailedToUpdateBlockStatuses        = errors.New("failed to update block statuses")
+	ErrFailedToOpenDB                     = errors.New("failed to open postgres database")
+	ErrFailedToInsertTransactions         = errors.New("failed to bulk insert transactions")
+	ErrFailedToGetRows                    = errors.New("failed to get rows")
+	ErrFailedToSetBlockProcessing         = errors.New("failed to set block processing")
+	ErrFailedToUpsertTransactions         = errors.New("failed to upsert transactions")
+	ErrFailedToUpsertBlockTransactionsMap = errors.New("failed to upsert block transactions map")
+	ErrMismatchedTxIDsAndMerklePathLength = errors.New("mismatched tx IDs and merkle path length")
 )
 
 type Stats struct {

--- a/internal/test_utils/utils.go
+++ b/internal/test_utils/utils.go
@@ -69,7 +69,7 @@ func Retry(op func() error) error {
 	return nil
 }
 
-func LoadFixtures(t *testing.T, db *sql.DB, path string) {
+func LoadFixtures(t testing.TB, db *sql.DB, path string) {
 	t.Helper()
 
 	fixtures, err := testfixtures.New(
@@ -87,7 +87,7 @@ func LoadFixtures(t *testing.T, db *sql.DB, path string) {
 	}
 }
 
-func PruneTables(t *testing.T, db *sql.DB, tables ...string) {
+func PruneTables(t testing.TB, db *sql.DB, tables ...string) {
 	t.Helper()
 
 	for _, tab := range tables {


### PR DESCRIPTION
## Description of Changes

Currently upserting a block in blocktx is rather slow. To it up the function has been adapter and compared in a benchmark test. That test seems to indicate that the new implementation is faster.

![image](https://github.com/user-attachments/assets/22612b2e-02eb-4fdb-86db-f66380b4ec06)

Additionally a benchmark test was added to find the optimal batch size. The results don't show a clear winner but it seems that the best batch size is slightly higher. So that has been increased slightly.

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
