### PR TITLE
feat(ARCO-324): rebroadcast stale txs

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -58,12 +58,13 @@ stateDiagram-v2
     ACCEPTED_BY_NETWORK --> SEEN_ON_NETWORK: ARC has received Transaction ID\n announcement from another peer
     ACCEPTED_BY_NETWORK --> SEEN_IN_ORPHAN_MEMPOOL: Peer has sent a 'missing inputs' message
     SEEN_IN_ORPHAN_MEMPOOL --> SEEN_ON_NETWORK: All parent transactions\n have been received by peer
-    SEEN_ON_NETWORK --> MINED: Transaction ID was included in a BLOCK message
     SEEN_ON_NETWORK --> DOUBLE_SPEND_ATTEMPTED: A competing transactions entered the mempool
-    DOUBLE_SPEND_ATTEMPTED --> MINED: This transaction was accepted and mined
     DOUBLE_SPEND_ATTEMPTED --> REJECTED: This transaction was rejected in favor\n of one of the competing transactions
-    MINED --> MINED_IN_STALE_BLOCK: This transaction was mined in a block that became stale after reorg
+    DOUBLE_SPEND_ATTEMPTED --> MINED: This transaction was accepted and mined
+    SEEN_ON_NETWORK --> MINED: Transaction ID was included in a BLOCK message
+    MINED_IN_STALE_BLOCK --> SEEN_ON_NETWORK: Transaction gets re-broadcasted
     MINED --> [*]
