### PR TITLE
feat: broadcaster ramp up

### DIFF
--- a/internal/broadcaster/helpers.go
+++ b/internal/broadcaster/helpers.go
@@ -90,6 +90,7 @@ type DynamicTicker struct {
 var (
 	ErrStepsZero                          = errors.New("steps must be greater than 0")
 	ErrStartIntervalNotGreaterEndInterval = errors.New("startInterval must be greater than endInterval")
+	ErrTickerIsNil                        = errors.New("ticker is nil")
 )
 
 // NewDynamicTicker returns a dynamic ticker based on time.Ticker. The time intervals linearly decrease starting from startInterval to endInterval. After a specified number of steps the time interval is equal to endInterval.
@@ -116,11 +117,15 @@ func (t *DynamicTicker) Stop() {
 	t.ticker.Stop()
 }
 
-func (t *DynamicTicker) GetTickerCh() <-chan time.Time {
+func (t *DynamicTicker) GetTickerCh() (<-chan time.Time, error) {
 	timeCh := make(chan time.Time)
 	step := int64(0)
 	stepsReached := false
 	stepNs := int64(float64(t.startInterval.Nanoseconds()-t.endInterval.Nanoseconds()) / float64(t.steps))
+
+	if t.ticker == nil {
+		return nil, ErrTickerIsNil
+	}
 
 	go func() {
 		for tick := range t.ticker.C {
@@ -143,5 +148,5 @@ func (t *DynamicTicker) GetTickerCh() <-chan time.Time {
 		}
 	}()
 
-	return timeCh
+	return timeCh, nil
 }

--- a/internal/broadcaster/helpers.go
+++ b/internal/broadcaster/helpers.go
@@ -92,6 +92,7 @@ var (
 	ErrStartIntervalNotGreaterEndInterval = errors.New("startInterval must be greater than endInterval")
 )
 
+// NewDynamicTicker returns a dynamic ticker based on time.Ticker. The time intervals linearly decrease starting from startInterval to endInterval. After a specified number of steps the time interval is equal to endInterval.
 func NewDynamicTicker(startInterval time.Duration, endInterval time.Duration, steps int64) (DynamicTicker, error) {
 	if steps < 1 {
 		return DynamicTicker{}, ErrStepsZero

--- a/internal/broadcaster/helpers.go
+++ b/internal/broadcaster/helpers.go
@@ -146,7 +146,6 @@ func (t *DynamicTicker) GetTickerCh() <-chan time.Time {
 
 				if step >= t.steps-1 {
 					if !stepsReached {
-						slog.Default().Info("new interval", "interval", t.endInterval)
 						t.ticker.Reset(t.endInterval)
 						stepsReached = true
 					}
@@ -157,8 +156,6 @@ func (t *DynamicTicker) GetTickerCh() <-chan time.Time {
 				step++
 
 				newInterval := t.startInterval - time.Duration(stepNs*step)
-
-				slog.Default().Info("new interval", "interval", newInterval)
 
 				t.ticker.Reset(newInterval)
 			}

--- a/internal/broadcaster/helpers_test.go
+++ b/internal/broadcaster/helpers_test.go
@@ -1,0 +1,72 @@
+package broadcaster
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDynamicTicker(t *testing.T) {
+	tt := []struct {
+		name          string
+		startInterval time.Duration
+		endInterval   time.Duration
+		steps         int64
+
+		expectedError error
+	}{
+		{
+			name:          "success",
+			startInterval: 3 * time.Second,
+			endInterval:   1 * time.Second,
+			steps:         6,
+		},
+		{
+			name:          "error - end interval greater than start interval",
+			startInterval: 3 * time.Second,
+			endInterval:   6 * time.Second,
+			steps:         6,
+
+			expectedError: ErrStartIntervalNotGreaterEndInterval,
+		},
+		{
+			name:          "error - steps 0",
+			startInterval: 3 * time.Second,
+			endInterval:   6 * time.Second,
+			steps:         0,
+
+			expectedError: ErrStepsZero,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+
+			ticker, actualErr := NewDynamicTicker(tc.startInterval, tc.endInterval, tc.steps)
+			tickerCh := ticker.GetTickerCh()
+			if tc.expectedError != nil {
+				require.ErrorIs(t, actualErr, tc.expectedError)
+				return
+			}
+			require.NoError(t, actualErr)
+
+			counter := 0
+
+		outerLoop:
+			for {
+				select {
+				case <-tickerCh:
+					slog.Default().Info("ticker ticked")
+					counter++
+
+					if counter >= 10 {
+						break outerLoop
+					}
+				}
+			}
+
+		})
+	}
+}

--- a/internal/broadcaster/helpers_test.go
+++ b/internal/broadcaster/helpers_test.go
@@ -46,12 +46,14 @@ func TestNewDynamicTicker(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			ticker, actualErr := NewDynamicTicker(tc.startInterval, tc.endInterval, tc.steps)
-			tickerCh := ticker.GetTickerCh()
 			if tc.expectedError != nil {
 				require.ErrorIs(t, actualErr, tc.expectedError)
 				return
 			}
 			require.NoError(t, actualErr)
+
+			tickerCh, err := ticker.GetTickerCh()
+			require.NoError(t, err)
 
 			logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 

--- a/internal/broadcaster/rate_broadcaster.go
+++ b/internal/broadcaster/rate_broadcaster.go
@@ -111,7 +111,7 @@ func (b *UTXORateBroadcaster) Start() error {
 
 	submitBatchInterval := time.Duration(millisecondsPerSecond/float64(submitBatchesPerSecond)) * time.Millisecond
 
-	submitBatchTicker, err := NewDynamicTicker(10*time.Second, submitBatchInterval, 10)
+	submitBatchTicker, err := NewDynamicTicker(5*time.Second+submitBatchInterval, submitBatchInterval, 10)
 	if err != nil {
 		return err
 	}

--- a/internal/broadcaster/rate_broadcaster.go
+++ b/internal/broadcaster/rate_broadcaster.go
@@ -116,7 +116,10 @@ func (b *UTXORateBroadcaster) Start() error {
 		return err
 	}
 
-	tickerCh := submitBatchTicker.GetTickerCh()
+	tickerCh, err := submitBatchTicker.GetTickerCh()
+	if err != nil {
+		return fmt.Errorf("failed to get ticker channel: %w", err)
+	}
 
 	errCh := make(chan error, 100)
 


### PR DESCRIPTION
## Description of Changes

- NewDynamicTicker returns a dynamic ticker based on time.Ticker. The time intervals linearly decrease starting from startInterval to endInterval. After a specified number of steps the time interval is equal to endInterval.
- Use dynamic ticker in broadcaster-cli so that transactions submitted slowly ramp up instead of starting with a constant rate until the end.

## Testing Procedure

- [X] I have added new unit tests
- [X] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
