### PR TITLE
fix: Recover time label in logs

### DIFF
--- a/internal/k8s_watcher/watcher_test.go
+++ b/internal/k8s_watcher/watcher_test.go
@@ -4,16 +4,15 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	btxMocks "github.com/bitcoin-sv/arc/internal/blocktx/mocks"
 	"github.com/bitcoin-sv/arc/internal/k8s_watcher"
 	"github.com/bitcoin-sv/arc/internal/k8s_watcher/mocks"
 	mtmMocks "github.com/bitcoin-sv/arc/internal/metamorph/mocks"
-	"github.com/lmittmann/tint"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStartMetamorphWatcher(t *testing.T) {
@@ -98,7 +97,7 @@ func TestStartMetamorphWatcher(t *testing.T) {
 			}
 
 			watcher := k8s_watcher.New(metamorphMock, blocktxMock, k8sClientMock, "test-namespace", k8s_watcher.WithMetamorphTicker(ticker),
-				k8s_watcher.WithLogger(slog.New(tint.NewHandler(os.Stdout, &tint.Options{Level: slog.LevelInfo, TimeFormat: time.Kitchen}))),
+				k8s_watcher.WithLogger(slog.Default()),
 				k8s_watcher.WithRetryInterval(20*time.Millisecond),
 			)
 			err := watcher.Start()
@@ -188,7 +187,7 @@ func TestStartBlocktxWatcher(t *testing.T) {
 			}
 
 			watcher := k8s_watcher.New(metamorphMock, blocktxMock, k8sClientMock, "test-namespace", k8s_watcher.WithBlocktxTicker(ticker),
-				k8s_watcher.WithLogger(slog.New(tint.NewHandler(os.Stdout, &tint.Options{Level: slog.LevelInfo, TimeFormat: time.Kitchen}))),
+				k8s_watcher.WithLogger(slog.Default()),
 			)
 			err := watcher.Start()
 			require.NoError(t, err)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -72,10 +72,6 @@ func NewLogger(logLevel, logFormat string) (*slog.Logger, error) {
 
 // replaceAttr inspired by https://go.dev/src/log/slog/example_custom_levels_test.go
 func replaceAttr(_ []string, a slog.Attr) slog.Attr {
-	if a.Key == slog.TimeKey {
-		return slog.Attr{}
-	}
-
 	// Customize the name of the level key
 	if a.Key == slog.LevelKey {
 		level := a.Value.Any().(slog.Level) //nolint:errcheck,revive

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -22,6 +22,12 @@ func Test_NewLogger(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name:          "valid logger",
+			loglevel:      "INFO",
+			logformat:     "json",
+			expectedError: nil,
+		},
+		{
 			name:          "invalid log format",
 			loglevel:      "INFO",
 			logformat:     "invalid format",
@@ -39,6 +45,10 @@ func Test_NewLogger(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// when
 			sut, err := NewLogger(tc.loglevel, tc.logformat)
+
+			if sut != nil {
+				sut.Info("test")
+			}
 
 			// then
 			assert.ErrorIs(t, err, tc.expectedError)


### PR DESCRIPTION
## Description of Changes

Recover time label in logs

## Testing Procedure

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
