### PR TITLE
fix: re-register txs

### DIFF
--- a/cmd/arc/services/blocktx.go
+++ b/cmd/arc/services/blocktx.go
@@ -83,7 +83,6 @@ func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), err
 	}
 
 	registerTxsChan := make(chan []byte, chanBufferSize)
-	requestTxChannel := make(chan []byte, chanBufferSize)
 
 	natsConnection, err := nats_connection.New(arcConfig.MessageQueue.URL, logger)
 	if err != nil {
@@ -93,7 +92,7 @@ func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), err
 
 	if arcConfig.MessageQueue.Streaming.Enabled {
 		opts := []nats_jetstream.Option{
-			nats_jetstream.WithSubscribedWorkQueuePolicy(blocktx.RegisterTxTopic, blocktx.RequestTxTopic),
+			nats_jetstream.WithSubscribedWorkQueuePolicy(blocktx.RegisterTxTopic),
 			nats_jetstream.WithWorkQueuePolicy(blocktx.MinedTxsTopic),
 		}
 		if arcConfig.MessageQueue.Streaming.FileStorage {
@@ -122,7 +121,6 @@ func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), err
 	processorOpts = append(processorOpts,
 		blocktx.WithRetentionDays(btxConfig.RecordRetentionDays),
 		blocktx.WithRegisterTxsChan(registerTxsChan),
-		blocktx.WithRequestTxChan(requestTxChannel),
 		blocktx.WithRegisterTxsInterval(btxConfig.RegisterTxsInterval),
 		blocktx.WithMessageQueueClient(mqClient),
 		blocktx.WithMaxBlockProcessingDuration(btxConfig.MaxBlockProcessingDuration),

--- a/cmd/arc/services/metamorph.go
+++ b/cmd/arc/services/metamorph.go
@@ -110,7 +110,7 @@ func StartMetamorph(logger *slog.Logger, arcConfig *config.ArcConfig, cacheStore
 	if arcConfig.MessageQueue.Streaming.Enabled {
 		opts := []nats_jetstream.Option{
 			nats_jetstream.WithSubscribedWorkQueuePolicy(metamorph.MinedTxsTopic, metamorph.SubmitTxTopic),
-			nats_jetstream.WithWorkQueuePolicy(metamorph.RegisterTxTopic, metamorph.RequestTxTopic),
+			nats_jetstream.WithWorkQueuePolicy(metamorph.RegisterTxTopic),
 			nats_jetstream.WithInterestPolicy(metamorph.CallbackTopic),
 		}
 		if arcConfig.MessageQueue.Streaming.FileStorage {

--- a/internal/blocktx/integration_test/helpers.go
+++ b/internal/blocktx/integration_test/helpers.go
@@ -26,7 +26,7 @@ func setupSut(t *testing.T, dbInfo string) (*blocktx.Processor, *blocktx.PeerHan
 
 	blockProcessCh := make(chan *p2p.BlockMessage, 10)
 
-	requestTxChannel := make(chan []byte, 10)
+	registerTxChannel := make(chan []byte, 10)
 	publishedTxsCh := make(chan *blocktx_api.TransactionBlock, 10)
 
 	store, err := postgresql.New(dbInfo, 10, 80)
@@ -51,12 +51,12 @@ func setupSut(t *testing.T, dbInfo string) (*blocktx.Processor, *blocktx.PeerHan
 		nil,
 		blockProcessCh,
 		blocktx.WithMessageQueueClient(mqClient),
-		blocktx.WithRequestTxChan(requestTxChannel),
-		blocktx.WithRegisterRequestTxsBatchSize(1), // process transaction immediately
+		blocktx.WithRegisterTxsChan(registerTxChannel),
+		blocktx.WithRegisterTxsBatchSize(1), // process transaction immediately
 	)
 	require.NoError(t, err)
 
-	return processor, p2pMsgHandler, store, requestTxChannel, publishedTxsCh
+	return processor, p2pMsgHandler, store, registerTxChannel, publishedTxsCh
 }
 
 func getPublishedTxs(publishedTxsCh chan *blocktx_api.TransactionBlock) []*blocktx_api.TransactionBlock {

--- a/internal/blocktx/integration_test/merkle_paths_test.go
+++ b/internal/blocktx/integration_test/merkle_paths_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	testutils "github.com/bitcoin-sv/arc/internal/test_utils"
 	"github.com/stretchr/testify/require"
+
+	testutils "github.com/bitcoin-sv/arc/internal/test_utils"
 )
 
 func TestMerklePaths(t *testing.T) {
@@ -18,14 +19,14 @@ func TestMerklePaths(t *testing.T) {
 		defer pruneTables(t, dbConn)
 		testutils.LoadFixtures(t, dbConn, "fixtures/merkle_paths")
 
-		processor, _, _, requestTxChannel, publishedTxsCh := setupSut(t, dbInfo)
+		processor, _, _, registerTxChannel, publishedTxsCh := setupSut(t, dbInfo)
 
 		txWithoutMerklePath := testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853")
 		expectedMerklePath := "fefe8a0c0003020002cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853010021132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e010100f883cc2d3bb5d4485accaa3502cf834934420616d8556b204da5658456b48b21010100e2277e52528e1a5e6117e45300e3f5f169b1712292399d065bc5167c54b8e0b5"
 
 		// when
-		requestTxChannel <- txWithoutMerklePath[:]
-		processor.StartProcessRequestTxs()
+		registerTxChannel <- txWithoutMerklePath[:]
+		processor.StartProcessRegisterTxs()
 
 		// give blocktx time to pull all transactions from block and calculate the merkle path
 		time.Sleep(200 * time.Millisecond)

--- a/internal/blocktx/mq_client.go
+++ b/internal/blocktx/mq_client.go
@@ -9,7 +9,6 @@ import (
 const (
 	MinedTxsTopic   = "mined-txs"
 	RegisterTxTopic = "register-tx"
-	RequestTxTopic  = "request-tx"
 )
 
 type MessageQueueClient interface {

--- a/internal/blocktx/processor_opts.go
+++ b/internal/blocktx/processor_opts.go
@@ -31,33 +31,15 @@ func WithRegisterTxsInterval(d time.Duration) func(*Processor) {
 	}
 }
 
-func WithRegisterRequestTxsInterval(d time.Duration) func(*Processor) {
-	return func(p *Processor) {
-		p.registerRequestTxsInterval = d
-	}
-}
-
 func WithRegisterTxsChan(registerTxsChan chan []byte) func(*Processor) {
 	return func(processor *Processor) {
 		processor.registerTxsChan = registerTxsChan
 	}
 }
 
-func WithRequestTxChan(requestTxChannel chan []byte) func(*Processor) {
-	return func(processor *Processor) {
-		processor.requestTxChannel = requestTxChannel
-	}
-}
-
 func WithRegisterTxsBatchSize(size int) func(*Processor) {
 	return func(processor *Processor) {
 		processor.registerTxsBatchSize = size
-	}
-}
-
-func WithRegisterRequestTxsBatchSize(size int) func(*Processor) {
-	return func(processor *Processor) {
-		processor.registerRequestTxsBatchSize = size
 	}
 }
 

--- a/internal/metamorph/mq_client.go
+++ b/internal/metamorph/mq_client.go
@@ -10,7 +10,6 @@ const (
 	SubmitTxTopic   = "submit-tx"
 	MinedTxsTopic   = "mined-txs"
 	RegisterTxTopic = "register-tx"
-	RequestTxTopic  = "request-tx"
 	CallbackTopic   = "callback"
 )
 

--- a/internal/metamorph/processor.go
+++ b/internal/metamorph/processor.go
@@ -638,14 +638,14 @@ func (p *Processor) StartRequestingSeenOnNetworkTxs() {
 
 					for _, tx := range seenOnNetworkTxs {
 						// by requesting tx, blocktx checks if it has the transaction mined in the database and sends it back
-						if err = p.mqClient.Publish(ctx, RequestTxTopic, tx.Hash[:]); err != nil {
-							p.logger.Error("failed to request tx from blocktx", slog.String("hash", tx.Hash.String()), slog.String("err", err.Error()))
+						if err = p.mqClient.Publish(ctx, RegisterTxTopic, tx.Hash[:]); err != nil {
+							p.logger.Error("Failed to register tx in blocktx", slog.String("hash", tx.Hash.String()), slog.String("err", err.Error()))
 						}
 					}
 				}
 
 				if totalSeenOnNetworkTxs > 0 {
-					p.logger.Info("SEEN_ON_NETWORK txs being requested", slog.Int("number", totalSeenOnNetworkTxs))
+					p.logger.Info("Transactions seen on network re-registered", slog.Int("number", totalSeenOnNetworkTxs))
 				}
 
 				tracing.EndTracing(span, nil)


### PR DESCRIPTION
## Description of Changes

- Publish txs seen on network on register-tx topic instead of request-tx topic
- Those txs which have not been registered for example due to a message queue outage will additionally be re-registered in the process so that Merkle path will be calculated for them

## Testing Procedure

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