+    MINED --> MINED_IN_STALE_BLOCK: This transaction was mined in a block that became stale after reorg
 ```
 
 ## Microservices

--- a/internal/blocktx/integration_test/fixtures/stale_block/blocktx.registered_transactions.yaml
+++ b/internal/blocktx/integration_test/fixtures/stale_block/blocktx.registered_transactions.yaml
@@ -1,0 +1,2 @@
+- hash: 0xcd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853
+  inserted_at: 2023-12-15 14:00:00

--- a/internal/blocktx/integration_test/fixtures/stale_orphans/blocktx.blocks.yaml
+++ b/internal/blocktx/integration_test/fixtures/stale_orphans/blocktx.blocks.yaml
@@ -34,6 +34,7 @@
   status: 10
   is_longest: true
   chainwork: '12301577519373468' # Higher chainwork
+# Competing
 - inserted_at: 2023-12-15 14:50:00
   id: 1005
   hash: 0x76404890880cb36ce68100abb05b3a958e17c0ed274d5c0a0000000000000000
@@ -46,6 +47,7 @@
   status: 20 # STALE
   is_longest: false
   chainwork: '62209952899966'
+# Orphans
 - inserted_at: 2023-12-15 14:50:00
   id: 1006
   hash: 0x000000000000000003b15d668b54c4b91ae81a86298ee209d9f39fd7a769bcde

--- a/internal/blocktx/integration_test/fixtures/stale_orphans/blocktx.registered_transactions.yaml
+++ b/internal/blocktx/integration_test/fixtures/stale_orphans/blocktx.registered_transactions.yaml
@@ -1,0 +1,2 @@
+- hash: 0xde0753d9ce6f92e340843cbfdd11e58beff8c578956ecdec4c461b018a26b8a9
+  inserted_at: 2023-12-15 14:00:00

--- a/internal/blocktx/integration_test/helpers.go
+++ b/internal/blocktx/integration_test/helpers.go
@@ -33,7 +33,7 @@ func setupSut(t *testing.T, dbInfo string) (*blocktx.Processor, *blocktx_p2p.Msg
 	require.NoError(t, err)
 
 	mqClient := &mocks.MessageQueueClientMock{
-		PublishMarshalFunc: func(ctx context.Context, topic string, m proto.Message) error {
+		PublishMarshalFunc: func(_ context.Context, _ string, m proto.Message) error {
 			serialized, ok := m.(*blocktx_api.TransactionBlocks)
 			require.True(t, ok)
 

--- a/internal/blocktx/integration_test/helpers.go
+++ b/internal/blocktx/integration_test/helpers.go
@@ -14,9 +14,8 @@ import (
 	"github.com/bitcoin-sv/arc/internal/blocktx/bcnet"
 	"github.com/bitcoin-sv/arc/internal/blocktx/bcnet/blocktx_p2p"
 	"github.com/bitcoin-sv/arc/internal/blocktx/blocktx_api"
+	"github.com/bitcoin-sv/arc/internal/blocktx/mocks"
 	"github.com/bitcoin-sv/arc/internal/blocktx/store/postgresql"
-	"github.com/bitcoin-sv/arc/pkg/message_queue/nats/client/nats_core"
-	nats_mock "github.com/bitcoin-sv/arc/pkg/message_queue/nats/client/nats_core/mocks"
 	"github.com/bitcoin-sv/arc/pkg/test_utils"
 )
 
@@ -33,17 +32,15 @@ func setupSut(t *testing.T, dbInfo string) (*blocktx.Processor, *blocktx_p2p.Msg
 	store, err := postgresql.New(dbInfo, 10, 80)
 	require.NoError(t, err)
 
-	mockNatsConn := &nats_mock.NatsConnectionMock{
-		PublishFunc: func(_ string, data []byte) error {
-			serialized := &blocktx_api.TransactionBlocks{}
-			err := proto.Unmarshal(data, serialized)
-			require.NoError(t, err)
+	mqClient := &mocks.MessageQueueClientMock{
+		PublishMarshalFunc: func(ctx context.Context, topic string, m proto.Message) error {
+			serialized, ok := m.(*blocktx_api.TransactionBlocks)
+			require.True(t, ok)
 
 			publishedTxsCh <- serialized
 			return nil
 		},
 	}
-	mqClient := nats_core.New(mockNatsConn, nats_core.WithLogger(logger))
 
 	p2pMsgHandler := blocktx_p2p.NewMsgHandler(logger, nil, blockProcessCh)
 	processor, err := blocktx.NewProcessor(

--- a/internal/blocktx/integration_test/reorg_integration_test.go
+++ b/internal/blocktx/integration_test/reorg_integration_test.go
@@ -251,8 +251,6 @@ func TestReorg(t *testing.T) {
 			blockHash822021        = "d46bf0a189927b62c8ff785d393a545093ca01af159aed771a8d94749f06c060"
 			blockHash822022Orphan  = "0000000000000000059d6add76e3ddb8ec4f5ffd6efecd4c8b8c577bd32aed6c"
 			blockHash822023Orphan  = "0000000000000000082131979a4e25a5101912a5f8461e18f306d23e158161cd"
-
-			txhash822019 = "71fbb8fb5c0f978e3c221bc6ac235587f3c26fa10e231b54fce972d4a5c30e5e"
 		)
 
 		blockHash := testutils.RevChainhash(t, blockHash822021)

--- a/internal/blocktx/integration_test/reorg_integration_test.go
+++ b/internal/blocktx/integration_test/reorg_integration_test.go
@@ -10,7 +10,7 @@ package integrationtest
 // 		1. Blocks at heights 822014-822017 (LONGEST), 822018-822020 (ORPHANED) and 822022-822023 (ORPHANED) are added to db from fixtures
 // 		2. A hardcoded msg with competing block at height 822015 is being sent through the mocked PeerHandler
 // 		3. This block has a chainwork lower than the current tip of chain - becomes STALE
-// 		4. Registered transactions from this block are ignored
+// 		4. Registered transactions from this block that are not in the longest chain are published with blockstatus = STALE
 // 		5. Next competing block, at height 822016 is being sent through the mocked PeerHandler
 // 		6. This block has a greater chainwork than the current tip of longest chain - it becomes LONGEST despite not being the highest
 // 		7. Verification of reorg - checking if statuses are correctly switched
@@ -128,10 +128,18 @@ func TestReorg(t *testing.T) {
 		verifyBlock(t, store, blockHash822015Fork, 822015, blocktx_api.Status_STALE)
 		verifyBlock(t, store, blockHash822015, 822015, blocktx_api.Status_LONGEST)
 
+		expectedTxs := []*blocktx_api.TransactionBlock{
+			{
+				BlockHash:       blockHash[:],
+				BlockHeight:     822015,
+				TransactionHash: testutils.RevChainhash(t, txhash822015)[:],
+				BlockStatus:     blocktx_api.Status_STALE,
+			},
+		}
+
 		publishedTxs := getPublishedTxs(publishedTxsCh)
 
-		// verify the no transaction was published to metamorph
-		require.Len(t, publishedTxs, 0)
+		verifyTxs(t, expectedTxs, publishedTxs)
 	})
 
 	t.Run("reorg", func(t *testing.T) {
@@ -243,6 +251,8 @@ func TestReorg(t *testing.T) {
 			blockHash822021        = "d46bf0a189927b62c8ff785d393a545093ca01af159aed771a8d94749f06c060"
 			blockHash822022Orphan  = "0000000000000000059d6add76e3ddb8ec4f5ffd6efecd4c8b8c577bd32aed6c"
 			blockHash822023Orphan  = "0000000000000000082131979a4e25a5101912a5f8461e18f306d23e158161cd"
+
+			txhash822019 = "71fbb8fb5c0f978e3c221bc6ac235587f3c26fa10e231b54fce972d4a5c30e5e"
 		)
 
 		blockHash := testutils.RevChainhash(t, blockHash822021)
@@ -283,10 +293,19 @@ func TestReorg(t *testing.T) {
 		verifyBlock(t, store, blockHash822022Orphan, 822022, blocktx_api.Status_ORPHANED)
 		verifyBlock(t, store, blockHash822023Orphan, 822023, blocktx_api.Status_ORPHANED)
 
+		bh := testutils.RevChainhash(t, blockHash822019Orphan)
+		expectedTxs := []*blocktx_api.TransactionBlock{
+			{
+				BlockHash:       bh[:],
+				BlockHeight:     822019,
+				TransactionHash: testutils.RevChainhash(t, txhash822019)[:],
+				BlockStatus:     blocktx_api.Status_STALE,
+			},
+		}
+
 		publishedTxs := getPublishedTxs(publishedTxsCh)
 
-		// verify no transaction was published
-		require.Len(t, publishedTxs, 0)
+		verifyTxs(t, expectedTxs, publishedTxs)
 	})
 
 	t.Run("reorg orphans", func(t *testing.T) {

--- a/internal/blocktx/integration_test/reorg_integration_test.go
+++ b/internal/blocktx/integration_test/reorg_integration_test.go
@@ -293,12 +293,11 @@ func TestReorg(t *testing.T) {
 		verifyBlock(t, store, blockHash822022Orphan, 822022, blocktx_api.Status_ORPHANED)
 		verifyBlock(t, store, blockHash822023Orphan, 822023, blocktx_api.Status_ORPHANED)
 
-		bh := testutils.RevChainhash(t, blockHash822019Orphan)
 		expectedTxs := []*blocktx_api.TransactionBlock{
 			{
-				BlockHash:       bh[:],
-				BlockHeight:     822019,
-				TransactionHash: testutils.RevChainhash(t, txhash822019)[:],
+				BlockHash:       blockHash[:],
+				BlockHeight:     822021,
+				TransactionHash: txHash[:],
 				BlockStatus:     blocktx_api.Status_STALE,
 			},
 		}

--- a/internal/blocktx/processor.go
+++ b/internal/blocktx/processor.go
@@ -288,7 +288,7 @@ func (p *Processor) processTransactions(txHashes [][]byte) error {
 
 	p.logger.Info("registered tx hashes", slog.Int("hashes", len(txHashes)), slog.Int64("new", rowsAffected))
 
-	minedTxs, err := p.store.GetMinedTransactions(p.ctx, txHashes, false)
+	minedTxs, err := p.store.GetMinedTransactions(p.ctx, txHashes)
 	if err != nil {
 		return fmt.Errorf("failed to get mined txs: %v", err)
 	}
@@ -480,7 +480,13 @@ func (p *Processor) assignBlockStatus(ctx context.Context, block *blocktx_api.Bl
 }
 
 func (p *Processor) longestTipExists(ctx context.Context) (bool, error) {
-	_, err := p.store.GetChainTip(ctx)
+	const (
+		hoursPerDay   = 24
+		blocksPerHour = 6
+	)
+	heightRange := p.dataRetentionDays * hoursPerDay * blocksPerHour
+
+	_, err := p.store.GetChainTip(ctx, heightRange)
 	if err != nil && !errors.Is(err, store.ErrBlockNotFound) {
 		return false, err
 	}

--- a/internal/blocktx/processor.go
+++ b/internal/blocktx/processor.go
@@ -492,7 +492,7 @@ func (p *Processor) longestTipExists(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (p *Processor) getRegisteredTransactions(ctx context.Context, blocks []*blocktx_api.Block) (txsToPublish []store.BlockTransaction, ok bool) {
+func (p *Processor) getRegisteredTransactions(ctx context.Context, blocks []*blocktx_api.Block) (txs []store.BlockTransaction, ok bool) {
 	var err error
 	ctx, span := tracing.StartTracing(ctx, "getRegisteredTransactions", p.tracingEnabled, p.tracingAttributes...)
 	defer func() {
@@ -504,14 +504,14 @@ func (p *Processor) getRegisteredTransactions(ctx context.Context, blocks []*blo
 		blockHashes[i] = b.Hash
 	}
 
-	txsToPublish, err = p.store.GetRegisteredTxsByBlockHashes(ctx, blockHashes)
+	txs, err = p.store.GetRegisteredTxsByBlockHashes(ctx, blockHashes)
 	if err != nil {
 		block := blocks[len(blocks)-1]
 		p.logger.Error("unable to get registered transactions", slog.String("hash", getHashStringNoErr(block.Hash)), slog.Uint64("height", block.Height), slog.String("err", err.Error()))
 		return nil, false
 	}
 
-	return txsToPublish, true
+	return txs, true
 }
 
 func (p *Processor) insertBlockAndStoreTransactions(ctx context.Context, incomingBlock *blocktx_api.Block, txHashes []*chainhash.Hash, merkleRoot chainhash.Hash) (err error) {
@@ -634,7 +634,7 @@ func (p *Processor) storeTransactions(ctx context.Context, blockID uint64, block
 	return nil
 }
 
-func (p *Processor) handleStaleBlock(ctx context.Context, block *blocktx_api.Block) (longestTxs, staleTxs []store.BlockTransaction, ok bool) {
+func (p *Processor) handleStaleBlock(ctx context.Context, block *blocktx_api.Block, orphans ...*blocktx_api.Block) (longestTxs, staleTxs []store.BlockTransaction, ok bool) {
 	var err error
 	ctx, span := tracing.StartTracing(ctx, "handleStaleBlock", p.tracingEnabled, p.tracingAttributes...)
 	defer func() {
@@ -672,7 +672,21 @@ func (p *Processor) handleStaleBlock(ctx context.Context, block *blocktx_api.Blo
 		return longestTxs, staleTxs, true
 	}
 
-	return nil, nil, true
+	if len(orphans) > 0 {
+		staleTxs, ok = p.getRegisteredTransactions(ctx, orphans)
+	} else {
+		staleTxs, ok = p.getRegisteredTransactions(ctx, staleBlocks)
+	}
+	if !ok {
+		return nil, nil, false
+	}
+
+	longestTxs, ok = p.getRegisteredTransactions(ctx, longestBlocks)
+	if !ok {
+		return nil, nil, false
+	}
+
+	return nil, exclusiveRightTxs(longestTxs, staleTxs), true
 }
 
 func (p *Processor) performReorg(ctx context.Context, staleBlocks []*blocktx_api.Block, longestBlocks []*blocktx_api.Block) (longestTxs, staleTxs []store.BlockTransaction, err error) {
@@ -754,7 +768,7 @@ func (p *Processor) handleOrphans(ctx context.Context, block *blocktx_api.Block)
 		}
 
 		block.Status = blocktx_api.Status_STALE
-		return p.handleStaleBlock(ctx, block)
+		return p.handleStaleBlock(ctx, block, orphans...)
 	}
 
 	if ancestor.Status == blocktx_api.Status_LONGEST {

--- a/internal/blocktx/processor_test.go
+++ b/internal/blocktx/processor_test.go
@@ -165,13 +165,13 @@ func TestHandleBlock(t *testing.T) {
 				GetLongestBlockByHeightFunc: func(_ context.Context, _ uint64) (*blocktx_api.Block, error) {
 					return nil, store.ErrBlockNotFound
 				},
-				GetChainTipFunc: func(_ context.Context) (*blocktx_api.Block, error) {
+				GetChainTipFunc: func(_ context.Context, _ int) (*blocktx_api.Block, error) {
 					return nil, store.ErrBlockNotFound
 				},
 				UpsertBlockFunc: func(_ context.Context, _ *blocktx_api.Block) (uint64, error) {
 					return 0, nil
 				},
-				GetMinedTransactionsFunc: func(_ context.Context, _ [][]byte, _ bool) ([]store.BlockTransaction, error) {
+				GetMinedTransactionsFunc: func(_ context.Context, _ [][]byte) ([]store.BlockTransaction, error) {
 					return nil, nil
 				},
 				GetRegisteredTxsByBlockHashesFunc: func(_ context.Context, _ [][]byte) ([]store.BlockTransaction, error) {
@@ -367,7 +367,7 @@ func TestHandleBlockReorgAndOrphans(t *testing.T) {
 					}
 					return nil, store.ErrBlockNotFound
 				},
-				GetChainTipFunc: func(_ context.Context) (*blocktx_api.Block, error) {
+				GetChainTipFunc: func(_ context.Context, _ int) (*blocktx_api.Block, error) {
 					return &blocktx_api.Block{}, nil
 				},
 				UpsertBlockFunc: func(_ context.Context, block *blocktx_api.Block) (uint64, error) {

--- a/internal/blocktx/processor_test.go
+++ b/internal/blocktx/processor_test.go
@@ -427,7 +427,7 @@ func TestHandleBlockReorgAndOrphans(t *testing.T) {
 				GetRegisteredTxsByBlockHashesFunc: func(_ context.Context, _ [][]byte) ([]store.BlockTransaction, error) {
 					return nil, nil
 				},
-				GetMinedTransactionsFunc: func(_ context.Context, _ [][]byte, _ bool) ([]store.BlockTransaction, error) {
+				GetMinedTransactionsFunc: func(_ context.Context, _ [][]byte) ([]store.BlockTransaction, error) {
 					return nil, nil
 				},
 				GetBlockTransactionsHashesFunc: func(_ context.Context, _ []byte) ([]*chainhash.Hash, error) {
@@ -680,7 +680,7 @@ func TestStartProcessRegisterTxs(t *testing.T) {
 				RegisterTransactionsFunc: func(_ context.Context, _ [][]byte) (int64, error) {
 					return 0, registerErrTest
 				},
-				GetMinedTransactionsFunc: func(_ context.Context, _ [][]byte, _ bool) ([]store.BlockTransaction, error) {
+				GetMinedTransactionsFunc: func(_ context.Context, _ [][]byte) ([]store.BlockTransaction, error) {
 					return tc.getMinedTxs, tc.getMinedTxsErr
 				},
 				GetBlockTransactionsHashesFunc: func(_ context.Context, _ []byte) ([]*chainhash.Hash, error) {

--- a/internal/blocktx/store/mocks/blocktx_store_mock.go
+++ b/internal/blocktx/store/mocks/blocktx_store_mock.go
@@ -37,7 +37,7 @@ var _ store.BlocktxStore = &BlocktxStoreMock{}
 //			GetBlockTransactionsHashesFunc: func(ctx context.Context, blockHash []byte) ([]*chainhash.Hash, error) {
 //				panic("mock out the GetBlockTransactionsHashes method")
 //			},
-//			GetChainTipFunc: func(ctx context.Context) (*blocktx_api.Block, error) {
+//			GetChainTipFunc: func(ctx context.Context, heightRange int) (*blocktx_api.Block, error) {
 //				panic("mock out the GetChainTip method")
 //			},
 //			GetLongestBlockByHeightFunc: func(ctx context.Context, height uint64) (*blocktx_api.Block, error) {
@@ -46,7 +46,7 @@ var _ store.BlocktxStore = &BlocktxStoreMock{}
 //			GetLongestChainFromHeightFunc: func(ctx context.Context, height uint64) ([]*blocktx_api.Block, error) {
 //				panic("mock out the GetLongestChainFromHeight method")
 //			},
-//			GetMinedTransactionsFunc: func(ctx context.Context, hashes [][]byte, onlyLongestChain bool) ([]store.BlockTransaction, error) {
+//			GetMinedTransactionsFunc: func(ctx context.Context, hashes [][]byte) ([]store.BlockTransaction, error) {
 //				panic("mock out the GetMinedTransactions method")
 //			},
 //			GetOrphansBackToNonOrphanAncestorFunc: func(ctx context.Context, hash []byte) ([]*blocktx_api.Block, *blocktx_api.Block, error) {
@@ -108,7 +108,7 @@ type BlocktxStoreMock struct {
 	GetBlockTransactionsHashesFunc func(ctx context.Context, blockHash []byte) ([]*chainhash.Hash, error)
 
 	// GetChainTipFunc mocks the GetChainTip method.
-	GetChainTipFunc func(ctx context.Context) (*blocktx_api.Block, error)
+	GetChainTipFunc func(ctx context.Context, heightRange int) (*blocktx_api.Block, error)
 
 	// GetLongestBlockByHeightFunc mocks the GetLongestBlockByHeight method.
 	GetLongestBlockByHeightFunc func(ctx context.Context, height uint64) (*blocktx_api.Block, error)
@@ -117,7 +117,7 @@ type BlocktxStoreMock struct {
 	GetLongestChainFromHeightFunc func(ctx context.Context, height uint64) ([]*blocktx_api.Block, error)
 
 	// GetMinedTransactionsFunc mocks the GetMinedTransactions method.
-	GetMinedTransactionsFunc func(ctx context.Context, hashes [][]byte, onlyLongestChain bool) ([]store.BlockTransaction, error)
+	GetMinedTransactionsFunc func(ctx context.Context, hashes [][]byte) ([]store.BlockTransaction, error)
 
 	// GetOrphansBackToNonOrphanAncestorFunc mocks the GetOrphansBackToNonOrphanAncestor method.
 	GetOrphansBackToNonOrphanAncestorFunc func(ctx context.Context, hash []byte) ([]*blocktx_api.Block, *blocktx_api.Block, error)
@@ -194,6 +194,8 @@ type BlocktxStoreMock struct {
 		GetChainTip []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// HeightRange is the heightRange argument value.
+			HeightRange int
 		}
 		// GetLongestBlockByHeight holds details about calls to the GetLongestBlockByHeight method.
 		GetLongestBlockByHeight []struct {
@@ -215,8 +217,6 @@ type BlocktxStoreMock struct {
 			Ctx context.Context
 			// Hashes is the hashes argument value.
 			Hashes [][]byte
-			// OnlyLongestChain is the onlyLongestChain argument value.
-			OnlyLongestChain bool
 		}
 		// GetOrphansBackToNonOrphanAncestor holds details about calls to the GetOrphansBackToNonOrphanAncestor method.
 		GetOrphansBackToNonOrphanAncestor []struct {
@@ -512,19 +512,21 @@ func (mock *BlocktxStoreMock) GetBlockTransactionsHashesCalls() []struct {
 }
 
 // GetChainTip calls GetChainTipFunc.
-func (mock *BlocktxStoreMock) GetChainTip(ctx context.Context) (*blocktx_api.Block, error) {
+func (mock *BlocktxStoreMock) GetChainTip(ctx context.Context, heightRange int) (*blocktx_api.Block, error) {
 	if mock.GetChainTipFunc == nil {
 		panic("BlocktxStoreMock.GetChainTipFunc: method is nil but BlocktxStore.GetChainTip was just called")
 	}
 	callInfo := struct {
-		Ctx context.Context
+		Ctx         context.Context
+		HeightRange int
 	}{
-		Ctx: ctx,
+		Ctx:         ctx,
+		HeightRange: heightRange,
 	}
 	mock.lockGetChainTip.Lock()
 	mock.calls.GetChainTip = append(mock.calls.GetChainTip, callInfo)
 	mock.lockGetChainTip.Unlock()
-	return mock.GetChainTipFunc(ctx)
+	return mock.GetChainTipFunc(ctx, heightRange)
 }
 
 // GetChainTipCalls gets all the calls that were made to GetChainTip.
@@ -532,10 +534,12 @@ func (mock *BlocktxStoreMock) GetChainTip(ctx context.Context) (*blocktx_api.Blo
 //
 //	len(mockedBlocktxStore.GetChainTipCalls())
 func (mock *BlocktxStoreMock) GetChainTipCalls() []struct {
-	Ctx context.Context
+	Ctx         context.Context
+	HeightRange int
 } {
 	var calls []struct {
-		Ctx context.Context
+		Ctx         context.Context
+		HeightRange int
 	}
 	mock.lockGetChainTip.RLock()
 	calls = mock.calls.GetChainTip
@@ -616,23 +620,21 @@ func (mock *BlocktxStoreMock) GetLongestChainFromHeightCalls() []struct {
 }
 
 // GetMinedTransactions calls GetMinedTransactionsFunc.
-func (mock *BlocktxStoreMock) GetMinedTransactions(ctx context.Context, hashes [][]byte, onlyLongestChain bool) ([]store.BlockTransaction, error) {
+func (mock *BlocktxStoreMock) GetMinedTransactions(ctx context.Context, hashes [][]byte) ([]store.BlockTransaction, error) {
 	if mock.GetMinedTransactionsFunc == nil {
 		panic("BlocktxStoreMock.GetMinedTransactionsFunc: method is nil but BlocktxStore.GetMinedTransactions was just called")
 	}
 	callInfo := struct {
-		Ctx              context.Context
-		Hashes           [][]byte
-		OnlyLongestChain bool
+		Ctx    context.Context
+		Hashes [][]byte
 	}{
-		Ctx:              ctx,
-		Hashes:           hashes,
-		OnlyLongestChain: onlyLongestChain,
+		Ctx:    ctx,
+		Hashes: hashes,
 	}
 	mock.lockGetMinedTransactions.Lock()
 	mock.calls.GetMinedTransactions = append(mock.calls.GetMinedTransactions, callInfo)
 	mock.lockGetMinedTransactions.Unlock()
-	return mock.GetMinedTransactionsFunc(ctx, hashes, onlyLongestChain)
+	return mock.GetMinedTransactionsFunc(ctx, hashes)
 }
 
 // GetMinedTransactionsCalls gets all the calls that were made to GetMinedTransactions.
@@ -640,14 +642,12 @@ func (mock *BlocktxStoreMock) GetMinedTransactions(ctx context.Context, hashes [
 //
 //	len(mockedBlocktxStore.GetMinedTransactionsCalls())
 func (mock *BlocktxStoreMock) GetMinedTransactionsCalls() []struct {
-	Ctx              context.Context
-	Hashes           [][]byte
-	OnlyLongestChain bool
+	Ctx    context.Context
+	Hashes [][]byte
 } {
 	var calls []struct {
-		Ctx              context.Context
-		Hashes           [][]byte
-		OnlyLongestChain bool
+		Ctx    context.Context
+		Hashes [][]byte
 	}
 	mock.lockGetMinedTransactions.RLock()
 	calls = mock.calls.GetMinedTransactions

--- a/internal/blocktx/store/postgresql/fixtures/get_block_by_height/blocktx.blocks.yaml
+++ b/internal/blocktx/store/postgresql/fixtures/get_block_by_height/blocktx.blocks.yaml
@@ -54,3 +54,15 @@
   tx_count: 36724
   status: 10
   chainwork: '123456'
+- inserted_at: 2023-12-15 14:50:00
+  id: 5
+  hash: 0x000000000000000005167c951069b0e3c803753b8ebeaa2ddaca85b89526b297
+  prevhash: 0x76404890880cb36ce68100abb05b3a958e17c0ed274d5c0a0000000000000000
+  merkleroot: 0xc458aa382364e216c9c0533175ec8579a544c750ca181b18296e784d1dc53085
+  height: 822025
+  processed_at: 2023-12-15 14:40:00
+  size: 8630000
+  tx_count: 36724
+  status: 30 # ORPHANED
+  is_longest: false
+  chainwork: '123456'

--- a/internal/blocktx/store/postgresql/fixtures/insert_block_transactions/blocktx.blocks.yaml
+++ b/internal/blocktx/store/postgresql/fixtures/insert_block_transactions/blocktx.blocks.yaml
@@ -4,7 +4,7 @@
   prevhash:  0x000000000000000001a7aa3999410ca53fb645851531ec0a7a5cb9ce2d4ae313
   merkleroot:  0x0d72bf92e7862df18d1935c171ca4dbb70d268b0f025e46716e913bc7e4f2bdb
   height:  826481
-  status: 10 # STALE
+  status: 10
   is_longest: true
   processed_at:  2024-01-10 13:06:06.122
   size:  108689370

--- a/internal/blocktx/store/postgresql/get_block.go
+++ b/internal/blocktx/store/postgresql/get_block.go
@@ -22,10 +22,14 @@ func (p *PostgreSQL) GetLongestBlockByHeight(ctx context.Context, height uint64)
 	return p.queryBlockByPredicate(ctx, predicate, height)
 }
 
-func (p *PostgreSQL) GetChainTip(ctx context.Context) (*blocktx_api.Block, error) {
-	predicate := "WHERE height = (SELECT MAX(height) FROM blocktx.blocks blks WHERE blks.is_longest = true)"
+func (p *PostgreSQL) GetChainTip(ctx context.Context, heightRange int) (*blocktx_api.Block, error) {
+	predicate := `WHERE height = (SELECT MAX(height) from blocktx.blocks WHERE is_longest = true)
+									AND is_longest = true
+									AND height > (SELECT MAX(height) - $1 from blocktx.blocks)
+									AND processed_at IS NOT NULL
+	`
 
-	return p.queryBlockByPredicate(ctx, predicate)
+	return p.queryBlockByPredicate(ctx, predicate, heightRange)
 }
 
 func (p *PostgreSQL) queryBlockByPredicate(ctx context.Context, predicate string, predicateParams ...any) (*blocktx_api.Block, error) {

--- a/internal/blocktx/store/postgresql/get_transactions.go
+++ b/internal/blocktx/store/postgresql/get_transactions.go
@@ -11,16 +11,11 @@ import (
 	"github.com/bitcoin-sv/arc/pkg/tracing"
 )
 
-func (p *PostgreSQL) GetMinedTransactions(ctx context.Context, hashes [][]byte, onlyLongestChain bool) (minedTransactions []store.BlockTransaction, err error) {
+func (p *PostgreSQL) GetMinedTransactions(ctx context.Context, hashes [][]byte) (minedTransactions []store.BlockTransaction, err error) {
 	ctx, span := tracing.StartTracing(ctx, "GetMinedTransactions", p.tracingEnabled, p.tracingAttributes...)
 	defer func() {
 		tracing.EndTracing(span, err)
 	}()
-
-	if onlyLongestChain {
-		predicate := "WHERE bt.hash = ANY($1) AND b.is_longest = true"
-		return p.getTransactionBlocksByPredicate(ctx, predicate, pq.Array(hashes))
-	}
 
 	predicate := "WHERE bt.hash = ANY($1) AND (b.status = $2 OR b.status = $3) AND b.processed_at IS NOT NULL"
 

--- a/internal/blocktx/store/postgresql/postgres_test.go
+++ b/internal/blocktx/store/postgresql/postgres_test.go
@@ -903,10 +903,12 @@ func TestPostgresStore_InsertTransactions_CompetingBlocks(t *testing.T) {
 			MerkleRoot:      testutils.HexDecodeString(t, "0d72bf92e7862df18d1935c171ca4dbb70d268b0f025e46716e913bc7e4f2bdb"),
 		},
 		{
-			TxHash:      txHash[:],
-			BlockHash:   testutils.RevChainhash(t, "7258b02da70a3e367e4c993b049fa9b76ef8f090ef9fd2010000000000000000")[:],
-			BlockHeight: uint64(826481),
-			BlockStatus: blocktx_api.Status_STALE,
+			TxHash:          txHash[:],
+			BlockHash:       testutils.RevChainhash(t, "7258b02da70a3e367e4c993b049fa9b76ef8f090ef9fd2010000000000000000")[:],
+			BlockHeight:     uint64(826481),
+			BlockStatus:     blocktx_api.Status_STALE,
+			MerkleTreeIndex: int64(0),
+			MerkleRoot:      testutils.HexDecodeString(t, "0d72bf92e7862df18d1935c171ca4dbb70d268b0f025e46716e913bc7e4f2bdb"),
 		},
 	}
 

--- a/internal/blocktx/store/postgresql/postgres_test.go
+++ b/internal/blocktx/store/postgresql/postgres_test.go
@@ -906,7 +906,6 @@ func TestPostgresStore_InsertTransactions_CompetingBlocks(t *testing.T) {
 			TxHash:      txHash[:],
 			BlockHash:   testutils.RevChainhash(t, "7258b02da70a3e367e4c993b049fa9b76ef8f090ef9fd2010000000000000000")[:],
 			BlockHeight: uint64(826481),
-			MerklePath:  "merkle-path-2",
 			BlockStatus: blocktx_api.Status_STALE,
 		},
 	}

--- a/internal/blocktx/store/store.go
+++ b/internal/blocktx/store/store.go
@@ -35,13 +35,13 @@ type BlocktxStore interface {
 	RegisterTransactions(ctx context.Context, txHashes [][]byte) (rowsAffected int64, err error)
 	GetBlock(ctx context.Context, hash *chainhash.Hash) (*blocktx_api.Block, error)
 	GetLongestBlockByHeight(ctx context.Context, height uint64) (*blocktx_api.Block, error)
-	GetChainTip(ctx context.Context) (*blocktx_api.Block, error)
+	GetChainTip(ctx context.Context, heightRange int) (*blocktx_api.Block, error)
 	UpsertBlock(ctx context.Context, block *blocktx_api.Block) (uint64, error)
 	InsertBlockTransactions(ctx context.Context, blockID uint64, txsWithMerklePaths []TxHashWithMerkleTreeIndex) error
 	MarkBlockAsDone(ctx context.Context, hash *chainhash.Hash, size uint64, txCount uint64) error
 	GetBlockGaps(ctx context.Context, heightRange int) ([]*BlockGap, error)
 	ClearBlocktxTable(ctx context.Context, retentionDays int32, table string) (*blocktx_api.RowsAffectedResponse, error)
-	GetMinedTransactions(ctx context.Context, hashes [][]byte, onlyLongestChain bool) ([]BlockTransaction, error)
+	GetMinedTransactions(ctx context.Context, hashes [][]byte) ([]BlockTransaction, error)
 	GetLongestChainFromHeight(ctx context.Context, height uint64) ([]*blocktx_api.Block, error)
 	GetStaleChainBackFromHash(ctx context.Context, hash []byte) ([]*blocktx_api.Block, error)
 	GetOrphansBackToNonOrphanAncestor(ctx context.Context, hash []byte) (orphans []*blocktx_api.Block, nonOrphanAncestor *blocktx_api.Block, err error)

--- a/internal/metamorph/bcnet/mediator.go
+++ b/internal/metamorph/bcnet/mediator.go
@@ -82,21 +82,24 @@ func NewMediator(l *slog.Logger, classic bool, messenger *p2p.NetworkMessenger, 
 
 func (m *Mediator) AskForTxAsync(ctx context.Context, tx *store.Data) {
 	_, span := tracing.StartTracing(ctx, "AskForTxAsync", m.tracingEnabled, m.tracingAttributes...)
+	defer func() {
+		tracing.EndTracing(span, nil)
+	}()
 
 	m.p2pMessenger.RequestWithAutoBatch(tx.Hash, wire.InvTypeTx)
-	tracing.EndTracing(span, nil)
 }
 
 func (m *Mediator) AnnounceTxAsync(ctx context.Context, tx *store.Data) {
 	_, span := tracing.StartTracing(ctx, "AskForTxAsync", m.tracingEnabled, m.tracingAttributes...)
+	defer func() {
+		tracing.EndTracing(span, nil)
+	}()
 
 	if m.classic {
 		m.p2pMessenger.AnnounceWithAutoBatch(tx.Hash, wire.InvTypeTx)
 	} else {
 		_ = m.mcaster.SendTx(tx.RawTx)
 	}
-
-	tracing.EndTracing(span, nil)
 }
 
 func (m *Mediator) GetPeers() []p2p.PeerI {

--- a/internal/metamorph/processor.go
+++ b/internal/metamorph/processor.go
@@ -346,7 +346,7 @@ func (p *Processor) updateMined(ctx context.Context, txsBlocks []*blocktx_api.Tr
 }
 
 func (p *Processor) rebroadcastStaleTxs(ctx context.Context, txsBlocks []*blocktx_api.TransactionBlock) {
-	ctx, span := tracing.StartTracing(ctx, "rebroadcastStaleTxs", p.tracingEnabled, p.tracingAttributes...)
+	_, span := tracing.StartTracing(ctx, "rebroadcastStaleTxs", p.tracingEnabled, p.tracingAttributes...)
 	defer tracing.EndTracing(span, nil)
 
 	for _, tx := range txsBlocks {

--- a/internal/metamorph/processor.go
+++ b/internal/metamorph/processor.go
@@ -361,12 +361,12 @@ func (p *Processor) rebroadcastStaleTxs(ctx context.Context, txsBlocks []*blockt
 
 		p.logger.Debug("Re-announcing stale tx", slog.String("hash", txHash.String()))
 
-		tx, err := p.store.Get(ctx, txHash[:])
+		txData, err := p.store.Get(ctx, txHash[:])
 		if err != nil {
 			p.logger.Error("Failed to get transaction", slog.String("hash", txHash.String()))
 			continue
 		}
-		p.bcMediator.AnnounceTxAsync(ctx, tx)
+		p.bcMediator.AnnounceTxAsync(ctx, txData)
 	}
 }
 

--- a/internal/metamorph/processor_helpers.go
+++ b/internal/metamorph/processor_helpers.go
@@ -9,8 +9,6 @@ import (
 	"github.com/libsv/go-p2p/chaincfg/chainhash"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/libsv/go-p2p/chaincfg/chainhash"
-
 	"github.com/bitcoin-sv/arc/internal/cache"
 	"github.com/bitcoin-sv/arc/internal/callbacker/callbacker_api"
 	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"

--- a/internal/metamorph/processor_helpers.go
+++ b/internal/metamorph/processor_helpers.go
@@ -9,6 +9,8 @@ import (
 	"github.com/libsv/go-p2p/chaincfg/chainhash"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/libsv/go-p2p/chaincfg/chainhash"
+
 	"github.com/bitcoin-sv/arc/internal/cache"
 	"github.com/bitcoin-sv/arc/internal/callbacker/callbacker_api"
 	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
@@ -119,15 +121,11 @@ func (p *Processor) getStatusUpdateCount() (int, error) {
 }
 
 func shouldUpdateCompetingTxs(new, found store.UpdateStatus) bool {
-	if new.Status >= found.Status && !unorderedEqual(new.CompetingTxs, found.CompetingTxs) {
-		return true
-	}
-
-	return false
+	return new.Status >= found.Status && !unorderedEqual(new.CompetingTxs, found.CompetingTxs)
 }
 
 func shouldUpdateStatus(new, found store.UpdateStatus) bool {
-	return new.Status > found.Status
+	return new.Status > found.Status || found.Status == metamorph_api.Status_MINED_IN_STALE_BLOCK
 }
 
 // unorderedEqual checks if two string slices contain

--- a/internal/metamorph/store/postgresql/fixtures/update_double_spend/metamorph.transactions.yaml
+++ b/internal/metamorph/store/postgresql/fixtures/update_double_spend/metamorph.transactions.yaml
@@ -30,3 +30,8 @@
   status: 70
   stored_at: 2023-10-01 14:00:00
   last_submitted_at: 2023-10-01 14:00:00
+- hash: 0xfe3ae78226a8a1c78039a7d10590a42dc4b691acaa8cbc6831b464da49e8ba08
+  locked_by: metamorph-1
+  status: 115
+  stored_at: 2023-10-01 14:00:00
+  last_submitted_at: 2023-10-01 14:00:00

--- a/internal/metamorph/store/postgresql/fixtures/update_status/metamorph.transactions.yaml
+++ b/internal/metamorph/store/postgresql/fixtures/update_status/metamorph.transactions.yaml
@@ -28,3 +28,8 @@
   status: 70
   stored_at: 2023-10-01 14:00:00
   last_submitted_at: 2023-10-01 14:00:00
+- hash: 0xfe3ae78226a8a1c78039a7d10590a42dc4b691acaa8cbc6831b464da49e8ba08
+  locked_by: metamorph-1
+  status: 115
+  stored_at: 2023-10-01 14:00:00
+  last_submitted_at: 2023-10-01 14:00:00

--- a/internal/metamorph/store/postgresql/postgres.go
+++ b/internal/metamorph/store/postgresql/postgres.go
@@ -689,8 +689,8 @@ func (p *PostgreSQL) UpdateStatusBulk(ctx context.Context, updates []store.Updat
 				SELECT t.hash, t.status, t.reject_reason, t.history_update, t.timestamp
 				FROM UNNEST($2::BYTEA[], $3::INT[], $4::TEXT[], $5::JSONB[], $6::TIMESTAMP WITH TIME ZONE[]) AS t(hash, status, reject_reason, history_update, timestamp)
 			) AS bulk_query
-			WHERE metamorph.transactions.hash = bulk_query.hash
-				AND metamorph.transactions.status < bulk_query.status
+			WHERE metamorph.transactions.hash=bulk_query.hash
+				AND (metamorph.transactions.status < bulk_query.status OR metamorph.transactions.status=$7)
 		RETURNING metamorph.transactions.stored_at
 		,metamorph.transactions.hash
 		,metamorph.transactions.status
@@ -722,7 +722,15 @@ func (p *PostgreSQL) UpdateStatusBulk(ctx context.Context, updates []store.Updat
 		return nil, err
 	}
 
-	rows, err := tx.QueryContext(ctx, qBulk, p.now(), pq.Array(txHashes), pq.Array(statuses), pq.Array(rejectReasons), pq.Array(statusHistories), pq.Array(timestamps))
+	rows, err := tx.QueryContext(ctx, qBulk,
+		p.now(),
+		pq.Array(txHashes),
+		pq.Array(statuses),
+		pq.Array(rejectReasons),
+		pq.Array(statusHistories),
+		pq.Array(timestamps),
+		metamorph_api.Status_MINED_IN_STALE_BLOCK,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -880,7 +888,7 @@ func (p *PostgreSQL) UpdateDoubleSpend(ctx context.Context, updates []store.Upda
 				AS t(hash, status, reject_reason, competing_txs)
 			) AS bulk_query
 			WHERE metamorph.transactions.hash=bulk_query.hash
-				AND metamorph.transactions.status <= bulk_query.status
+				AND (metamorph.transactions.status <= bulk_query.status OR metamorph.transactions.status=$6)
 				AND (metamorph.transactions.competing_txs IS NULL
 						OR LENGTH(metamorph.transactions.competing_txs) < LENGTH(bulk_query.competing_txs))
 		RETURNING metamorph.transactions.stored_at
@@ -943,7 +951,14 @@ func (p *PostgreSQL) UpdateDoubleSpend(ctx context.Context, updates []store.Upda
 		}
 	}
 
-	rows, err = tx.QueryContext(ctx, qBulk, p.now(), pq.Array(txHashes), pq.Array(statuses), pq.Array(rejectReasons), pq.Array(competingTxs))
+	rows, err = tx.QueryContext(ctx, qBulk,
+		p.now(),
+		pq.Array(txHashes),
+		pq.Array(statuses),
+		pq.Array(rejectReasons),
+		pq.Array(competingTxs),
+		metamorph_api.Status_MINED_IN_STALE_BLOCK,
+	)
 	if err != nil {
 		if rollbackErr := tx.Rollback(); rollbackErr != nil {
 			return nil, errors.Join(err, fmt.Errorf("failed to rollback: %v", rollbackErr))

--- a/internal/metamorph/store/postgresql/postgres_test.go
+++ b/internal/metamorph/store/postgresql/postgres_test.go
@@ -388,6 +388,10 @@ func TestPostgresDB(t *testing.T) {
 				Status: metamorph_api.Status_SENT_TO_NETWORK,
 			},
 			{
+				Hash:   *testutils2.RevChainhash(t, "fe3ae78226a8a1c78039a7d10590a42dc4b691acaa8cbc6831b464da49e8ba08"), // update expected - old status = MINED_IN_STALE_BLOCK
+				Status: metamorph_api.Status_SEEN_ON_NETWORK,
+			},
+			{
 				Hash:   *testutils2.RevChainhash(t, "3ce1e0c6cbbbe2118c3f80d2e6899d2d487f319ef0923feb61f3d26335b2225c"), // update not expected - hash non-existent in db
 				Status: metamorph_api.Status_ANNOUNCED_TO_NETWORK,
 			},
@@ -396,7 +400,7 @@ func TestPostgresDB(t *testing.T) {
 				Status: metamorph_api.Status_ANNOUNCED_TO_NETWORK,
 			},
 		}
-		updatedStatuses := 3
+		updatedStatuses := 4
 
 		statusUpdates, err := postgresDB.UpdateStatusBulk(ctx, updates)
 		require.NoError(t, err)
@@ -411,6 +415,9 @@ func TestPostgresDB(t *testing.T) {
 
 		require.Equal(t, metamorph_api.Status_SEEN_ON_NETWORK, statusUpdates[2].Status)
 		require.Equal(t, *testutils2.RevChainhash(t, "ee76f5b746893d3e6ae6a14a15e464704f4ebd601537820933789740acdcf6aa"), *statusUpdates[2].Hash)
+
+		require.Equal(t, metamorph_api.Status_SEEN_ON_NETWORK, statusUpdates[3].Status)
+		require.Equal(t, *testutils2.RevChainhash(t, "fe3ae78226a8a1c78039a7d10590a42dc4b691acaa8cbc6831b464da49e8ba08"), *statusUpdates[3].Hash)
 
 		returnedDataRequested, err := postgresDB.Get(ctx, testutils2.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f")[:])
 		require.NoError(t, err)
@@ -453,6 +460,11 @@ func TestPostgresDB(t *testing.T) {
 				Error:        errors.New("double spend attempted"),
 			},
 			{
+				Hash:         *testutils2.RevChainhash(t, "fe3ae78226a8a1c78039a7d10590a42dc4b691acaa8cbc6831b464da49e8ba08"), // update expected - old status = MINED_IN_STALE_BLOCK
+				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
+				CompetingTxs: []string{"1234"},
+			},
+			{
 				Hash:         *testutils2.RevChainhash(t, "3ce1e0c6cbbbe2118c3f80d2e6899d2d487f319ef0923feb61f3d26335b2225c"), // update not expected - hash non-existent in db
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"1234"},
@@ -463,7 +475,7 @@ func TestPostgresDB(t *testing.T) {
 				CompetingTxs: []string{"1234"},
 			},
 		}
-		updatedStatuses := 4
+		updatedStatuses := 5
 
 		statusUpdates, err := postgresDB.UpdateDoubleSpend(ctx, updates)
 		require.NoError(t, err)
@@ -485,6 +497,10 @@ func TestPostgresDB(t *testing.T) {
 		require.Equal(t, *testutils2.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f"), *statusUpdates[3].Hash)
 		require.Equal(t, []string{"1234"}, statusUpdates[3].CompetingTxs)
 		require.Equal(t, "double spend attempted", statusUpdates[3].RejectReason)
+
+		require.Equal(t, metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, statusUpdates[4].Status)
+		require.Equal(t, *testutils2.RevChainhash(t, "fe3ae78226a8a1c78039a7d10590a42dc4b691acaa8cbc6831b464da49e8ba08"), *statusUpdates[4].Hash)
+		require.Equal(t, []string{"1234"}, statusUpdates[4].CompetingTxs)
 
 		statusUpdates, err = postgresDB.UpdateDoubleSpend(ctx, updates)
 		require.NoError(t, err)

--- a/test/submit_05_reorg_test.go
+++ b/test/submit_05_reorg_test.go
@@ -145,7 +145,7 @@ func TestReorg(t *testing.T) {
 	// verify that stale tx is still SEEN_ON_NETWORK
 	statusURL = fmt.Sprintf("%s/%s", arcEndpointV1Tx, txStale.TxID())
 	statusResp = getRequest[TransactionResponse](t, statusURL)
-	require.Equal(t, StatusSeenOnNetwork, statusResp.TxStatus)
+	require.Equal(t, StatusMinedInStaleBlock, statusResp.TxStatus)
 
 	// verify that nothing changed so far with previous mined txs
 	statusURL = fmt.Sprintf("%s/%s", arcEndpointV1Tx, tx1.TxID())

--- a/test/submit_05_reorg_test.go
+++ b/test/submit_05_reorg_test.go
@@ -174,22 +174,11 @@ func TestReorg(t *testing.T) {
 	require.Equal(t, StatusMined, statusResp.TxStatus)
 	require.Equal(t, staleHash, *statusResp.BlockHash)
 
-	// verify that tx2 is now MINED_IN_STALE_BLOCK
-	statusURL = fmt.Sprintf("%s/%s", arcEndpointV1Tx, tx2.TxID())
+	// verify that tx2 was rebroadcasted and is now MINED with new block data
+	statusURL = fmt.Sprintf("%s/%s", arcEndpointV1Tx, tx2.TxID().String())
 	statusResp = getRequest[TransactionResponse](t, statusURL)
-	require.Equal(t, StatusMinedInStaleBlock, statusResp.TxStatus)
+	require.Equal(t, StatusMined, statusResp.TxStatus)
 	require.Equal(t, tx2BlockHash, *statusResp.BlockHash)
-
-	// verify that callback for tx2 was received with status MINED_IN_STALE_BLOCK
-	select {
-	case status := <-callbackReceivedChan:
-		require.Equal(t, tx2.TxID().String(), status.Txid)
-		require.Equal(t, StatusMinedInStaleBlock, status.TxStatus)
-	case err := <-callbackErrChan:
-		t.Fatalf("callback error: %v", err)
-	case <-time.After(1 * time.Second):
-		t.Fatal("callback exceeded timeout")
-	}
 }
 
 func call(t *testing.T, method string, params []interface{}) {


### PR DESCRIPTION
## Description of Changes

Replaces https://github.com/bitcoin-sv/arc/pull/691

- Transactions that are ONLY in the STALE chain and are not found in the longest chain, will try to be re-announced to the network and circle back from statuses SEEN_ON_NETWORK forward.
- Removed option onlyLongestChain from GetMinedTransactions blocktx store method.
- Respecting height range in GetChainTip blocktx store method.

## Testing Procedure

- [X] I have added new unit tests
- [X] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have updated `CHANGELOG.md` with my changes
