### PR TITLE
fix: Drop callbacks with nonexisting host

### DIFF
--- a/internal/callbacker/background_workers_test.go
+++ b/internal/callbacker/background_workers_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/bitcoin-sv/arc/internal/callbacker/store"
 )
 
-func TestStartCallbackStoreClenaup(t *testing.T) {
+func TestStartCallbackStoreCleanup(t *testing.T) {
 	tt := []struct {
 		name                     string
 		deleteFailedOlderThanErr error
@@ -98,10 +98,13 @@ func TestStartFailedCallbacksDispatch(t *testing.T) {
 					require.Equal(t, 100, limit)
 					return tc.storedCallbacks, tc.popFailedManyErr
 				},
+				SetFunc: func(_ context.Context, _ *store.CallbackData) error {
+					return nil
+				},
 			}
 			sender := &mocks.SenderIMock{
-				SendFunc: func(_ string, _ string, _ *callbacker.Callback) bool {
-					return true
+				SendFunc: func(_ string, _ string, _ *callbacker.Callback) (bool, bool) {
+					return true, false
 				},
 			}
 			logger := slog.Default()
@@ -169,10 +172,13 @@ func TestDispatchPersistedCallbacks(t *testing.T) {
 
 					return tc.storedCallbacks, tc.popManyErr
 				},
+				SetFunc: func(_ context.Context, _ *store.CallbackData) error {
+					return nil
+				},
 			}
 			sender := &mocks.SenderIMock{
-				SendFunc: func(_ string, _ string, _ *callbacker.Callback) bool {
-					return true
+				SendFunc: func(_ string, _ string, _ *callbacker.Callback) (bool, bool) {
+					return true, false
 				},
 			}
 			logger := slog.Default()

--- a/internal/callbacker/callbacker.go
+++ b/internal/callbacker/callbacker.go
@@ -5,8 +5,8 @@ import (
 )
 
 type SenderI interface {
-	Send(url, token string, callback *Callback) bool
-	SendBatch(url, token string, callbacks []*Callback) bool
+	Send(url, token string, callback *Callback) (success, retry bool)
+	SendBatch(url, token string, callbacks []*Callback) (success, retry bool)
 }
 
 type Callback struct {

--- a/internal/callbacker/dispatcher_test.go
+++ b/internal/callbacker/dispatcher_test.go
@@ -42,7 +42,7 @@ func TestCallbackDispatcher(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
 			cMq := &mocks.SenderIMock{
-				SendFunc: func(_, _ string, _ *callbacker.Callback) bool { return true },
+				SendFunc: func(_, _ string, _ *callbacker.Callback) (bool, bool) { return true, false },
 			}
 
 			var savedCallbacks []*store.CallbackData
@@ -51,11 +51,14 @@ func TestCallbackDispatcher(t *testing.T) {
 					savedCallbacks = append(savedCallbacks, data...)
 					return nil
 				},
+				SetFunc: func(_ context.Context, _ *store.CallbackData) error {
+					return nil
+				},
 			}
 
 			sendingConfig := callbacker.SendConfig{
 				PauseAfterSingleModeSuccessfulSend: tc.sendInterval,
-				Expiration:                         time.Duration(24 * time.Hour),
+				Expiration:                         24 * time.Hour,
 			}
 
 			sut := callbacker.NewCallbackDispatcher(cMq, sMq, slog.Default(), &sendingConfig)

--- a/internal/callbacker/mocks/callbacker_mock.go
+++ b/internal/callbacker/mocks/callbacker_mock.go
@@ -18,10 +18,10 @@ var _ callbacker.SenderI = &SenderIMock{}
 //
 //		// make and configure a mocked callbacker.SenderI
 //		mockedSenderI := &SenderIMock{
-//			SendFunc: func(url string, token string, callback *callbacker.Callback) bool {
+//			SendFunc: func(url string, token string, callback *callbacker.Callback) (bool, bool) {
 //				panic("mock out the Send method")
 //			},
-//			SendBatchFunc: func(url string, token string, callbacks []*callbacker.Callback) bool {
+//			SendBatchFunc: func(url string, token string, callbacks []*callbacker.Callback) (bool, bool) {
 //				panic("mock out the SendBatch method")
 //			},
 //		}
@@ -32,10 +32,10 @@ var _ callbacker.SenderI = &SenderIMock{}
 //	}
 type SenderIMock struct {
 	// SendFunc mocks the Send method.
-	SendFunc func(url string, token string, callback *callbacker.Callback) bool
+	SendFunc func(url string, token string, callback *callbacker.Callback) (bool, bool)
 
 	// SendBatchFunc mocks the SendBatch method.
-	SendBatchFunc func(url string, token string, callbacks []*callbacker.Callback) bool
+	SendBatchFunc func(url string, token string, callbacks []*callbacker.Callback) (bool, bool)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -63,7 +63,7 @@ type SenderIMock struct {
 }
 
 // Send calls SendFunc.
-func (mock *SenderIMock) Send(url string, token string, callback *callbacker.Callback) bool {
+func (mock *SenderIMock) Send(url string, token string, callback *callbacker.Callback) (bool, bool) {
 	if mock.SendFunc == nil {
 		panic("SenderIMock.SendFunc: method is nil but SenderI.Send was just called")
 	}
@@ -103,7 +103,7 @@ func (mock *SenderIMock) SendCalls() []struct {
 }
 
 // SendBatch calls SendBatchFunc.
-func (mock *SenderIMock) SendBatch(url string, token string, callbacks []*callbacker.Callback) bool {
+func (mock *SenderIMock) SendBatch(url string, token string, callbacks []*callbacker.Callback) (bool, bool) {
 	if mock.SendBatchFunc == nil {
 		panic("SenderIMock.SendBatchFunc: method is nil but SenderI.SendBatch was just called")
 	}

--- a/internal/callbacker/send_manager.go
+++ b/internal/callbacker/send_manager.go
@@ -282,7 +282,8 @@ func (m *SendManager) send(callback *CallbackEntry) {
 	// quick fix for client issue with to fast callbacks
 	time.Sleep(m.sendDelay)
 
-	if m.sender.Send(m.url, callback.Token, callback.Data) {
+	success, retry := m.sender.Send(m.url, callback.Token, callback.Data)
+	if !retry || success {
 		time.Sleep(m.singleSendSleep)
 		return
 	}
@@ -308,7 +309,8 @@ func (m *SendManager) sendBatch(batch []*CallbackEntry) {
 	// quick fix for client issue with to fast callbacks
 	time.Sleep(m.sendDelay)
 
-	if m.sender.SendBatch(m.url, token, callbacks) {
+	success, retry := m.sender.SendBatch(m.url, token, callbacks)
+	if !retry || success {
 		return
 	}
 

--- a/internal/callbacker/send_manager_test.go
+++ b/internal/callbacker/send_manager_test.go
@@ -86,8 +86,8 @@ func TestSendManager(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
 			cMq := &mocks.SenderIMock{
-				SendFunc:      func(_, _ string, _ *callbacker.Callback) bool { return true },
-				SendBatchFunc: func(_, _ string, _ []*callbacker.Callback) bool { return true },
+				SendFunc:      func(_, _ string, _ *callbacker.Callback) (bool, bool) { return true, false },
+				SendBatchFunc: func(_, _ string, _ []*callbacker.Callback) (bool, bool) { return true, false },
 			}
 
 			var savedCallbacks []*store.CallbackData
@@ -188,8 +188,12 @@ func TestSendManager_FailedCallbacks(t *testing.T) {
 			// given
 			var sendOK int32
 			senderMq := &mocks.SenderIMock{
-				SendFunc:      func(_, _ string, _ *callbacker.Callback) bool { return atomic.LoadInt32(&sendOK) == 1 },
-				SendBatchFunc: func(_, _ string, _ []*callbacker.Callback) bool { return atomic.LoadInt32(&sendOK) == 1 },
+				SendFunc: func(_, _ string, _ *callbacker.Callback) (bool, bool) {
+					return atomic.LoadInt32(&sendOK) == 1, atomic.LoadInt32(&sendOK) != 1
+				},
+				SendBatchFunc: func(_, _ string, _ []*callbacker.Callback) (bool, bool) {
+					return atomic.LoadInt32(&sendOK) == 1, atomic.LoadInt32(&sendOK) != 1
+				},
 			}
 
 			storeMq := &mocks.CallbackerStoreMock{

--- a/internal/callbacker/server_test.go
+++ b/internal/callbacker/server_test.go
@@ -58,8 +58,8 @@ func TestSendCallback(t *testing.T) {
 		// Given
 		sendOK := true
 		senderMq := &mocks.SenderIMock{
-			SendFunc:      func(_, _ string, _ *callbacker.Callback) bool { return sendOK },
-			SendBatchFunc: func(_, _ string, _ []*callbacker.Callback) bool { return sendOK },
+			SendFunc:      func(_, _ string, _ *callbacker.Callback) (bool, bool) { return sendOK, false },
+			SendBatchFunc: func(_, _ string, _ []*callbacker.Callback) (bool, bool) { return sendOK, false },
 		}
 
 		storeMq := &mocks.CallbackerStoreMock{


### PR DESCRIPTION
## Description of Changes
Currently callbacks with non-existing hosts are still retried even though they should be dropped

- Sender returns two booleans indicating whether the callback was successful and whether it should be retired
- If a host is non-existent, the callback was not successful, but it should not be retried

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [X] I have added new unit tests
- [X] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
