### PR TITLE
fix: Shutdown callback server before closing channels

### DIFF
--- a/test/utils.go
+++ b/test/utils.go
@@ -172,13 +172,14 @@ func startCallbackSrv(t *testing.T, receivedChan chan *TransactionResponse, errC
 	srv := &http.Server{Addr: ":9000"}
 	shutdownFn = func() {
 		t.Logf("shutting down callback listener %s", callbackURL)
-		close(receivedChan)
-		close(errChan)
 
 		if err := srv.Shutdown(context.TODO()); err != nil {
 			t.Fatal("failed to shut down server")
 		}
 		t.Log("callback listener is down")
+
+		close(receivedChan)
+		close(errChan)
 	}
 
 	go func(server *http.Server) {


### PR DESCRIPTION
## Description of Changes

Shutdown callback server before closing channels so that writhing to closed channel is not possible

## Testing Procedure

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
