### PR TITLE
fix: Use ticker instead of timer to update URL mappings

### DIFF
--- a/internal/callbacker/processor.go
+++ b/internal/callbacker/processor.go
@@ -147,7 +147,7 @@ func (p *Processor) Start() error {
 func (p *Processor) startSyncURLMapping() {
 	p.waitGroup.Add(1)
 	go func() {
-		timer := time.NewTimer(syncInterval)
+		timer := time.NewTicker(syncInterval)
 		defer func() {
 			timer.Stop()
 			p.waitGroup.Done()


### PR DESCRIPTION
## Description of Changes

Use ticker instead of timer to update URL mappings

## Testing Procedure

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
