### PR TITLE
fix(BPAAS-2065): traces

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,5 +23,5 @@ jobs:
 
       - name: e2e test
         run: |
-          docker compose --env-file ./.env.dev up blocktx callbacker metamorph api tests --scale blocktx=4 --scale metamorph=2 --exit-code-from tests
+          docker compose --env-file ./.env.dev up blocktx callbacker metamorph api tests --scale blocktx=2 --scale metamorph=2 --exit-code-from tests
           docker compose down

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ install:
 
 .PHONY: install_gen
 install_gen:
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.5
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.6
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
 	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1
 	go install github.com/matryer/moq@v0.5.3

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ run_e2e_tests:
 .PHONY: run_e2e_tests_with_tracing
 run_e2e_tests_with_tracing:
 	docker compose down -v --remove-orphans
-	ARC_TRACING_ENABLED=TRUE docker compose up --env-file ./.env.dev --build blocktx callbacker metamorph api tests jaeger --scale blocktx=4 --scale metamorph=2 --no-attach jaeger
+	ARC_TRACING_ENABLED=TRUE docker compose --env-file ./.env.dev up --build blocktx callbacker metamorph api tests jaeger --scale blocktx=4 --scale metamorph=2 --no-attach jaeger
 
 .PHONY: run_e2e_mcast_tests
 run_e2e_mcast_tests:

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ run:
 .PHONY: run_e2e_tests
 run_e2e_tests:
 	docker compose down -v --remove-orphans
-	docker compose --env-file ./.env.dev up --build blocktx callbacker metamorph api tests --scale blocktx=4 --scale metamorph=2 --exit-code-from tests
+	docker compose --env-file ./.env.dev up --build blocktx callbacker metamorph api tests --scale blocktx=2 --scale metamorph=2 --exit-code-from tests
 	docker compose down
 
 .PHONY: run_e2e_tests_with_tracing
 run_e2e_tests_with_tracing:
 	docker compose down -v --remove-orphans
-	ARC_TRACING_ENABLED=TRUE docker compose --env-file ./.env.dev up --build blocktx callbacker metamorph api tests jaeger --scale blocktx=4 --scale metamorph=2 --no-attach jaeger
+	ARC_TRACING_ENABLED=TRUE docker compose --env-file ./.env.dev up --build blocktx callbacker metamorph api tests jaeger --scale blocktx=2 --scale metamorph=2 --no-attach jaeger
 
 .PHONY: run_e2e_mcast_tests
 run_e2e_mcast_tests:

