### PR TITLE
fix(ARCO-299): nats reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ migrate -database "postgres://<username>:<password>@<host>:<port>/<db-name>?sslm
 <a id="message-queue"></a>
 ## Message Queue
 
-For the communication between Metamorph and BlockTx a message queue is used. Currently the only available implementation of that message queue uses [NATS](https://nats.io/). A message queue of this type has to run in order for ARC to run.
+For the asynchronous communication between services a message queue is used. Currently, the only available implementation of that message queue uses [NATS](https://nats.io/). A message queue of this type has to run in order for ARC to run. If for any reason the connection to the NATS server is closed after all reconnection attempts, ARC will shut down automatically.
 
-Metamorph publishes new transactions to the message queue and BlockTx subscribes to the message queue, receive the transactions and stores them. Once BlockTx finds these transactions have been mined in a block it updates the block information and publishes the block information to the message queue. Metamorph subscribes to the message queue and receives the block information and updates the status of the transactions.
+One instance where the message queue is used is the communication between Metamorph & Blocktx service. Metamorph publishes new transactions to the message queue and BlockTx subscribes to the message queue, receive the transactions and stores them. Once BlockTx finds these transactions have been mined in a block it updates the block information and publishes the block information to the message queue. Metamorph subscribes to the message queue and receives the block information and updates the status of the transactions.
 
 ![Message Queue](./doc/message_queue.png)
 

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -61,6 +61,8 @@ func run() error {
 
 	shutdownFns := make([]func(), 0)
 
+	shutdownCh := make(chan string, 1)
+
 	go func() {
 		if arcConfig.ProfilerAddr != "" {
 			logger.Info(fmt.Sprintf("Starting profiler on http://%s/debug/pprof", arcConfig.ProfilerAddr))
@@ -93,7 +95,7 @@ func run() error {
 
 	if startBlockTx {
 		logger.Info("Starting BlockTx")
-		shutdown, err := cmd.StartBlockTx(logger, arcConfig)
+		shutdown, err := cmd.StartBlockTx(logger, arcConfig, shutdownCh)
 		if err != nil {
 			return fmt.Errorf("failed to start blocktx: %v", err)
 		}
@@ -102,7 +104,7 @@ func run() error {
 
 	if startMetamorph {
 		logger.Info("Starting Metamorph")
-		shutdown, err := cmd.StartMetamorph(logger, arcConfig, cacheStore)
+		shutdown, err := cmd.StartMetamorph(logger, arcConfig, cacheStore, shutdownCh)
 		if err != nil {
 			return fmt.Errorf("failed to start metamorph: %v", err)
 		}
@@ -111,7 +113,7 @@ func run() error {
 
 	if startAPI {
 		logger.Info("Starting API")
-		shutdown, err := cmd.StartAPIServer(logger, arcConfig)
+		shutdown, err := cmd.StartAPIServer(logger, arcConfig, shutdownCh)
 		if err != nil {
 			return fmt.Errorf("failed to start api: %v", err)
 		}
@@ -129,7 +131,7 @@ func run() error {
 	}
 
 	if startCallbacker {
-		shutdown, err := cmd.StartCallbacker(logger, arcConfig)
+		shutdown, err := cmd.StartCallbacker(logger, arcConfig, shutdownCh)
 		if err != nil {
 			return fmt.Errorf("failed to start callbacker: %v", err)
 		}
@@ -140,7 +142,12 @@ func run() error {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM, syscall.SIGINT)
 
-	<-signalChan
+	select {
+	case reason := <-shutdownCh:
+		logger.Info("Received shutdown signal", slog.String("reason", reason))
+	case sig := <-signalChan:
+		logger.Info("Received shutdown signal", slog.String("reason", sig.String()))
+	}
 	appCleanup(logger, shutdownFns)
 
 	return nil

--- a/cmd/arc/services/api.go
+++ b/cmd/arc/services/api.go
@@ -54,11 +54,9 @@ func StartAPIServer(logger *slog.Logger, arcConfig *config.ArcConfig, shutdownCh
 	}
 
 	go func() {
-		select {
-		case <-clientClosedCh:
-			logger.Warn("message queue client closed")
-			shutdownCh <- "message queue client closed"
-		}
+		<-clientClosedCh
+		logger.Warn("message queue client closed")
+		shutdownCh <- "message queue client closed"
 	}()
 
 	mtmOpts := []func(*metamorph.Metamorph){

--- a/cmd/arc/services/api.go
+++ b/cmd/arc/services/api.go
@@ -229,7 +229,7 @@ func setAPIEcho(logger *slog.Logger, arcConfig *config.ArcConfig) *echo.Echo {
 func natsMqClient(logger *slog.Logger, arcConfig *config.ArcConfig, clientClosedCh chan struct{}) (metamorph.MessageQueueClient, error) {
 	logger = logger.With("module", "nats")
 
-	conn, err := nats_connection.New(arcConfig.MessageQueue.URL, logger, clientClosedCh)
+	conn, err := nats_connection.New(arcConfig.MessageQueue.URL, logger, nats_connection.WithClientClosedChannel(clientClosedCh))
 	if err != nil {
 		return nil, fmt.Errorf("failed to establish connection to message queue at URL %s: %v", arcConfig.MessageQueue.URL, err)
 	}

--- a/cmd/arc/services/api.go
+++ b/cmd/arc/services/api.go
@@ -36,7 +36,7 @@ import (
 	"github.com/bitcoin-sv/arc/pkg/woc_client"
 )
 
-func StartAPIServer(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), error) {
+func StartAPIServer(logger *slog.Logger, arcConfig *config.ArcConfig, shutdownCh chan string) (func(), error) {
 	logger = logger.With(slog.String("service", "api"))
 
 	e := setAPIEcho(logger, arcConfig)
@@ -46,10 +46,20 @@ func StartAPIServer(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), e
 	// check the swagger definition against our requests
 	apiHandler.CheckSwagger(e)
 
-	mqClient, err := natsMqClient(logger, arcConfig)
+	clientClosedCh := make(chan struct{}, 1)
+
+	mqClient, err := natsMqClient(logger, arcConfig, clientClosedCh)
 	if err != nil {
 		return nil, err
 	}
+
+	go func() {
+		select {
+		case <-clientClosedCh:
+			logger.Warn("message queue client closed")
+			shutdownCh <- "message queue client closed"
+		}
+	}()
 
 	mtmOpts := []func(*metamorph.Metamorph){
 		metamorph.WithMqClient(mqClient),
@@ -218,10 +228,10 @@ func setAPIEcho(logger *slog.Logger, arcConfig *config.ArcConfig) *echo.Echo {
 	return e
 }
 
-func natsMqClient(logger *slog.Logger, arcConfig *config.ArcConfig) (metamorph.MessageQueueClient, error) {
+func natsMqClient(logger *slog.Logger, arcConfig *config.ArcConfig, clientClosedCh chan struct{}) (metamorph.MessageQueueClient, error) {
 	logger = logger.With("module", "nats")
 
-	conn, err := nats_connection.New(arcConfig.MessageQueue.URL, logger)
+	conn, err := nats_connection.New(arcConfig.MessageQueue.URL, logger, clientClosedCh)
 	if err != nil {
 		return nil, fmt.Errorf("failed to establish connection to message queue at URL %s: %v", arcConfig.MessageQueue.URL, err)
 	}

--- a/cmd/arc/services/blocktx.go
+++ b/cmd/arc/services/blocktx.go
@@ -31,7 +31,7 @@ const (
 	blockProcessingBuffer = 100
 )
 
-func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), error) {
+func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig, shutdownCh chan string) (func(), error) {
 	logger = logger.With(slog.String("service", "blocktx"))
 	logger.Info("Starting")
 
@@ -84,11 +84,19 @@ func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), err
 
 	registerTxsChan := make(chan []byte, chanBufferSize)
 
-	natsConnection, err := nats_connection.New(arcConfig.MessageQueue.URL, logger)
+	clientClosedCh := make(chan struct{}, 1)
+	natsConnection, err := nats_connection.New(arcConfig.MessageQueue.URL, logger, clientClosedCh)
 	if err != nil {
 		stopFn()
 		return nil, fmt.Errorf("failed to establish connection to message queue at URL %s: %v", arcConfig.MessageQueue.URL, err)
 	}
+	go func() {
+		select {
+		case <-clientClosedCh:
+			logger.Warn("message queue client closed")
+			shutdownCh <- "message queue client closed"
+		}
+	}()
 
 	if arcConfig.MessageQueue.Streaming.Enabled {
 		opts := []nats_jetstream.Option{

--- a/cmd/arc/services/blocktx.go
+++ b/cmd/arc/services/blocktx.go
@@ -85,7 +85,7 @@ func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig, shutdownCh c
 	registerTxsChan := make(chan []byte, chanBufferSize)
 
 	clientClosedCh := make(chan struct{}, 1)
-	natsConnection, err := nats_connection.New(arcConfig.MessageQueue.URL, logger, clientClosedCh)
+	natsConnection, err := nats_connection.New(arcConfig.MessageQueue.URL, logger, nats_connection.WithClientClosedChannel(clientClosedCh))
 	if err != nil {
 		stopFn()
 		return nil, fmt.Errorf("failed to establish connection to message queue at URL %s: %v", arcConfig.MessageQueue.URL, err)

--- a/cmd/arc/services/blocktx.go
+++ b/cmd/arc/services/blocktx.go
@@ -90,12 +90,11 @@ func StartBlockTx(logger *slog.Logger, arcConfig *config.ArcConfig, shutdownCh c
 		stopFn()
 		return nil, fmt.Errorf("failed to establish connection to message queue at URL %s: %v", arcConfig.MessageQueue.URL, err)
 	}
+
 	go func() {
-		select {
-		case <-clientClosedCh:
-			logger.Warn("message queue client closed")
-			shutdownCh <- "message queue client closed"
-		}
+		<-clientClosedCh
+		logger.Warn("message queue client closed")
+		shutdownCh <- "message queue client closed"
 	}()
 
 	if arcConfig.MessageQueue.Streaming.Enabled {

--- a/cmd/arc/services/callbacker.go
+++ b/cmd/arc/services/callbacker.go
@@ -87,7 +87,7 @@ func StartCallbacker(logger *slog.Logger, arcConfig *config.ArcConfig, shutdownC
 
 	clientClosedCh := make(chan struct{}, 1)
 
-	natsConnection, err := nats_connection.New(arcConfig.MessageQueue.URL, logger, clientClosedCh)
+	natsConnection, err := nats_connection.New(arcConfig.MessageQueue.URL, logger, nats_connection.WithClientClosedChannel(clientClosedCh))
 	if err != nil {
 		stopFn()
 		return nil, fmt.Errorf("failed to establish connection to message queue at URL %s: %v", arcConfig.MessageQueue.URL, err)

--- a/cmd/arc/services/callbacker.go
+++ b/cmd/arc/services/callbacker.go
@@ -38,7 +38,7 @@ import (
 	"github.com/bitcoin-sv/arc/pkg/message_queue/nats/nats_connection"
 )
 
-func StartCallbacker(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), error) {
+func StartCallbacker(logger *slog.Logger, arcConfig *config.ArcConfig, shutdownCh chan string) (func(), error) {
 	logger = logger.With(slog.String("service", "callbacker"))
 	logger.Info("Starting")
 
@@ -85,11 +85,21 @@ func StartCallbacker(logger *slog.Logger, arcConfig *config.ArcConfig) (func(), 
 
 	dispatcher = callbacker.NewCallbackDispatcher(sender, runNewManager)
 
-	natsConnection, err := nats_connection.New(arcConfig.MessageQueue.URL, logger)
+	clientClosedCh := make(chan struct{}, 1)
+
+	natsConnection, err := nats_connection.New(arcConfig.MessageQueue.URL, logger, clientClosedCh)
 	if err != nil {
 		stopFn()
 		return nil, fmt.Errorf("failed to establish connection to message queue at URL %s: %v", arcConfig.MessageQueue.URL, err)
 	}
+
+	go func() {
+		select {
+		case <-clientClosedCh:
+			logger.Warn("message queue client closed")
+			shutdownCh <- "message queue client closed"
+		}
+	}()
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/cmd/arc/services/callbacker.go
+++ b/cmd/arc/services/callbacker.go
@@ -94,11 +94,9 @@ func StartCallbacker(logger *slog.Logger, arcConfig *config.ArcConfig, shutdownC
 	}
 
 	go func() {
-		select {
-		case <-clientClosedCh:
-			logger.Warn("message queue client closed")
-			shutdownCh <- "message queue client closed"
-		}
+		<-clientClosedCh
+		logger.Warn("message queue client closed")
+		shutdownCh <- "message queue client closed"
 	}()
 
 	hostname, err := os.Hostname()

--- a/cmd/arc/services/metamorph.go
+++ b/cmd/arc/services/metamorph.go
@@ -111,12 +111,11 @@ func StartMetamorph(logger *slog.Logger, arcConfig *config.ArcConfig, cacheStore
 		stopFn()
 		return nil, fmt.Errorf("failed to establish connection to message queue at URL %s: %v", arcConfig.MessageQueue.URL, err)
 	}
+
 	go func() {
-		select {
-		case <-clientClosedCh:
-			logger.Warn("message queue client closed")
-			shutdownCh <- "message queue client closed"
-		}
+		<-clientClosedCh
+		logger.Warn("message queue client closed")
+		shutdownCh <- "message queue client closed"
 	}()
 
 	if arcConfig.MessageQueue.Streaming.Enabled {

--- a/cmd/arc/services/metamorph.go
+++ b/cmd/arc/services/metamorph.go
@@ -106,7 +106,7 @@ func StartMetamorph(logger *slog.Logger, arcConfig *config.ArcConfig, cacheStore
 	submittedTxsChan := make(chan *metamorph_api.TransactionRequest, chanBufferSize)
 
 	clientClosedCh := make(chan struct{}, 1)
-	natsClient, err := nats_connection.New(arcConfig.MessageQueue.URL, logger, clientClosedCh)
+	natsClient, err := nats_connection.New(arcConfig.MessageQueue.URL, logger, nats_connection.WithClientClosedChannel(clientClosedCh))
 	if err != nil {
 		stopFn()
 		return nil, fmt.Errorf("failed to establish connection to message queue at URL %s: %v", arcConfig.MessageQueue.URL, err)

--- a/internal/blocktx/processor.go
+++ b/internal/blocktx/processor.go
@@ -304,7 +304,7 @@ func (p *Processor) registerTransactions(txHashes [][]byte) {
 
 	err = p.publishMinedTxs(txHashes)
 	if err != nil {
-		p.logger.Error("failed to publish mined txs", slog.String("err", err.Error()))
+		p.logger.Error("Failed to publish mined txs", slog.String("err", err.Error()))
 	}
 }
 
@@ -836,7 +836,7 @@ func (p *Processor) publishTxsToMetamorph(ctx context.Context, txs []store.Block
 
 		err := p.mqClient.PublishMarshal(ctx, MinedTxsTopic, txBlock)
 		if err != nil {
-			p.logger.Error("failed to publish mined txs", slog.String("blockHash", getHashStringNoErr(tx.BlockHash)), slog.Uint64("height", tx.BlockHeight), slog.String("txHash", getHashStringNoErr(tx.TxHash)), slog.String("err", err.Error()))
+			p.logger.Error("Failed to publish mined txs", slog.String("blockHash", getHashStringNoErr(tx.BlockHash)), slog.Uint64("height", tx.BlockHeight), slog.String("txHash", getHashStringNoErr(tx.TxHash)), slog.String("err", err.Error()))
 			publishErr = err
 		}
 	}

--- a/internal/metamorph/processor.go
+++ b/internal/metamorph/processor.go
@@ -326,7 +326,7 @@ func (p *Processor) updateMined(ctx context.Context, txsBlocks []*blocktx_api.Tr
 			for _, request := range requests {
 				err = p.mqClient.PublishMarshal(ctx, CallbackTopic, request)
 				if err != nil {
-					p.logger.Error("failed to publish callback", slog.String("err", err.Error()))
+					p.logger.Error("Failed to publish callback", slog.String("err", err.Error()))
 				}
 			}
 		}
@@ -574,7 +574,7 @@ func (p *Processor) statusUpdateWithCallback(ctx context.Context, statusUpdates,
 			for _, request := range requests {
 				err = p.mqClient.PublishMarshal(ctx, CallbackTopic, request)
 				if err != nil {
-					p.logger.Error("failed to publish callback", slog.String("err", err.Error()))
+					p.logger.Error("Failed to publish callback", slog.String("err", err.Error()))
 				}
 			}
 		}

--- a/pkg/message_queue/nats/client/nats_core/integration_test/client_integration_test.go
+++ b/pkg/message_queue/nats/client/nats_core/integration_test/client_integration_test.go
@@ -51,13 +51,13 @@ func testmain(m *testing.M) int {
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	natsConnClient, err = nats_connection.New(natsURL, logger, nil)
+	natsConnClient, err = nats_connection.New(natsURL, logger)
 	if err != nil {
 		log.Printf("failed to create nats connection: %v", err)
 		return 1
 	}
 
-	natsConn, err = nats_connection.New(natsURL, logger, nil)
+	natsConn, err = nats_connection.New(natsURL, logger)
 	if err != nil {
 		log.Printf("failed to create nats connection: %v", err)
 		return 1

--- a/pkg/message_queue/nats/client/nats_core/integration_test/client_integration_test.go
+++ b/pkg/message_queue/nats/client/nats_core/integration_test/client_integration_test.go
@@ -51,24 +51,19 @@ func testmain(m *testing.M) int {
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	natsConnClient, err = nats_connection.New(natsURL, logger)
+	natsConnClient, err = nats_connection.New(natsURL, logger, nil)
 	if err != nil {
 		log.Printf("failed to create nats connection: %v", err)
 		return 1
 	}
 
-	natsConn, err = nats_connection.New(natsURL, logger)
+	natsConn, err = nats_connection.New(natsURL, logger, nil)
 	if err != nil {
 		log.Printf("failed to create nats connection: %v", err)
 		return 1
 	}
 
 	defer func() {
-		err = natsConn.Drain()
-		if err != nil {
-			log.Fatalf("failed to drain nats connection: %v", err)
-		}
-
 		mqClient.Shutdown()
 
 		err = pool.Purge(resource)

--- a/pkg/message_queue/nats/client/nats_jetstream/integration_test/client_integration_test.go
+++ b/pkg/message_queue/nats/client/nats_jetstream/integration_test/client_integration_test.go
@@ -50,13 +50,13 @@ func testmain(m *testing.M) int {
 
 	logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	natsConnClient, err = nats_connection.New(natsURL, logger, nil)
+	natsConnClient, err = nats_connection.New(natsURL, logger)
 	if err != nil {
 		log.Printf("failed to create nats connection: %v", err)
 		return 1
 	}
 
-	natsConn, err = nats_connection.New(natsURL, logger, nil)
+	natsConn, err = nats_connection.New(natsURL, logger)
 	if err != nil {
 		log.Printf("failed to create nats connection: %v", err)
 		return 1

--- a/pkg/message_queue/nats/client/nats_jetstream/integration_test/client_integration_test.go
+++ b/pkg/message_queue/nats/client/nats_jetstream/integration_test/client_integration_test.go
@@ -50,24 +50,19 @@ func testmain(m *testing.M) int {
 
 	logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	natsConnClient, err = nats_connection.New(natsURL, logger)
+	natsConnClient, err = nats_connection.New(natsURL, logger, nil)
 	if err != nil {
 		log.Printf("failed to create nats connection: %v", err)
 		return 1
 	}
 
-	natsConn, err = nats_connection.New(natsURL, logger)
+	natsConn, err = nats_connection.New(natsURL, logger, nil)
 	if err != nil {
 		log.Printf("failed to create nats connection: %v", err)
 		return 1
 	}
 
 	defer func() {
-		err = natsConn.Drain()
-		if err != nil {
-			log.Fatalf("failed to drain nats connection: %v", err)
-		}
-
 		mqClient.Shutdown()
 
 		err = pool.Purge(resource)

--- a/pkg/message_queue/nats/nats_connection/nats_connection.go
+++ b/pkg/message_queue/nats/nats_connection/nats_connection.go
@@ -16,6 +16,8 @@ func New(natsURL string, logger *slog.Logger) (*nats.Conn, error) {
 	var nc *nats.Conn
 	var err error
 
+	logger.With(slog.String("module", "nats"))
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err

--- a/pkg/message_queue/nats/nats_connection/nats_connection.go
+++ b/pkg/message_queue/nats/nats_connection/nats_connection.go
@@ -45,7 +45,6 @@ func New(natsURL string, logger *slog.Logger, clientClosedCh chan struct{}) (*na
 			}
 
 			logger.Error("client disconnected", args...)
-
 		}),
 		nats.ReconnectHandler(func(_ *nats.Conn) {
 			logger.Info("client reconnected")

--- a/pkg/message_queue/nats/nats_connection/nats_connection.go
+++ b/pkg/message_queue/nats/nats_connection/nats_connection.go
@@ -60,10 +60,10 @@ func New(natsURL string, logger *slog.Logger, clientClosedCh chan struct{}) (*na
 			}
 		}),
 		nats.RetryOnFailedConnect(true),
-		nats.PingInterval(30 * time.Second),
+		nats.PingInterval(15 * time.Second),
 		nats.MaxPingsOutstanding(2),
 		nats.ReconnectBufSize(8 * 1024 * 1024),
-		nats.MaxReconnects(60),
+		nats.MaxReconnects(10),
 		nats.ReconnectWait(2 * time.Second),
 	}
 

--- a/pkg/message_queue/nats/nats_connection/nats_connection_test.go
+++ b/pkg/message_queue/nats/nats_connection/nats_connection_test.go
@@ -5,15 +5,20 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
+	"github.com/bitcoin-sv/arc/pkg/message_queue/nats/client/test_api"
 	"github.com/bitcoin-sv/arc/pkg/test_utils"
 )
 
 var (
-	natsURL string
+	natsURL  string
+	resource *dockertest.Resource
+	err      error
 )
 
 func TestMain(m *testing.M) {
@@ -28,49 +33,54 @@ func testmain(m *testing.M) int {
 	}
 
 	port := "4334"
-	resource, natsInfo, err := testutils.RunNats(pool, port, "")
+	resource, natsURL, err = testutils.RunNats(pool, port, "")
 	if err != nil {
 		log.Print(err)
 		return 1
 	}
 	defer func() {
-		err = pool.Purge(resource)
-		if err != nil {
-			log.Fatalf("failed to purge pool: %v", err)
+		purgeErr := pool.Purge(resource)
+		if purgeErr != nil {
+			log.Println(purgeErr)
 		}
 	}()
 
-	natsURL = natsInfo
+	time.Sleep(5 * time.Second)
 	return m.Run()
 }
 
 func TestNewNatsConnection(t *testing.T) {
-	tt := []struct {
-		name          string
-		url           string
-		expectedError error
-	}{
-		{
-			name: "success",
-			url:  natsURL,
-		},
-		{
-			name: "error",
-			url:  "wrong url",
+	t.Run("error - wrong URL", func(t *testing.T) {
+		_, err = New("wrong url", slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})), nil)
+		require.ErrorIs(t, err, ErrNatsConnectionFailed)
+	})
 
-			expectedError: ErrNatsConnectionFailed,
-		},
-	}
+	t.Run("success", func(t *testing.T) {
+		clientClosedCh := make(chan struct{}, 1)
 
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := New(tc.url, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
-			if tc.expectedError != nil {
-				require.ErrorIs(t, err, tc.expectedError)
-				return
-			}
+		conn, err := New(natsURL, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})), clientClosedCh)
+		require.NoError(t, err)
+		testMessage := &test_api.TestMessage{
+			Ok: true,
+		}
+		var data []byte
+		data, err = proto.Marshal(testMessage)
+		require.NoError(t, err)
 
-			require.NoError(t, err)
-		})
-	}
+		time.Sleep(1 * time.Second)
+
+		err = conn.Publish("abc", data)
+		require.NoError(t, err)
+
+		err = resource.Close()
+		require.NoError(t, err)
+		timer := time.NewTimer(15 * time.Second)
+		select {
+		case <-clientClosedCh:
+			t.Log("client closed signal received")
+		case <-timer.C:
+			t.Log("client closed signal not received")
+			t.Fail()
+		}
+	})
 }

--- a/pkg/message_queue/nats/nats_connection/nats_connection_test.go
+++ b/pkg/message_queue/nats/nats_connection/nats_connection_test.go
@@ -51,14 +51,19 @@ func testmain(m *testing.M) int {
 
 func TestNewNatsConnection(t *testing.T) {
 	t.Run("error - wrong URL", func(t *testing.T) {
-		_, err = New("wrong url", slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})), nil)
+		_, err = New("wrong url", slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
 		require.ErrorIs(t, err, ErrNatsConnectionFailed)
 	})
 
 	t.Run("success", func(t *testing.T) {
 		clientClosedCh := make(chan struct{}, 1)
 
-		conn, err := New(natsURL, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})), clientClosedCh)
+		conn, err := New(natsURL,
+			slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})),
+			WithClientClosedChannel(clientClosedCh),
+			WithMaxReconnects(1),
+			WithReconnectWait(100*time.Millisecond),
+		)
 		require.NoError(t, err)
 		testMessage := &test_api.TestMessage{
 			Ok: true,


### PR DESCRIPTION
## Description of Changes

- If NATS client connection is closed, shutdown ARC
- Modify NATS connection options settings

## Testing Procedure

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
