### PR TITLE
test: reorg support e2e tests

### DIFF
--- a/test/submit_01_single_test.go
+++ b/test/submit_01_single_test.go
@@ -13,8 +13,6 @@ import (
 	"time"
 
 	sdkTx "github.com/bitcoin-sv/go-sdk/transaction"
-	"github.com/libsv/go-bc"
-	"github.com/libsv/go-p2p/chaincfg/chainhash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -142,28 +140,8 @@ func TestSubmitMined(t *testing.T) {
 		tx, _ := sdkTx.NewTransactionFromHex(rawTx.Hex)
 		exRawTx := tx.String()
 
-		blockData := node_client.GetBlockDataByBlockHash(t, bitcoind, rawTx.BlockHash)
-		blockTxHashes := make([]*chainhash.Hash, len(blockData.Txs))
-		var txIndex uint64
-
-		for i, blockTx := range blockData.Txs {
-			h, err := chainhash.NewHashFromStr(blockTx)
-			require.NoError(t, err)
-
-			blockTxHashes[i] = h
-
-			if blockTx == rawTx.Hash {
-				txIndex = uint64(i)
-			}
-		}
-
-		merkleTree := bc.BuildMerkleTreeStoreChainHash(blockTxHashes)
-		require.Equal(t, merkleTree[len(merkleTree)-1].String(), blockData.MerkleRoot)
-
-		merklePath, err := bc.NewBUMPFromMerkleTreeAndIndex(blockData.Height, merkleTree, txIndex)
-		require.NoError(t, err)
-		merklePathStr, err := merklePath.String()
-		require.NoError(t, err)
+		txID := utxos[0].Txid
+		merklePathStr := getMerklePath(t, txID)
 
 		callbackReceivedChan := make(chan *TransactionResponse)
 		callbackErrChan := make(chan error)

--- a/test/submit_05_reorg_test.go
+++ b/test/submit_05_reorg_test.go
@@ -3,7 +3,6 @@
 package test
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"testing"
@@ -20,39 +19,6 @@ func TestReorg(t *testing.T) {
 	utxos := node_client.GetUtxos(t, bitcoind, address)
 	require.True(t, len(utxos) > 0, "No UTXOs available for the address")
 
-	tx1, err := node_client.CreateTx(privateKey, address, utxos[0])
-	require.NoError(t, err)
-
-	// submit tx1
-	rawTx, err := tx1.EFHex()
-	require.NoError(t, err)
-	resp := postRequest[TransactionResponse](t, arcEndpointV1Tx, createPayload(t, TransactionRequest{RawTx: rawTx}), map[string]string{"X-WaitFor": StatusSeenOnNetwork}, http.StatusOK)
-	require.Equal(t, StatusSeenOnNetwork, resp.TxStatus)
-
-	// mine tx1
-	invHash := node_client.Generate(t, bitcoind, 1)
-
-	// verify tx1 = MINED
-	statusURL := fmt.Sprintf("%s/%s", arcEndpointV1Tx, tx1.TxID())
-	statusResp := getRequest[TransactionResponse](t, statusURL)
-	require.Equal(t, StatusMined, statusResp.TxStatus)
-	require.Equal(t, invHash, *statusResp.BlockHash)
-
-	// get new UTXO for tx2
-	txID := node_client.SendToAddress(t, bitcoind, address, float64(0.002))
-	utxos = node_client.GetUtxos(t, bitcoind, address)
-	require.True(t, len(utxos) > 0, "No UTXOs available for the address")
-
-	// make sure to pick the correct UTXO
-	var utxo node_client.UnspentOutput
-	for _, u := range utxos {
-		if u.Txid == txID {
-			utxo = u
-		}
-	}
-
-	tx2, err := node_client.CreateTx(privateKey, address, utxo)
-	require.NoError(t, err)
 	lis, err := net.Listen("tcp", ":9000")
 	require.NoError(t, err)
 	mux := http.NewServeMux()
@@ -80,6 +46,53 @@ func TestReorg(t *testing.T) {
 		}
 	}()
 
+	tx1, err := node_client.CreateTx(privateKey, address, utxos[0])
+	require.NoError(t, err)
+
+	// submit tx1
+	rawTx, err := tx1.EFHex()
+	require.NoError(t, err)
+	resp := postRequest[TransactionResponse](t, arcEndpointV1Tx, createPayload(t, TransactionRequest{RawTx: rawTx}),
+		map[string]string{
+			"X-WaitFor": StatusSeenOnNetwork,
+			//"X-CallbackUrl":   callbackURL,
+			//"X-CallbackToken": token,
+		}, http.StatusOK)
+	require.Equal(t, StatusSeenOnNetwork, resp.TxStatus)
+
+	// mine tx1
+	invHash := node_client.Generate(t, bitcoind, 1)
+
+	// verify tx1 = MINED
+	checkStatusBlockHash(t, tx1.TxID().String(), StatusMined, invHash)
+
+	//select {
+	//case status := <-callbackReceivedChan:
+	//	require.Equal(t, tx1.TxID().String(), status.Txid)
+	//	require.Equal(t, StatusMined, status.TxStatus)
+	//	require.Equal(t, invHash, *status.BlockHash)
+	//case err := <-callbackErrChan:
+	//	t.Fatalf("callback error: %v", err)
+	//case <-time.After(1 * time.Second):
+	//	t.Fatal("callback exceeded timeout")
+	//}
+
+	// get new UTXO for tx2
+	txID := node_client.SendToAddress(t, bitcoind, address, float64(0.002))
+	utxos = node_client.GetUtxos(t, bitcoind, address)
+	require.True(t, len(utxos) > 0, "No UTXOs available for the address")
+
+	// make sure to pick the correct UTXO
+	var utxo node_client.UnspentOutput
+	for _, u := range utxos {
+		if u.Txid == txID {
+			utxo = u
+		}
+	}
+
+	tx2, err := node_client.CreateTx(privateKey, address, utxo)
+	require.NoError(t, err)
+
 	// submit tx2
 	rawTx, err = tx2.EFHex()
 	require.NoError(t, err)
@@ -94,11 +107,8 @@ func TestReorg(t *testing.T) {
 	// mine tx2
 	tx2BlockHash := node_client.Generate(t, bitcoind, 1)
 
-	// verify tx2 = MINED
-	statusURL = fmt.Sprintf("%s/%s", arcEndpointV1Tx, tx2.TxID())
-	statusResp = getRequest[TransactionResponse](t, statusURL)
-	require.Equal(t, StatusMined, statusResp.TxStatus)
-	require.Equal(t, tx2BlockHash, *statusResp.BlockHash)
+	// verify tx2 is MINED
+	checkStatusBlockHash(t, tx2.TxID().String(), StatusMined, tx2BlockHash)
 
 	select {
 	case status := <-callbackReceivedChan:
@@ -143,42 +153,25 @@ func TestReorg(t *testing.T) {
 	staleHash := node_client.Generate(t, bitcoind, 1)
 
 	// verify that stale tx is still SEEN_ON_NETWORK
-	statusURL = fmt.Sprintf("%s/%s", arcEndpointV1Tx, txStale.TxID())
-	statusResp = getRequest[TransactionResponse](t, statusURL)
-	require.Equal(t, StatusSeenOnNetwork, statusResp.TxStatus)
+	checkStatus(t, txStale.TxID().String(), StatusSeenOnNetwork)
 
 	// verify that nothing changed so far with previous mined txs
-	statusURL = fmt.Sprintf("%s/%s", arcEndpointV1Tx, tx1.TxID())
-	statusResp = getRequest[TransactionResponse](t, statusURL)
-	require.Equal(t, StatusMined, statusResp.TxStatus)
-	require.Equal(t, invHash, *statusResp.BlockHash)
+	checkStatusBlockHash(t, tx1.TxID().String(), StatusMined, invHash)
 
-	statusURL = fmt.Sprintf("%s/%s", arcEndpointV1Tx, tx2.TxID())
-	statusResp = getRequest[TransactionResponse](t, statusURL)
-	require.Equal(t, StatusMined, statusResp.TxStatus)
-	require.Equal(t, tx2BlockHash, *statusResp.BlockHash)
+	checkStatusBlockHash(t, tx2.TxID().String(), StatusMined, tx2BlockHash)
 
 	// make the STALE chain LONGEST by adding 2 new blocks
 	node_client.Generate(t, bitcoind, 1)
 	node_client.Generate(t, bitcoind, 1)
 
 	// verify that stale tx is now MINED
-	statusURL = fmt.Sprintf("%s/%s", arcEndpointV1Tx, txStale.TxID())
-	statusResp = getRequest[TransactionResponse](t, statusURL)
-	require.Equal(t, StatusMined, statusResp.TxStatus)
-	require.Equal(t, staleHash, *statusResp.BlockHash)
+	checkStatusBlockHash(t, txStale.TxID().String(), StatusMined, staleHash)
 
 	// verify that previous mined tx1 have updated block info
-	statusURL = fmt.Sprintf("%s/%s", arcEndpointV1Tx, tx1.TxID())
-	statusResp = getRequest[TransactionResponse](t, statusURL)
-	require.Equal(t, StatusMined, statusResp.TxStatus)
-	require.Equal(t, staleHash, *statusResp.BlockHash)
+	checkStatusBlockHash(t, tx1.TxID().String(), StatusMined, staleHash)
 
 	// verify that tx2 is now MINED_IN_STALE_BLOCK
-	statusURL = fmt.Sprintf("%s/%s", arcEndpointV1Tx, tx2.TxID())
-	statusResp = getRequest[TransactionResponse](t, statusURL)
-	require.Equal(t, StatusMinedInStaleBlock, statusResp.TxStatus)
-	require.Equal(t, tx2BlockHash, *statusResp.BlockHash)
+	checkStatusBlockHash(t, tx2.TxID().String(), StatusMinedInStaleBlock, tx2BlockHash)
 
 	// verify that callback for tx2 was received with status MINED_IN_STALE_BLOCK
 	select {

--- a/test/utils.go
+++ b/test/utils.go
@@ -305,3 +305,16 @@ func checkMerklePath(t *testing.T, statusResponse TransactionResponse) {
 	blockRoot := node_client.GetBlockRootByHeight(t, bitcoind, int(*statusResponse.BlockHeight))
 	require.Equal(t, blockRoot, root)
 }
+
+func checkStatus(t *testing.T, txID string, expectedStatus string) {
+	statusURL := fmt.Sprintf("%s/%s", arcEndpointV1Tx, txID)
+	statusResp := getRequest[TransactionResponse](t, statusURL)
+	require.Equal(t, expectedStatus, statusResp.TxStatus)
+}
+
+func checkStatusBlockHash(t *testing.T, txID string, expectedStatus string, expectedBlockHash string) {
+	statusURL := fmt.Sprintf("%s/%s", arcEndpointV1Tx, txID)
+	statusResp := getRequest[TransactionResponse](t, statusURL)
+	require.Equal(t, expectedStatus, statusResp.TxStatus)
+	require.Equal(t, expectedBlockHash, *statusResp.BlockHash)
+}

--- a/test/utils.go
+++ b/test/utils.go
@@ -20,6 +20,7 @@ import (
 	sdkTx "github.com/bitcoin-sv/go-sdk/transaction"
 	"github.com/bitcoin-sv/go-sdk/transaction/template/p2pkh"
 	"github.com/libsv/go-bc"
+	"github.com/libsv/go-p2p/chaincfg/chainhash"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bitcoin-sv/arc/internal/node_client"
@@ -317,4 +318,32 @@ func checkStatusBlockHash(t *testing.T, txID string, expectedStatus string, expe
 	statusResp := getRequest[TransactionResponse](t, statusURL)
 	require.Equal(t, expectedStatus, statusResp.TxStatus)
 	require.Equal(t, expectedBlockHash, *statusResp.BlockHash)
+}
+
+func getMerklePath(t *testing.T, txID string) string {
+	rawTx, _ := bitcoind.GetRawTransaction(txID)
+	blockData := node_client.GetBlockDataByBlockHash(t, bitcoind, rawTx.BlockHash)
+	blockTxHashes := make([]*chainhash.Hash, len(blockData.Txs))
+	var txIndex uint64
+
+	for i, blockTx := range blockData.Txs {
+		h, err := chainhash.NewHashFromStr(blockTx)
+		require.NoError(t, err)
+
+		blockTxHashes[i] = h
+
+		if blockTx == rawTx.Hash {
+			txIndex = uint64(i)
+		}
+	}
+
+	merkleTree := bc.BuildMerkleTreeStoreChainHash(blockTxHashes)
+	require.Equal(t, merkleTree[len(merkleTree)-1].String(), blockData.MerkleRoot)
+
+	merklePath, err := bc.NewBUMPFromMerkleTreeAndIndex(blockData.Height, merkleTree, txIndex)
+	require.NoError(t, err)
+	merklePathStr, err := merklePath.String()
+	require.NoError(t, err)
+
+	return merklePathStr
 }


### PR DESCRIPTION
## Description of Changes

- Expand e2e test for block reorg: Check for 2nd callback with updated block hash & merkle path
- Refactor functions used in e2e tests

## Testing Procedure

- [X] I have added new unit tests
- [X] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