--- a/cmd/arc/services/metamorph.go
+++ b/cmd/arc/services/metamorph.go
@@ -83,6 +83,7 @@ func StartMetamorph(logger *slog.Logger, arcConfig *config.ArcConfig, cacheStore
 		optsServer = append(optsServer, metamorph.WithServerTracer(attributes...))
 		callbackerOpts = append(callbackerOpts, callbacker.WithTracerCallbacker(attributes...))
 		processorOpts = append(processorOpts, metamorph.WithTracerProcessor(attributes...))
+		bcMediatorOpts = append(bcMediatorOpts, bcnet.WithTracer(attributes...))
 	}
 
 	stopFn := func() {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./test/config/bitcoin.conf:/data/bitcoin.conf
       - node1-data:/data
-    command: [ "/entrypoint.sh", "bitcoind", "-connect=node2:18333", "-connect=node3:18333" ]
+    command: [ "/entrypoint.sh", "bitcoind", "-connect=node2:18333" ]
 
   node2:
     container_name: node2
@@ -27,20 +27,7 @@ services:
     volumes:
       - ./test/config/bitcoin.conf:/data/bitcoin.conf
       - node2-data:/data
-    command: [ "/entrypoint.sh", "bitcoind", "-connect=node1:18333", "-connect=node3:18333" ]
-
-  node3:
-    container_name: node3
-    image: bitcoinsv/bitcoin-sv:1.1.0
-    expose:
-      - "18332"
-      - "18333"
-    healthcheck:
-      test: [ "CMD", "/entrypoint.sh", "bitcoin-cli", "getinfo" ]
-    volumes:
-      - ./test/config/bitcoin.conf:/data/bitcoin.conf
-      - node3-data:/data
-    command: [ "/entrypoint.sh", "bitcoind", "-connect=node1:18333", "-connect=node2:18333" ]
+    command: [ "/entrypoint.sh", "bitcoind", "-connect=node1:18333" ]
 
   db:
     image: postgres:15.4
@@ -176,8 +163,6 @@ services:
         condition: service_healthy
       node2:
         condition: service_healthy
-      node3:
-        condition: service_healthy
       migrate-blocktx:
         condition: service_completed_successfully
     healthcheck:
@@ -273,8 +258,6 @@ volumes:
   node1-data:
     external: false
   node2-data:
-    external: false
-  node3-data:
     external: false
   nats1-data:
     external: false

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -252,7 +252,7 @@ services:
         condition: service_healthy
 
   jaeger:
-    image: jaegertracing/all-in-one:1.35
+    image: jaegertracing/all-in-one:1.68.0
     profiles: ["tracing"]
     ports:
       - "16686:16686"

--- a/internal/metamorph/client.go
+++ b/internal/metamorph/client.go
@@ -240,7 +240,12 @@ func (m *Metamorph) Health(ctx context.Context) (err error) {
 
 // SubmitTransactions submits transactions to the bitcoin network and returns the transaction in raw format.
 func (m *Metamorph) SubmitTransactions(ctx context.Context, txs sdkTx.Transactions, options *TransactionOptions) (txStatuses []*TransactionStatus, err error) {
-	ctx, span := tracing.StartTracing(ctx, "SubmitTransactions", m.tracingEnabled, m.tracingAttributes...)
+	attributes := m.tracingAttributes
+	if len(txs) == 1 {
+		attributes = append(m.tracingAttributes, attribute.String("txID", txs[0].TxID().String()))
+	}
+
+	ctx, span := tracing.StartTracing(ctx, "SubmitTransactions", m.tracingEnabled, attributes...)
 	defer func() {
 		tracing.EndTracing(span, err)
 	}()

--- a/internal/metamorph/metamorph_api/metamorph_api.pb.go
+++ b/internal/metamorph/metamorph_api/metamorph_api.pb.go
@@ -1267,11 +1267,9 @@ const file_internal_metamorph_metamorph_api_metamorph_api_proto_rawDesc = "" +
 	"\x16DOUBLE_SPEND_ATTEMPTED\x10d\x12\f\n" +
 	"\bREJECTED\x10n\x12\x18\n" +
 	"\x14MINED_IN_STALE_BLOCK\x10s\x12\t\n" +
-	"\x05MINED\x10x2\x99\a\n" +
+	"\x05MINED\x10x2\xdd\x05\n" +
 	"\fMetaMorphAPI\x12A\n" +
-	"\x06Health\x12\x16.google.protobuf.Empty\x1a\x1d.metamorph_api.HealthResponse\"\x00\x12Z\n" +
-	"\x0ePutTransaction\x12!.metamorph_api.TransactionRequest\x1a .metamorph_api.TransactionStatus\"\x03\x88\x02\x01\x12^\n" +
-	"\x0fPutTransactions\x12\".metamorph_api.TransactionRequests\x1a\".metamorph_api.TransactionStatuses\"\x03\x88\x02\x01\x12`\n" +
+	"\x06Health\x12\x16.google.protobuf.Empty\x1a\x1d.metamorph_api.HealthResponse\"\x00\x12`\n" +
 	"\x10PostTransactions\x12&.metamorph_api.PostTransactionsRequest\x1a\".metamorph_api.TransactionStatuses\"\x00\x12W\n" +
 	"\x0eGetTransaction\x12'.metamorph_api.TransactionStatusRequest\x1a\x1a.metamorph_api.Transaction\"\x00\x12Z\n" +
 	"\x0fGetTransactions\x12(.metamorph_api.TransactionsStatusRequest\x1a\x1b.metamorph_api.Transactions\"\x00\x12c\n" +
@@ -1331,27 +1329,23 @@ var file_internal_metamorph_metamorph_api_metamorph_api_proto_depIdxs = []int32{
 	8,  // 13: metamorph_api.TransactionStatuses.Statuses:type_name -> metamorph_api.TransactionStatus
 	6,  // 14: metamorph_api.Transactions.transactions:type_name -> metamorph_api.Transaction
 	17, // 15: metamorph_api.MetaMorphAPI.Health:input_type -> google.protobuf.Empty
-	2,  // 16: metamorph_api.MetaMorphAPI.PutTransaction:input_type -> metamorph_api.TransactionRequest
-	3,  // 17: metamorph_api.MetaMorphAPI.PutTransactions:input_type -> metamorph_api.TransactionRequests
-	5,  // 18: metamorph_api.MetaMorphAPI.PostTransactions:input_type -> metamorph_api.PostTransactionsRequest
-	10, // 19: metamorph_api.MetaMorphAPI.GetTransaction:input_type -> metamorph_api.TransactionStatusRequest
-	14, // 20: metamorph_api.MetaMorphAPI.GetTransactions:input_type -> metamorph_api.TransactionsStatusRequest
-	10, // 21: metamorph_api.MetaMorphAPI.GetTransactionStatus:input_type -> metamorph_api.TransactionStatusRequest
-	14, // 22: metamorph_api.MetaMorphAPI.GetTransactionStatuses:input_type -> metamorph_api.TransactionsStatusRequest
-	11, // 23: metamorph_api.MetaMorphAPI.UpdateInstances:input_type -> metamorph_api.UpdateInstancesRequest
-	12, // 24: metamorph_api.MetaMorphAPI.ClearData:input_type -> metamorph_api.ClearDataRequest
-	1,  // 25: metamorph_api.MetaMorphAPI.Health:output_type -> metamorph_api.HealthResponse
-	8,  // 26: metamorph_api.MetaMorphAPI.PutTransaction:output_type -> metamorph_api.TransactionStatus
-	9,  // 27: metamorph_api.MetaMorphAPI.PutTransactions:output_type -> metamorph_api.TransactionStatuses
-	9,  // 28: metamorph_api.MetaMorphAPI.PostTransactions:output_type -> metamorph_api.TransactionStatuses
-	6,  // 29: metamorph_api.MetaMorphAPI.GetTransaction:output_type -> metamorph_api.Transaction
-	15, // 30: metamorph_api.MetaMorphAPI.GetTransactions:output_type -> metamorph_api.Transactions
-	8,  // 31: metamorph_api.MetaMorphAPI.GetTransactionStatus:output_type -> metamorph_api.TransactionStatus
-	9,  // 32: metamorph_api.MetaMorphAPI.GetTransactionStatuses:output_type -> metamorph_api.TransactionStatuses
-	17, // 33: metamorph_api.MetaMorphAPI.UpdateInstances:output_type -> google.protobuf.Empty
-	13, // 34: metamorph_api.MetaMorphAPI.ClearData:output_type -> metamorph_api.ClearDataResponse
-	25, // [25:35] is the sub-list for method output_type
-	15, // [15:25] is the sub-list for method input_type
+	5,  // 16: metamorph_api.MetaMorphAPI.PostTransactions:input_type -> metamorph_api.PostTransactionsRequest
+	10, // 17: metamorph_api.MetaMorphAPI.GetTransaction:input_type -> metamorph_api.TransactionStatusRequest
+	14, // 18: metamorph_api.MetaMorphAPI.GetTransactions:input_type -> metamorph_api.TransactionsStatusRequest
+	10, // 19: metamorph_api.MetaMorphAPI.GetTransactionStatus:input_type -> metamorph_api.TransactionStatusRequest
+	14, // 20: metamorph_api.MetaMorphAPI.GetTransactionStatuses:input_type -> metamorph_api.TransactionsStatusRequest
+	11, // 21: metamorph_api.MetaMorphAPI.UpdateInstances:input_type -> metamorph_api.UpdateInstancesRequest
+	12, // 22: metamorph_api.MetaMorphAPI.ClearData:input_type -> metamorph_api.ClearDataRequest
+	1,  // 23: metamorph_api.MetaMorphAPI.Health:output_type -> metamorph_api.HealthResponse
+	9,  // 24: metamorph_api.MetaMorphAPI.PostTransactions:output_type -> metamorph_api.TransactionStatuses
+	6,  // 25: metamorph_api.MetaMorphAPI.GetTransaction:output_type -> metamorph_api.Transaction
+	15, // 26: metamorph_api.MetaMorphAPI.GetTransactions:output_type -> metamorph_api.Transactions
+	8,  // 27: metamorph_api.MetaMorphAPI.GetTransactionStatus:output_type -> metamorph_api.TransactionStatus
+	9,  // 28: metamorph_api.MetaMorphAPI.GetTransactionStatuses:output_type -> metamorph_api.TransactionStatuses
+	17, // 29: metamorph_api.MetaMorphAPI.UpdateInstances:output_type -> google.protobuf.Empty
+	13, // 30: metamorph_api.MetaMorphAPI.ClearData:output_type -> metamorph_api.ClearDataResponse
+	23, // [23:31] is the sub-list for method output_type
+	15, // [15:23] is the sub-list for method input_type
 	15, // [15:15] is the sub-list for extension type_name
 	15, // [15:15] is the sub-list for extension extendee
 	0,  // [0:15] is the sub-list for field type_name

--- a/internal/metamorph/metamorph_api/metamorph_api.proto
+++ b/internal/metamorph/metamorph_api/metamorph_api.proto
@@ -29,12 +29,6 @@ enum Status {
 
 service MetaMorphAPI {
   rpc Health (google.protobuf.Empty) returns (HealthResponse) {}
-  rpc PutTransaction (TransactionRequest) returns (TransactionStatus) {
-    option deprecated = true;
-  }
-  rpc PutTransactions (TransactionRequests) returns (TransactionStatuses) {
-    option deprecated = true;
-  }
   rpc PostTransactions (PostTransactionsRequest) returns (TransactionStatuses) {}
   rpc GetTransaction (TransactionStatusRequest) returns (Transaction) {}
   rpc GetTransactions (TransactionsStatusRequest) returns (Transactions) {}

--- a/internal/metamorph/metamorph_api/metamorph_api_grpc.pb.go
+++ b/internal/metamorph/metamorph_api/metamorph_api_grpc.pb.go
@@ -21,8 +21,6 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	MetaMorphAPI_Health_FullMethodName                 = "/metamorph_api.MetaMorphAPI/Health"
-	MetaMorphAPI_PutTransaction_FullMethodName         = "/metamorph_api.MetaMorphAPI/PutTransaction"
-	MetaMorphAPI_PutTransactions_FullMethodName        = "/metamorph_api.MetaMorphAPI/PutTransactions"
 	MetaMorphAPI_PostTransactions_FullMethodName       = "/metamorph_api.MetaMorphAPI/PostTransactions"
 	MetaMorphAPI_GetTransaction_FullMethodName         = "/metamorph_api.MetaMorphAPI/GetTransaction"
 	MetaMorphAPI_GetTransactions_FullMethodName        = "/metamorph_api.MetaMorphAPI/GetTransactions"
@@ -37,10 +35,6 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type MetaMorphAPIClient interface {
 	Health(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*HealthResponse, error)
-	// Deprecated: Do not use.
-	PutTransaction(ctx context.Context, in *TransactionRequest, opts ...grpc.CallOption) (*TransactionStatus, error)
-	// Deprecated: Do not use.
-	PutTransactions(ctx context.Context, in *TransactionRequests, opts ...grpc.CallOption) (*TransactionStatuses, error)
 	PostTransactions(ctx context.Context, in *PostTransactionsRequest, opts ...grpc.CallOption) (*TransactionStatuses, error)
 	GetTransaction(ctx context.Context, in *TransactionStatusRequest, opts ...grpc.CallOption) (*Transaction, error)
 	GetTransactions(ctx context.Context, in *TransactionsStatusRequest, opts ...grpc.CallOption) (*Transactions, error)
@@ -62,28 +56,6 @@ func (c *metaMorphAPIClient) Health(ctx context.Context, in *emptypb.Empty, opts
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(HealthResponse)
 	err := c.cc.Invoke(ctx, MetaMorphAPI_Health_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-// Deprecated: Do not use.
-func (c *metaMorphAPIClient) PutTransaction(ctx context.Context, in *TransactionRequest, opts ...grpc.CallOption) (*TransactionStatus, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(TransactionStatus)
-	err := c.cc.Invoke(ctx, MetaMorphAPI_PutTransaction_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-// Deprecated: Do not use.
-func (c *metaMorphAPIClient) PutTransactions(ctx context.Context, in *TransactionRequests, opts ...grpc.CallOption) (*TransactionStatuses, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(TransactionStatuses)
-	err := c.cc.Invoke(ctx, MetaMorphAPI_PutTransactions_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -165,10 +137,6 @@ func (c *metaMorphAPIClient) ClearData(ctx context.Context, in *ClearDataRequest
 // for forward compatibility.
 type MetaMorphAPIServer interface {
 	Health(context.Context, *emptypb.Empty) (*HealthResponse, error)
-	// Deprecated: Do not use.
-	PutTransaction(context.Context, *TransactionRequest) (*TransactionStatus, error)
-	// Deprecated: Do not use.
-	PutTransactions(context.Context, *TransactionRequests) (*TransactionStatuses, error)
 	PostTransactions(context.Context, *PostTransactionsRequest) (*TransactionStatuses, error)
 	GetTransaction(context.Context, *TransactionStatusRequest) (*Transaction, error)
 	GetTransactions(context.Context, *TransactionsStatusRequest) (*Transactions, error)
@@ -188,12 +156,6 @@ type UnimplementedMetaMorphAPIServer struct{}
 
 func (UnimplementedMetaMorphAPIServer) Health(context.Context, *emptypb.Empty) (*HealthResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Health not implemented")
-}
-func (UnimplementedMetaMorphAPIServer) PutTransaction(context.Context, *TransactionRequest) (*TransactionStatus, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method PutTransaction not implemented")
-}
-func (UnimplementedMetaMorphAPIServer) PutTransactions(context.Context, *TransactionRequests) (*TransactionStatuses, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method PutTransactions not implemented")
 }
 func (UnimplementedMetaMorphAPIServer) PostTransactions(context.Context, *PostTransactionsRequest) (*TransactionStatuses, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PostTransactions not implemented")
@@ -251,42 +213,6 @@ func _MetaMorphAPI_Health_Handler(srv interface{}, ctx context.Context, dec func
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(MetaMorphAPIServer).Health(ctx, req.(*emptypb.Empty))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _MetaMorphAPI_PutTransaction_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(TransactionRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(MetaMorphAPIServer).PutTransaction(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: MetaMorphAPI_PutTransaction_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MetaMorphAPIServer).PutTransaction(ctx, req.(*TransactionRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _MetaMorphAPI_PutTransactions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(TransactionRequests)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(MetaMorphAPIServer).PutTransactions(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: MetaMorphAPI_PutTransactions_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MetaMorphAPIServer).PutTransactions(ctx, req.(*TransactionRequests))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -427,14 +353,6 @@ var MetaMorphAPI_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Health",
 			Handler:    _MetaMorphAPI_Health_Handler,
-		},
-		{
-			MethodName: "PutTransaction",
-			Handler:    _MetaMorphAPI_PutTransaction_Handler,
-		},
-		{
-			MethodName: "PutTransactions",
-			Handler:    _MetaMorphAPI_PutTransactions_Handler,
 		},
 		{
 			MethodName: "PostTransactions",

--- a/internal/metamorph/mocks/metamorph_api_mock.go
+++ b/internal/metamorph/mocks/metamorph_api_mock.go
@@ -42,12 +42,6 @@ var _ metamorph_api.MetaMorphAPIClient = &MetaMorphAPIClientMock{}
 //			PostTransactionsFunc: func(ctx context.Context, in *metamorph_api.PostTransactionsRequest, opts ...grpc.CallOption) (*metamorph_api.TransactionStatuses, error) {
 //				panic("mock out the PostTransactions method")
 //			},
-//			PutTransactionFunc: func(ctx context.Context, in *metamorph_api.TransactionRequest, opts ...grpc.CallOption) (*metamorph_api.TransactionStatus, error) {
-//				panic("mock out the PutTransaction method")
-//			},
-//			PutTransactionsFunc: func(ctx context.Context, in *metamorph_api.TransactionRequests, opts ...grpc.CallOption) (*metamorph_api.TransactionStatuses, error) {
-//				panic("mock out the PutTransactions method")
-//			},
 //			UpdateInstancesFunc: func(ctx context.Context, in *metamorph_api.UpdateInstancesRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
 //				panic("mock out the UpdateInstances method")
 //			},
@@ -78,12 +72,6 @@ type MetaMorphAPIClientMock struct {
 
 	// PostTransactionsFunc mocks the PostTransactions method.
 	PostTransactionsFunc func(ctx context.Context, in *metamorph_api.PostTransactionsRequest, opts ...grpc.CallOption) (*metamorph_api.TransactionStatuses, error)
-
-	// PutTransactionFunc mocks the PutTransaction method.
-	PutTransactionFunc func(ctx context.Context, in *metamorph_api.TransactionRequest, opts ...grpc.CallOption) (*metamorph_api.TransactionStatus, error)
-
-	// PutTransactionsFunc mocks the PutTransactions method.
-	PutTransactionsFunc func(ctx context.Context, in *metamorph_api.TransactionRequests, opts ...grpc.CallOption) (*metamorph_api.TransactionStatuses, error)
 
 	// UpdateInstancesFunc mocks the UpdateInstances method.
 	UpdateInstancesFunc func(ctx context.Context, in *metamorph_api.UpdateInstancesRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
@@ -153,24 +141,6 @@ type MetaMorphAPIClientMock struct {
 			// Opts is the opts argument value.
 			Opts []grpc.CallOption
 		}
-		// PutTransaction holds details about calls to the PutTransaction method.
-		PutTransaction []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// In is the in argument value.
-			In *metamorph_api.TransactionRequest
-			// Opts is the opts argument value.
-			Opts []grpc.CallOption
-		}
-		// PutTransactions holds details about calls to the PutTransactions method.
-		PutTransactions []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// In is the in argument value.
-			In *metamorph_api.TransactionRequests
-			// Opts is the opts argument value.
-			Opts []grpc.CallOption
-		}
 		// UpdateInstances holds details about calls to the UpdateInstances method.
 		UpdateInstances []struct {
 			// Ctx is the ctx argument value.
@@ -188,8 +158,6 @@ type MetaMorphAPIClientMock struct {
 	lockGetTransactions        sync.RWMutex
 	lockHealth                 sync.RWMutex
 	lockPostTransactions       sync.RWMutex
-	lockPutTransaction         sync.RWMutex
-	lockPutTransactions        sync.RWMutex
 	lockUpdateInstances        sync.RWMutex
 }
 
@@ -470,86 +438,6 @@ func (mock *MetaMorphAPIClientMock) PostTransactionsCalls() []struct {
 	mock.lockPostTransactions.RLock()
 	calls = mock.calls.PostTransactions
 	mock.lockPostTransactions.RUnlock()
-	return calls
-}
-
-// PutTransaction calls PutTransactionFunc.
-func (mock *MetaMorphAPIClientMock) PutTransaction(ctx context.Context, in *metamorph_api.TransactionRequest, opts ...grpc.CallOption) (*metamorph_api.TransactionStatus, error) {
-	if mock.PutTransactionFunc == nil {
-		panic("MetaMorphAPIClientMock.PutTransactionFunc: method is nil but MetaMorphAPIClient.PutTransaction was just called")
-	}
-	callInfo := struct {
-		Ctx  context.Context
-		In   *metamorph_api.TransactionRequest
-		Opts []grpc.CallOption
-	}{
-		Ctx:  ctx,
-		In:   in,
-		Opts: opts,
-	}
-	mock.lockPutTransaction.Lock()
-	mock.calls.PutTransaction = append(mock.calls.PutTransaction, callInfo)
-	mock.lockPutTransaction.Unlock()
-	return mock.PutTransactionFunc(ctx, in, opts...)
-}
-
-// PutTransactionCalls gets all the calls that were made to PutTransaction.
-// Check the length with:
-//
-//	len(mockedMetaMorphAPIClient.PutTransactionCalls())
-func (mock *MetaMorphAPIClientMock) PutTransactionCalls() []struct {
-	Ctx  context.Context
-	In   *metamorph_api.TransactionRequest
-	Opts []grpc.CallOption
-} {
-	var calls []struct {
-		Ctx  context.Context
-		In   *metamorph_api.TransactionRequest
-		Opts []grpc.CallOption
-	}
-	mock.lockPutTransaction.RLock()
-	calls = mock.calls.PutTransaction
-	mock.lockPutTransaction.RUnlock()
-	return calls
-}
-
-// PutTransactions calls PutTransactionsFunc.
-func (mock *MetaMorphAPIClientMock) PutTransactions(ctx context.Context, in *metamorph_api.TransactionRequests, opts ...grpc.CallOption) (*metamorph_api.TransactionStatuses, error) {
-	if mock.PutTransactionsFunc == nil {
-		panic("MetaMorphAPIClientMock.PutTransactionsFunc: method is nil but MetaMorphAPIClient.PutTransactions was just called")
-	}
-	callInfo := struct {
-		Ctx  context.Context
-		In   *metamorph_api.TransactionRequests
-		Opts []grpc.CallOption
-	}{
-		Ctx:  ctx,
-		In:   in,
-		Opts: opts,
-	}
-	mock.lockPutTransactions.Lock()
-	mock.calls.PutTransactions = append(mock.calls.PutTransactions, callInfo)
-	mock.lockPutTransactions.Unlock()
-	return mock.PutTransactionsFunc(ctx, in, opts...)
-}
-
-// PutTransactionsCalls gets all the calls that were made to PutTransactions.
-// Check the length with:
-//
-//	len(mockedMetaMorphAPIClient.PutTransactionsCalls())
-func (mock *MetaMorphAPIClientMock) PutTransactionsCalls() []struct {
-	Ctx  context.Context
-	In   *metamorph_api.TransactionRequests
-	Opts []grpc.CallOption
-} {
-	var calls []struct {
-		Ctx  context.Context
-		In   *metamorph_api.TransactionRequests
-		Opts []grpc.CallOption
-	}
-	mock.lockPutTransactions.RLock()
-	calls = mock.calls.PutTransactions
-	mock.lockPutTransactions.RUnlock()
 	return calls
 }
 

--- a/internal/metamorph/server.go
+++ b/internal/metamorph/server.go
@@ -245,28 +245,6 @@ func (s *Server) PostTransactions(ctx context.Context, req *metamorph_api.PostTr
 	return resp, nil
 }
 
-// toStoreData deprecated, Todo: remove
-func toStoreData(hash *chainhash.Hash, statusReceived metamorph_api.Status, req *metamorph_api.TransactionRequest) *store.Data {
-	callbacks := make([]store.Callback, 0)
-	if req.GetCallbackUrl() != "" || req.GetCallbackToken() != "" {
-		callbacks = []store.Callback{
-			{
-				CallbackURL:   req.GetCallbackUrl(),
-				CallbackToken: req.GetCallbackToken(),
-				AllowBatch:    req.GetCallbackBatch(),
-			},
-		}
-	}
-
-	return &store.Data{
-		Hash:              hash,
-		Status:            statusReceived,
-		Callbacks:         callbacks,
-		FullStatusUpdates: req.GetFullStatusUpdates(),
-		RawTx:             req.GetRawTx(),
-	}
-}
-
 func requestToStoreData(hash *chainhash.Hash, statusReceived metamorph_api.Status, req *metamorph_api.PostTransactionRequest) *store.Data {
 	callbacks := make([]store.Callback, 0)
 	if req.GetCallbackUrl() != "" || req.GetCallbackToken() != "" {

--- a/internal/metamorph/server.go
+++ b/internal/metamorph/server.go
@@ -152,8 +152,7 @@ func (s *Server) Health(ctx context.Context, _ *emptypb.Empty) (healthResp *meta
 	}, nil
 }
 
-// PutTransaction deprecated, Todo: remove
-func (s *Server) PutTransaction(ctx context.Context, req *metamorph_api.TransactionRequest) (txStatus *metamorph_api.TransactionStatus, err error) {
+func (s *Server) PostTransaction(ctx context.Context, req *metamorph_api.PostTransactionRequest) (txStatus *metamorph_api.TransactionStatus, err error) {
 	deadline, ok := ctx.Deadline()
 
 	// decrease time to get initial deadline
@@ -178,73 +177,8 @@ func (s *Server) PutTransaction(ctx context.Context, req *metamorph_api.Transact
 	statusReceived := metamorph_api.Status_RECEIVED
 
 	// Convert gRPC req to store.Data struct...
-	sReq := toStoreData(hash, statusReceived, req)
+	sReq := requestToStoreData(hash, statusReceived, req)
 	return s.processTransaction(ctx, req.GetWaitForStatus(), sReq, hash.String()), nil
-}
-
-// PutTransactions deprecated, Todo: remove
-func (s *Server) PutTransactions(ctx context.Context, req *metamorph_api.TransactionRequests) (txsStatuses *metamorph_api.TransactionStatuses, err error) {
-	deadline, ok := ctx.Deadline()
-
-	// decrease time to get initial deadline
-	newDeadline := deadline
-	if time.Now().Add(MaxTimeout * time.Second).Before(deadline) {
-		newDeadline = deadline.Add(-(time.Second * MaxTimeout))
-	}
-
-	// Create a new context with the updated deadline
-	if ok {
-		var newCancel context.CancelFunc
-		ctx, newCancel = context.WithDeadline(context.Background(), newDeadline)
-		defer newCancel()
-	}
-
-	ctx, span := tracing.StartTracing(ctx, "PutTransactions", s.tracingEnabled, s.tracingAttributes...)
-	defer func() {
-		tracing.EndTracing(span, err)
-	}()
-
-	// for each transaction if we have status in the db already set that status in the response
-	// if not we store the transaction data and set the transaction status in response array to - STORED
-	type processTxInput struct {
-		data          *store.Data
-		waitForStatus metamorph_api.Status
-		responseIndex int
-	}
-
-	// prepare response object before filling with tx statuses
-	resp := &metamorph_api.TransactionStatuses{}
-	resp.Statuses = make([]*metamorph_api.TransactionStatus, len(req.GetTransactions()))
-
-	processTxsInputMap := make(map[chainhash.Hash]processTxInput)
-
-	for ind, txReq := range req.GetTransactions() {
-		statusReceived := metamorph_api.Status_RECEIVED
-		hash := PtrTo(chainhash.DoubleHashH(txReq.GetRawTx()))
-
-		processTxsInputMap[*hash] = processTxInput{
-			data:          toStoreData(hash, statusReceived, txReq),
-			waitForStatus: txReq.GetWaitForStatus(),
-			responseIndex: ind,
-		}
-	}
-
-	// Concurrently process each transaction and wait for the transaction status to return
-	wg := &sync.WaitGroup{}
-	for hash, input := range processTxsInputMap {
-		wg.Add(1)
-		go func(ctx context.Context, processTxInput processTxInput, txID string, wg *sync.WaitGroup, resp *metamorph_api.TransactionStatuses) {
-			defer wg.Done()
-
-			statusNew := s.processTransaction(ctx, processTxInput.waitForStatus, processTxInput.data, txID)
-
-			resp.Statuses[processTxInput.responseIndex] = statusNew
-		}(ctx, input, hash.String(), wg, resp)
-	}
-
-	wg.Wait()
-
-	return resp, nil
 }
 
 func (s *Server) PostTransactions(ctx context.Context, req *metamorph_api.PostTransactionsRequest) (txsStatuses *metamorph_api.TransactionStatuses, err error) {

--- a/internal/metamorph/server.go
+++ b/internal/metamorph/server.go
@@ -33,6 +33,8 @@ const (
 	checkStatusIntervalDefault = 5 * time.Second
 	minedDoubleSpendMsg        = "previously double spend attempted"
 	MaxTimeout                 = 30
+	deadlineExtension          = 1 * time.Second * MaxTimeout
+	minusDeadlineExtension     = -1 * deadlineExtension
 )
 
 var (
@@ -159,17 +161,16 @@ func (s *Server) PostTransaction(ctx context.Context, req *metamorph_api.PostTra
 	}()
 
 	deadline, ok := ctx.Deadline()
-
-	// decrease time to get initial deadline
-	newDeadline := deadline
-	if time.Now().Add(MaxTimeout * time.Second).Before(deadline) {
-		newDeadline = deadline.Add(-(time.Second * MaxTimeout))
-	}
-
-	// Create a new context with the updated deadline
 	if ok {
+		// Create a new deadline
+		newDeadline := deadline
+		if time.Now().Add(deadlineExtension).Before(deadline) {
+			// decrease time to get initial deadline
+			newDeadline = deadline.Add(minusDeadlineExtension)
+		}
+
 		var newCancel context.CancelFunc
-		ctx, newCancel = context.WithDeadline(ctx, newDeadline)
+		ctx, newCancel = context.WithDeadline(context.WithoutCancel(ctx), newDeadline)
 		defer newCancel()
 	}
 
@@ -188,17 +189,16 @@ func (s *Server) PostTransactions(ctx context.Context, req *metamorph_api.PostTr
 	}()
 
 	deadline, ok := ctx.Deadline()
-
-	// decrease time to get initial deadline
-	newDeadline := deadline
-	if time.Now().Add(MaxTimeout * time.Second).Before(deadline) {
-		newDeadline = deadline.Add(-(time.Second * MaxTimeout))
-	}
-
-	// Create a new context with the updated deadline
 	if ok {
+		// Create a new deadline
+		newDeadline := deadline
+		if time.Now().Add(deadlineExtension).Before(deadline) {
+			// decrease time to get initial deadline
+			newDeadline = deadline.Add(minusDeadlineExtension)
+		}
+
 		var newCancel context.CancelFunc
-		ctx, newCancel = context.WithDeadline(ctx, newDeadline)
+		ctx, newCancel = context.WithDeadline(context.WithoutCancel(ctx), newDeadline)
 		defer newCancel()
 	}
 

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -71,10 +71,6 @@ metamorph:
       port:
         p2p: 18333
         zmq: 28332
-    - host: node3
-      port:
-        p2p: 18333
-        zmq: 28332
 
 blocktx:
   listenAddr: 0.0.0.0:8011
@@ -109,10 +105,6 @@ blocktx:
         p2p: 18333
         zmq: 28332
     - host: node2
-      port:
-        p2p: 18333
-        zmq: 28332
-    - host: node3
       port:
         p2p: 18333
         zmq: 28332

--- a/test/config/config_mcast.yaml
+++ b/test/config/config_mcast.yaml
@@ -71,10 +71,6 @@ metamorph:
       port:
         p2p: 18333
         zmq: 28332
-    - host: node3
-      port:
-        p2p: 18333
-        zmq: 28332
     mcast:
       tx:
         address: "[ff05::1]:9999"
@@ -114,10 +110,6 @@ blocktx:
         p2p: 18333
         zmq: 28332
     - host: node2
-      port:
-        p2p: 18333
-        zmq: 28332
-    - host: node3
       port:
         p2p: 18333
         zmq: 28332


### PR DESCRIPTION
## Description of Changes

Fixes
- Do not create new context but use existing one in order not to break the trace
- Make target for running e2e tests with Jaeger

Other changes
- Remove deprecated server functions
- Add traces back to mediator
- Upgrade jaegertracing docker image
- Run e2e tests with 2 blocktx instances
- Remove node 3 from e2e tests => run it with 2 nodes

## Testing Procedure

- [ ] I have added new unit tests
- [X] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
