### PR TITLE
fix: update mined competing

### DIFF
--- a/cmd/broadcaster-cli/app/keyset/new/new.go
+++ b/cmd/broadcaster-cli/app/keyset/new/new.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/helper"
-	"github.com/bitcoin-sv/arc/pkg/keyset"
 	chaincfg "github.com/bsv-blockchain/go-sdk/transaction/chaincfg"
 	"github.com/spf13/cobra"
+
+	"github.com/bitcoin-sv/arc/cmd/broadcaster-cli/helper"
+	"github.com/bitcoin-sv/arc/pkg/keyset"
 )
 
 var (

--- a/internal/metamorph/processor.go
+++ b/internal/metamorph/processor.go
@@ -581,11 +581,10 @@ func (p *Processor) statusUpdateWithCallback(ctx context.Context, statusUpdates,
 
 	for _, data := range updatedData {
 		p.logger.Debug("Status updated for tx", slog.String("status", data.Status.String()), slog.String("hash", data.Hash.String()))
-		sendCallback := false
+		sendCallback := data.Status >= metamorph_api.Status_REJECTED
+
 		if data.FullStatusUpdates {
 			sendCallback = data.Status >= metamorph_api.Status_SEEN_IN_ORPHAN_MEMPOOL
-		} else {
-			sendCallback = data.Status >= metamorph_api.Status_REJECTED
 		}
 
 		if sendCallback && len(data.Callbacks) > 0 {

--- a/internal/metamorph/processor.go
+++ b/internal/metamorph/processor.go
@@ -559,7 +559,7 @@ func (p *Processor) statusUpdateWithCallback(ctx context.Context, statusUpdates,
 	var updatedData []*store.Data
 
 	if len(statusUpdates) > 0 {
-		updatedData, err = p.store.UpdateStatusBulk(ctx, statusUpdates)
+		updatedData, err = p.store.UpdateStatus(ctx, statusUpdates)
 		if err != nil {
 			return err
 		}
@@ -574,7 +574,7 @@ func (p *Processor) statusUpdateWithCallback(ctx context.Context, statusUpdates,
 	}
 
 	statusHistoryUpdates := filterUpdates(statusUpdates, updatedData)
-	_, err = p.store.UpdateStatusHistoryBulk(ctx, statusHistoryUpdates)
+	_, err = p.store.UpdateStatusHistory(ctx, statusHistoryUpdates)
 	if err != nil {
 		p.logger.Error("failed to update status history", slog.String("err", err.Error()))
 	}

--- a/internal/metamorph/processor_test.go
+++ b/internal/metamorph/processor_test.go
@@ -542,14 +542,14 @@ func TestStartSendStatusForTransaction(t *testing.T) {
 					return &store.Data{Hash: testdata.TX2Hash}, nil
 				},
 				SetUnlockedByNameFunc: func(_ context.Context, _ string) (int64, error) { return 0, nil },
-				UpdateStatusBulkFunc: func(_ context.Context, _ []store.UpdateStatus) ([]*store.Data, error) {
+				UpdateStatusFunc: func(_ context.Context, _ []store.UpdateStatus) ([]*store.Data, error) {
 					if len(tc.updateResp) > 0 {
 						counter++
 						return tc.updateResp[counter-1], tc.updateErr
 					}
 					return nil, tc.updateErr
 				},
-				UpdateStatusHistoryBulkFunc: func(_ context.Context, _ []store.UpdateStatus) ([]*store.Data, error) {
+				UpdateStatusHistoryFunc: func(_ context.Context, _ []store.UpdateStatus) ([]*store.Data, error) {
 					return nil, nil
 				},
 				UpdateDoubleSpendFunc: func(_ context.Context, _ []store.UpdateStatus) ([]*store.Data, error) {
@@ -610,7 +610,7 @@ func TestStartSendStatusForTransaction(t *testing.T) {
 			time.Sleep(time.Millisecond * 300)
 
 			// then
-			require.Equal(t, tc.expectedUpdateStatusCalls, len(metamorphStore.UpdateStatusBulkCalls()))
+			require.Equal(t, tc.expectedUpdateStatusCalls, len(metamorphStore.UpdateStatusCalls()))
 			require.Equal(t, tc.expectedDoubleSpendCalls, len(metamorphStore.UpdateDoubleSpendCalls()))
 			require.Equal(t, tc.expectedCallbacks, len(mqClient.PublishMarshalCalls()))
 			sut.Shutdown()

--- a/internal/metamorph/store/mocks/store_mock.go
+++ b/internal/metamorph/store/mocks/store_mock.go
@@ -76,11 +76,11 @@ var _ store.MetamorphStore = &MetamorphStoreMock{}
 //			UpdateMinedFunc: func(ctx context.Context, txsBlocks []*blocktx_api.TransactionBlock) ([]*store.Data, error) {
 //				panic("mock out the UpdateMined method")
 //			},
-//			UpdateStatusBulkFunc: func(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error) {
-//				panic("mock out the UpdateStatusBulk method")
+//			UpdateStatusFunc: func(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error) {
+//				panic("mock out the UpdateStatus method")
 //			},
-//			UpdateStatusHistoryBulkFunc: func(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error) {
-//				panic("mock out the UpdateStatusHistoryBulk method")
+//			UpdateStatusHistoryFunc: func(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error) {
+//				panic("mock out the UpdateStatusHistory method")
 //			},
 //		}
 //
@@ -143,11 +143,11 @@ type MetamorphStoreMock struct {
 	// UpdateMinedFunc mocks the UpdateMined method.
 	UpdateMinedFunc func(ctx context.Context, txsBlocks []*blocktx_api.TransactionBlock) ([]*store.Data, error)
 
-	// UpdateStatusBulkFunc mocks the UpdateStatusBulk method.
-	UpdateStatusBulkFunc func(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error)
+	// UpdateStatusFunc mocks the UpdateStatus method.
+	UpdateStatusFunc func(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error)
 
-	// UpdateStatusHistoryBulkFunc mocks the UpdateStatusHistoryBulk method.
-	UpdateStatusHistoryBulkFunc func(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error)
+	// UpdateStatusHistoryFunc mocks the UpdateStatusHistory method.
+	UpdateStatusHistoryFunc func(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -289,15 +289,15 @@ type MetamorphStoreMock struct {
 			// TxsBlocks is the txsBlocks argument value.
 			TxsBlocks []*blocktx_api.TransactionBlock
 		}
-		// UpdateStatusBulk holds details about calls to the UpdateStatusBulk method.
-		UpdateStatusBulk []struct {
+		// UpdateStatus holds details about calls to the UpdateStatus method.
+		UpdateStatus []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Updates is the updates argument value.
 			Updates []store.UpdateStatus
 		}
-		// UpdateStatusHistoryBulk holds details about calls to the UpdateStatusHistoryBulk method.
-		UpdateStatusHistoryBulk []struct {
+		// UpdateStatusHistory holds details about calls to the UpdateStatusHistory method.
+		UpdateStatusHistory []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Updates is the updates argument value.
@@ -322,8 +322,8 @@ type MetamorphStoreMock struct {
 	lockSetUnlockedByNameExcept sync.RWMutex
 	lockUpdateDoubleSpend       sync.RWMutex
 	lockUpdateMined             sync.RWMutex
-	lockUpdateStatusBulk        sync.RWMutex
-	lockUpdateStatusHistoryBulk sync.RWMutex
+	lockUpdateStatus            sync.RWMutex
+	lockUpdateStatusHistory     sync.RWMutex
 }
 
 // ClearData calls ClearDataFunc.
@@ -998,10 +998,10 @@ func (mock *MetamorphStoreMock) UpdateMinedCalls() []struct {
 	return calls
 }
 
-// UpdateStatusBulk calls UpdateStatusBulkFunc.
-func (mock *MetamorphStoreMock) UpdateStatusBulk(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error) {
-	if mock.UpdateStatusBulkFunc == nil {
-		panic("MetamorphStoreMock.UpdateStatusBulkFunc: method is nil but MetamorphStore.UpdateStatusBulk was just called")
+// UpdateStatus calls UpdateStatusFunc.
+func (mock *MetamorphStoreMock) UpdateStatus(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error) {
+	if mock.UpdateStatusFunc == nil {
+		panic("MetamorphStoreMock.UpdateStatusFunc: method is nil but MetamorphStore.UpdateStatus was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
@@ -1010,17 +1010,17 @@ func (mock *MetamorphStoreMock) UpdateStatusBulk(ctx context.Context, updates []
 		Ctx:     ctx,
 		Updates: updates,
 	}
-	mock.lockUpdateStatusBulk.Lock()
-	mock.calls.UpdateStatusBulk = append(mock.calls.UpdateStatusBulk, callInfo)
-	mock.lockUpdateStatusBulk.Unlock()
-	return mock.UpdateStatusBulkFunc(ctx, updates)
+	mock.lockUpdateStatus.Lock()
+	mock.calls.UpdateStatus = append(mock.calls.UpdateStatus, callInfo)
+	mock.lockUpdateStatus.Unlock()
+	return mock.UpdateStatusFunc(ctx, updates)
 }
 
-// UpdateStatusBulkCalls gets all the calls that were made to UpdateStatusBulk.
+// UpdateStatusCalls gets all the calls that were made to UpdateStatus.
 // Check the length with:
 //
-//	len(mockedMetamorphStore.UpdateStatusBulkCalls())
-func (mock *MetamorphStoreMock) UpdateStatusBulkCalls() []struct {
+//	len(mockedMetamorphStore.UpdateStatusCalls())
+func (mock *MetamorphStoreMock) UpdateStatusCalls() []struct {
 	Ctx     context.Context
 	Updates []store.UpdateStatus
 } {
@@ -1028,16 +1028,16 @@ func (mock *MetamorphStoreMock) UpdateStatusBulkCalls() []struct {
 		Ctx     context.Context
 		Updates []store.UpdateStatus
 	}
-	mock.lockUpdateStatusBulk.RLock()
-	calls = mock.calls.UpdateStatusBulk
-	mock.lockUpdateStatusBulk.RUnlock()
+	mock.lockUpdateStatus.RLock()
+	calls = mock.calls.UpdateStatus
+	mock.lockUpdateStatus.RUnlock()
 	return calls
 }
 
-// UpdateStatusHistoryBulk calls UpdateStatusHistoryBulkFunc.
-func (mock *MetamorphStoreMock) UpdateStatusHistoryBulk(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error) {
-	if mock.UpdateStatusHistoryBulkFunc == nil {
-		panic("MetamorphStoreMock.UpdateStatusHistoryBulkFunc: method is nil but MetamorphStore.UpdateStatusHistoryBulk was just called")
+// UpdateStatusHistory calls UpdateStatusHistoryFunc.
+func (mock *MetamorphStoreMock) UpdateStatusHistory(ctx context.Context, updates []store.UpdateStatus) ([]*store.Data, error) {
+	if mock.UpdateStatusHistoryFunc == nil {
+		panic("MetamorphStoreMock.UpdateStatusHistoryFunc: method is nil but MetamorphStore.UpdateStatusHistory was just called")
 	}
 	callInfo := struct {
 		Ctx     context.Context
@@ -1046,17 +1046,17 @@ func (mock *MetamorphStoreMock) UpdateStatusHistoryBulk(ctx context.Context, upd
 		Ctx:     ctx,
 		Updates: updates,
 	}
-	mock.lockUpdateStatusHistoryBulk.Lock()
-	mock.calls.UpdateStatusHistoryBulk = append(mock.calls.UpdateStatusHistoryBulk, callInfo)
-	mock.lockUpdateStatusHistoryBulk.Unlock()
-	return mock.UpdateStatusHistoryBulkFunc(ctx, updates)
+	mock.lockUpdateStatusHistory.Lock()
+	mock.calls.UpdateStatusHistory = append(mock.calls.UpdateStatusHistory, callInfo)
+	mock.lockUpdateStatusHistory.Unlock()
+	return mock.UpdateStatusHistoryFunc(ctx, updates)
 }
 
-// UpdateStatusHistoryBulkCalls gets all the calls that were made to UpdateStatusHistoryBulk.
+// UpdateStatusHistoryCalls gets all the calls that were made to UpdateStatusHistory.
 // Check the length with:
 //
-//	len(mockedMetamorphStore.UpdateStatusHistoryBulkCalls())
-func (mock *MetamorphStoreMock) UpdateStatusHistoryBulkCalls() []struct {
+//	len(mockedMetamorphStore.UpdateStatusHistoryCalls())
+func (mock *MetamorphStoreMock) UpdateStatusHistoryCalls() []struct {
 	Ctx     context.Context
 	Updates []store.UpdateStatus
 } {
@@ -1064,8 +1064,8 @@ func (mock *MetamorphStoreMock) UpdateStatusHistoryBulkCalls() []struct {
 		Ctx     context.Context
 		Updates []store.UpdateStatus
 	}
-	mock.lockUpdateStatusHistoryBulk.RLock()
-	calls = mock.calls.UpdateStatusHistoryBulk
-	mock.lockUpdateStatusHistoryBulk.RUnlock()
+	mock.lockUpdateStatusHistory.RLock()
+	calls = mock.calls.UpdateStatusHistory
+	mock.lockUpdateStatusHistory.RUnlock()
 	return calls
 }

--- a/internal/metamorph/store/postgresql/fixtures/update_double_spend/metamorph.transactions.yaml
+++ b/internal/metamorph/store/postgresql/fixtures/update_double_spend/metamorph.transactions.yaml
@@ -4,6 +4,9 @@
   stored_at: 2023-10-01 14:00:00
   last_submitted_at: 2023-10-01 14:00:00
   competing_txs: '1234'
+  status_history:
+    - status: 40
+      timestamp: 2023-10-01 14:00:00
 - hash: 0x21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e
   locked_by: metamorph-3
   status: 50

--- a/internal/metamorph/store/postgresql/fixtures/update_mined_double_spend_attempted/metamorph.transactions.yaml
+++ b/internal/metamorph/store/postgresql/fixtures/update_mined_double_spend_attempted/metamorph.transactions.yaml
@@ -1,0 +1,18 @@
+- hash: 0xcd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853
+  locked_by: metamorph-1
+  status: 100
+  stored_at: 2023-10-01 14:00:00
+  last_submitted_at: 2023-10-01 14:00:00
+  competing_txs: '4e6b3dd04f51ac6ce3d051f80d819bed366a4ff29143bb58c01154cb322d1321,30f409d6951483e4d65a586205f373c2f72431ade49abb6f143e82fc53ea6cb1'
+- hash: 0x21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e
+  locked_by: metamorph-1
+  status: 100
+  stored_at: 2023-10-01 14:00:00
+  last_submitted_at: 2023-10-01 14:00:00
+  competing_txs: '538808e847d0add40ed9622fff53954c79e1f52db7c47ea0b6cdc0df972f3dcd,30f409d6951483e4d65a586205f373c2f72431ade49abb6f143e82fc53ea6cb1'
+- hash: 0xb16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430
+  locked_by: metamorph-1
+  status: 100
+  stored_at: 2023-10-01 14:00:00
+  last_submitted_at: 2023-10-01 14:00:00
+  competing_txs: '4e6b3dd04f51ac6ce3d051f80d819bed366a4ff29143bb58c01154cb322d1321,538808e847d0add40ed9622fff53954c79e1f52db7c47ea0b6cdc0df972f3dcd'

--- a/internal/metamorph/store/postgresql/postgres.go
+++ b/internal/metamorph/store/postgresql/postgres.go
@@ -600,7 +600,7 @@ func (p *PostgreSQL) GetSeenOnNetwork(ctx context.Context, since time.Time, unti
 	return res, nil
 }
 
-func (p *PostgreSQL) UpdateStatusBulk(ctx context.Context, updates []store.UpdateStatus) (res []*store.Data, err error) {
+func (p *PostgreSQL) UpdateStatus(ctx context.Context, updates []store.UpdateStatus) (res []*store.Data, err error) {
 	ctx, span := tracing.StartTracing(ctx, "UpdateStatusBulk", p.tracingEnabled, append(p.tracingAttributes, attribute.Int("updates", len(updates)))...)
 	defer func() {
 		tracing.EndTracing(span, err)
@@ -710,7 +710,7 @@ func (p *PostgreSQL) UpdateStatusBulk(ctx context.Context, updates []store.Updat
 	return res, nil
 }
 
-func (p *PostgreSQL) UpdateStatusHistoryBulk(ctx context.Context, updates []store.UpdateStatus) (res []*store.Data, err error) {
+func (p *PostgreSQL) UpdateStatusHistory(ctx context.Context, updates []store.UpdateStatus) (res []*store.Data, err error) {
 	ctx, span := tracing.StartTracing(ctx, "UpdateStatusHistoryBulk", p.tracingEnabled, append(p.tracingAttributes, attribute.Int("updates", len(updates)))...)
 	defer func() {
 		tracing.EndTracing(span, err)

--- a/internal/metamorph/store/postgresql/postgres_test.go
+++ b/internal/metamorph/store/postgresql/postgres_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
 	"github.com/bitcoin-sv/arc/internal/metamorph/store"
 	"github.com/bitcoin-sv/arc/internal/testdata"
-	testutils2 "github.com/bitcoin-sv/arc/pkg/test_utils"
+	testutils "github.com/bitcoin-sv/arc/pkg/test_utils"
 )
 
 const (
@@ -48,7 +48,7 @@ func testmain(m *testing.M) int {
 	}
 
 	port := "5433"
-	resource, connStr, err := testutils2.RunAndMigratePostgresql(pool, port, "metamorph", migrationsPath)
+	resource, connStr, err := testutils.RunAndMigratePostgresql(pool, port, "metamorph", migrationsPath)
 	if err != nil {
 		log.Print(err)
 		return 1
@@ -65,7 +65,7 @@ func testmain(m *testing.M) int {
 }
 
 func pruneTables(t *testing.T, db *sql.DB) {
-	testutils2.PruneTables(t, db, "metamorph.transactions")
+	testutils.PruneTables(t, db, "metamorph.transactions")
 }
 
 func TestPostgresDB(t *testing.T) {
@@ -146,16 +146,16 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("get raw txs", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/get_rawtxs")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/get_rawtxs")
 
 		hash1 := "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"
 		hash2 := "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e"
 		hash3 := "3e0b5b218c344110f09bf485bc58de4ea5378e55744185edf9c1dafa40068ecd"
 
 		hashes := make([][]byte, 0)
-		hashes = append(hashes, testutils2.RevChainhash(t, hash1).CloneBytes())
-		hashes = append(hashes, testutils2.RevChainhash(t, hash2).CloneBytes())
-		hashes = append(hashes, testutils2.RevChainhash(t, hash3).CloneBytes())
+		hashes = append(hashes, testutils.RevChainhash(t, hash1).CloneBytes())
+		hashes = append(hashes, testutils.RevChainhash(t, hash2).CloneBytes())
+		hashes = append(hashes, testutils.RevChainhash(t, hash3).CloneBytes())
 
 		expectedRawTxs := make([][]byte, 0)
 
@@ -180,11 +180,11 @@ func TestPostgresDB(t *testing.T) {
 	t.Run("get many", func(t *testing.T) {
 		// when
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
 
 		keys := [][]byte{
-			testutils2.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853")[:],
-			testutils2.RevChainhash(t, "ee76f5b746893d3e6ae6a14a15e464704f4ebd601537820933789740acdcf6aa")[:],
+			testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853")[:],
+			testutils.RevChainhash(t, "ee76f5b746893d3e6ae6a14a15e464704f4ebd601537820933789740acdcf6aa")[:],
 		}
 
 		// then
@@ -197,9 +197,9 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("set bulk", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/set_bulk")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/set_bulk")
 
-		hash2 := testutils2.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853") // hash already existing in db - no update expected
+		hash2 := testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853") // hash already existing in db - no update expected
 
 		data := []*store.Data{
 			{
@@ -257,17 +257,17 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("get unmined", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
 
 		// locked by metamorph-1
-		expectedHash0 := testutils2.RevChainhash(t, "3e0b5b218c344110f09bf485bc58de4ea5378e55744185edf9c1dafa40068ecd")
+		expectedHash0 := testutils.RevChainhash(t, "3e0b5b218c344110f09bf485bc58de4ea5378e55744185edf9c1dafa40068ecd")
 		// offset 0
 		records, err := postgresDB.GetUnmined(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 1, 0)
 		require.NoError(t, err)
 		require.Equal(t, expectedHash0, records[0].Hash)
 
 		// locked by metamorph-1
-		expectedHash1 := testutils2.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430")
+		expectedHash1 := testutils.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430")
 		// offset 1
 		records, err = postgresDB.GetUnmined(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 1, 1)
 		require.NoError(t, err)
@@ -276,20 +276,20 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("set locked by", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
 
 		err := postgresDB.SetLocked(ctx, time.Date(2023, 9, 15, 1, 0, 0, 0, time.UTC), 2)
 		require.NoError(t, err)
 
 		// locked by NONE
-		expectedHash2 := testutils2.RevChainhash(t, "12c04cfc5643f1cd25639ad42d6f8f0489557699d92071d7e0a5b940438c4357")
+		expectedHash2 := testutils.RevChainhash(t, "12c04cfc5643f1cd25639ad42d6f8f0489557699d92071d7e0a5b940438c4357")
 
 		// locked by NONE
-		expectedHash3 := testutils2.RevChainhash(t, "319b5eb9d99084b72002640d1445f49b8c83539260a7e5b2cbb16c1d2954a743")
+		expectedHash3 := testutils.RevChainhash(t, "319b5eb9d99084b72002640d1445f49b8c83539260a7e5b2cbb16c1d2954a743")
 
 		// check if previously unlocked tx has b
 		// locked by NONE
-		expectedHash4 := testutils2.RevChainhash(t, "78d66c8391ff5e4a65b494e39645facb420b744f77f3f3b83a3aa8573282176e")
+		expectedHash4 := testutils.RevChainhash(t, "78d66c8391ff5e4a65b494e39645facb420b744f77f3f3b83a3aa8573282176e")
 
 		// check if previously unlocked tx has been locked
 		dataReturned, err := postgresDB.Get(ctx, expectedHash2[:])
@@ -308,28 +308,28 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("set unlocked by name", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/set_unlocked_by_name")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/set_unlocked_by_name")
 
 		rows, err := postgresDB.SetUnlockedByName(ctx, "metamorph-3")
 		require.NoError(t, err)
 		require.Equal(t, int64(4), rows)
 
-		hash1 := testutils2.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853")
+		hash1 := testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853")
 		hash1Data, err := postgresDB.Get(ctx, hash1[:])
 		require.NoError(t, err)
 		require.Equal(t, "NONE", hash1Data.LockedBy)
 
-		hash2 := testutils2.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e")
+		hash2 := testutils.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e")
 		hash2Data, err := postgresDB.Get(ctx, hash2[:])
 		require.NoError(t, err)
 		require.Equal(t, "NONE", hash2Data.LockedBy)
 
-		hash3 := testutils2.RevChainhash(t, "f791ec50447e3001b9348930659527ea92dee506e9950014bcc7c5b146e2417f")
+		hash3 := testutils.RevChainhash(t, "f791ec50447e3001b9348930659527ea92dee506e9950014bcc7c5b146e2417f")
 		hash3Data, err := postgresDB.Get(ctx, hash3[:])
 		require.NoError(t, err)
 		require.Equal(t, "NONE", hash3Data.LockedBy)
 
-		hash4 := testutils2.RevChainhash(t, "89714f129748e5176a07fc4eb89cf27a9e60340117e6b56bb742acb2873f8140")
+		hash4 := testutils.RevChainhash(t, "89714f129748e5176a07fc4eb89cf27a9e60340117e6b56bb742acb2873f8140")
 		hash4Data, err := postgresDB.Get(ctx, hash4[:])
 		require.NoError(t, err)
 		require.Equal(t, "NONE", hash4Data.LockedBy)
@@ -337,28 +337,28 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("set unlocked by name except", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/set_unlocked_by_name")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/set_unlocked_by_name")
 
 		rows, err := postgresDB.SetUnlockedByNameExcept(ctx, []string{"metamorph-1", ""})
 		require.NoError(t, err)
 		require.Equal(t, int64(4), rows)
 
-		hash1 := testutils2.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853")
+		hash1 := testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853")
 		hash1Data, err := postgresDB.Get(ctx, hash1[:])
 		require.NoError(t, err)
 		require.Equal(t, "NONE", hash1Data.LockedBy)
 
-		hash2 := testutils2.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e")
+		hash2 := testutils.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e")
 		hash2Data, err := postgresDB.Get(ctx, hash2[:])
 		require.NoError(t, err)
 		require.Equal(t, "NONE", hash2Data.LockedBy)
 
-		hash3 := testutils2.RevChainhash(t, "f791ec50447e3001b9348930659527ea92dee506e9950014bcc7c5b146e2417f")
+		hash3 := testutils.RevChainhash(t, "f791ec50447e3001b9348930659527ea92dee506e9950014bcc7c5b146e2417f")
 		hash3Data, err := postgresDB.Get(ctx, hash3[:])
 		require.NoError(t, err)
 		require.Equal(t, "NONE", hash3Data.LockedBy)
 
-		hash4 := testutils2.RevChainhash(t, "89714f129748e5176a07fc4eb89cf27a9e60340117e6b56bb742acb2873f8140")
+		hash4 := testutils.RevChainhash(t, "89714f129748e5176a07fc4eb89cf27a9e60340117e6b56bb742acb2873f8140")
 		hash4Data, err := postgresDB.Get(ctx, hash4[:])
 		require.NoError(t, err)
 		require.Equal(t, "NONE", hash4Data.LockedBy)
@@ -366,40 +366,40 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("update status", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/update_status")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/update_status")
 
 		updates := []store.UpdateStatus{
 			{
-				Hash:   *testutils2.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"), // update expected
+				Hash:   *testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"), // update expected
 				Status: metamorph_api.Status_ACCEPTED_BY_NETWORK,
 			},
 			{
-				Hash:   *testutils2.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e"), // update not expected - old status = new status
+				Hash:   *testutils.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e"), // update not expected - old status = new status
 				Status: metamorph_api.Status_REQUESTED_BY_NETWORK,
 			},
 			{
-				Hash:   *testutils2.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430"), // update expected
+				Hash:   *testutils.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430"), // update expected
 				Status: metamorph_api.Status_REJECTED,
 				Error:  errors.New("missing inputs"),
 			},
 			{
-				Hash:   *testutils2.RevChainhash(t, "ee76f5b746893d3e6ae6a14a15e464704f4ebd601537820933789740acdcf6aa"), // update expected
+				Hash:   *testutils.RevChainhash(t, "ee76f5b746893d3e6ae6a14a15e464704f4ebd601537820933789740acdcf6aa"), // update expected
 				Status: metamorph_api.Status_SEEN_ON_NETWORK,
 			},
 			{
-				Hash:   *testutils2.RevChainhash(t, "3e0b5b218c344110f09bf485bc58de4ea5378e55744185edf9c1dafa40068ecd"), // update not expected - status is mined
+				Hash:   *testutils.RevChainhash(t, "3e0b5b218c344110f09bf485bc58de4ea5378e55744185edf9c1dafa40068ecd"), // update not expected - status is mined
 				Status: metamorph_api.Status_SENT_TO_NETWORK,
 			},
 			{
-				Hash:   *testutils2.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f"), // update not expected - old status > new status
+				Hash:   *testutils.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f"), // update not expected - old status > new status
 				Status: metamorph_api.Status_SENT_TO_NETWORK,
 			},
 			{
-				Hash:   *testutils2.RevChainhash(t, "3ce1e0c6cbbbe2118c3f80d2e6899d2d487f319ef0923feb61f3d26335b2225c"), // update not expected - hash non-existent in db
+				Hash:   *testutils.RevChainhash(t, "3ce1e0c6cbbbe2118c3f80d2e6899d2d487f319ef0923feb61f3d26335b2225c"), // update not expected - hash non-existent in db
 				Status: metamorph_api.Status_ANNOUNCED_TO_NETWORK,
 			},
 			{
-				Hash:   *testutils2.RevChainhash(t, "7e3350ca12a0dd9375540e13637b02e054a3436336e9d6b82fe7f2b23c710002"), // update not expected - hash non-existent in db
+				Hash:   *testutils.RevChainhash(t, "7e3350ca12a0dd9375540e13637b02e054a3436336e9d6b82fe7f2b23c710002"), // update not expected - hash non-existent in db
 				Status: metamorph_api.Status_ANNOUNCED_TO_NETWORK,
 			},
 		}
@@ -410,16 +410,16 @@ func TestPostgresDB(t *testing.T) {
 		require.Len(t, statusUpdates, updatedStatuses)
 
 		require.Equal(t, metamorph_api.Status_ACCEPTED_BY_NETWORK, statusUpdates[0].Status)
-		require.Equal(t, *testutils2.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"), *statusUpdates[0].Hash)
+		require.Equal(t, *testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"), *statusUpdates[0].Hash)
 
 		require.Equal(t, metamorph_api.Status_REJECTED, statusUpdates[1].Status)
 		require.Equal(t, "missing inputs", statusUpdates[1].RejectReason)
-		require.Equal(t, *testutils2.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430"), *statusUpdates[1].Hash)
+		require.Equal(t, *testutils.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430"), *statusUpdates[1].Hash)
 
 		require.Equal(t, metamorph_api.Status_SEEN_ON_NETWORK, statusUpdates[2].Status)
-		require.Equal(t, *testutils2.RevChainhash(t, "ee76f5b746893d3e6ae6a14a15e464704f4ebd601537820933789740acdcf6aa"), *statusUpdates[2].Hash)
+		require.Equal(t, *testutils.RevChainhash(t, "ee76f5b746893d3e6ae6a14a15e464704f4ebd601537820933789740acdcf6aa"), *statusUpdates[2].Hash)
 
-		returnedDataRequested, err := postgresDB.Get(ctx, testutils2.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f")[:])
+		returnedDataRequested, err := postgresDB.Get(ctx, testutils.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f")[:])
 		require.NoError(t, err)
 		require.Equal(t, metamorph_api.Status_ACCEPTED_BY_NETWORK, returnedDataRequested.Status)
 
@@ -430,42 +430,42 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("update double spend status", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/update_double_spend")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/update_double_spend")
 
 		updates := []store.UpdateStatus{
 			{
-				Hash:         *testutils2.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"), // update expected
+				Hash:         *testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"), // update expected
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"5678"},
 			},
 			{
-				Hash:         *testutils2.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e"), // update expected
+				Hash:         *testutils.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e"), // update expected
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"9999", "8888"},
 			},
 			{
-				Hash:         *testutils2.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430"), // update expected
+				Hash:         *testutils.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430"), // update expected
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"1234"},
 			},
 			{
-				Hash:         *testutils2.RevChainhash(t, "3e0b5b218c344110f09bf485bc58de4ea5378e55744185edf9c1dafa40068ecd"), // update not expected - status is mined
+				Hash:         *testutils.RevChainhash(t, "3e0b5b218c344110f09bf485bc58de4ea5378e55744185edf9c1dafa40068ecd"), // update not expected - status is mined
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"1234"},
 			},
 			{
-				Hash:         *testutils2.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f"), // update expected - old status < new status
+				Hash:         *testutils.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f"), // update expected - old status < new status
 				Status:       metamorph_api.Status_REJECTED,
 				CompetingTxs: []string{"1234"},
 				Error:        errors.New("double spend attempted"),
 			},
 			{
-				Hash:         *testutils2.RevChainhash(t, "3ce1e0c6cbbbe2118c3f80d2e6899d2d487f319ef0923feb61f3d26335b2225c"), // update not expected - hash non-existent in db
+				Hash:         *testutils.RevChainhash(t, "3ce1e0c6cbbbe2118c3f80d2e6899d2d487f319ef0923feb61f3d26335b2225c"), // update not expected - hash non-existent in db
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"1234"},
 			},
 			{
-				Hash:         *testutils2.RevChainhash(t, "7e3350ca12a0dd9375540e13637b02e054a3436336e9d6b82fe7f2b23c710002"), // update not expected - hash non-existent in db
+				Hash:         *testutils.RevChainhash(t, "7e3350ca12a0dd9375540e13637b02e054a3436336e9d6b82fe7f2b23c710002"), // update not expected - hash non-existent in db
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"1234"},
 			},
@@ -477,19 +477,19 @@ func TestPostgresDB(t *testing.T) {
 		require.Len(t, statusUpdates, updatedStatuses)
 
 		require.Equal(t, metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, statusUpdates[0].Status)
-		require.Equal(t, *testutils2.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"), *statusUpdates[0].Hash)
+		require.Equal(t, *testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"), *statusUpdates[0].Hash)
 		require.True(t, unorderedEqual([]string{"5678", "1234"}, statusUpdates[0].CompetingTxs))
 
 		require.Equal(t, metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, statusUpdates[1].Status)
-		require.Equal(t, *testutils2.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e"), *statusUpdates[1].Hash)
+		require.Equal(t, *testutils.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e"), *statusUpdates[1].Hash)
 		require.True(t, unorderedEqual([]string{"9999", "8888", "1234", "5678"}, statusUpdates[1].CompetingTxs))
 
 		require.Equal(t, metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, statusUpdates[2].Status)
-		require.Equal(t, *testutils2.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430"), *statusUpdates[2].Hash)
+		require.Equal(t, *testutils.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430"), *statusUpdates[2].Hash)
 		require.Equal(t, []string{"1234"}, statusUpdates[2].CompetingTxs)
 
 		require.Equal(t, metamorph_api.Status_REJECTED, statusUpdates[3].Status)
-		require.Equal(t, *testutils2.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f"), *statusUpdates[3].Hash)
+		require.Equal(t, *testutils.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f"), *statusUpdates[3].Hash)
 		require.Equal(t, []string{"1234"}, statusUpdates[3].CompetingTxs)
 		require.Equal(t, "double spend attempted", statusUpdates[3].RejectReason)
 
@@ -500,16 +500,16 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("update mined", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
 
 		unmined := *unminedData
 		err = postgresDB.Set(ctx, &unmined)
 		require.NoError(t, err)
 
-		chainHash2 := testutils2.RevChainhash(t, "ee76f5b746893d3e6ae6a14a15e464704f4ebd601537820933789740acdcf6aa")
-		chainHash3 := testutils2.RevChainhash(t, "a7fd98bd37f9b387dbef4f1a4e4790b9a0d48fb7bbb77455e8f39df0f8909db7")
-		competingHash := testutils2.RevChainhash(t, "67fc757d9ed6d119fc0926ae5c82c1a2cf036ec823257cfaea396e49184ec7ff")
-		chainhash4 := testutils2.RevChainhash(t, "3e0b5b218c344110f09bf485bc58de4ea5378e55744185edf9c1dafa40068ecd")
+		chainHash2 := testutils.RevChainhash(t, "ee76f5b746893d3e6ae6a14a15e464704f4ebd601537820933789740acdcf6aa")
+		chainHash3 := testutils.RevChainhash(t, "a7fd98bd37f9b387dbef4f1a4e4790b9a0d48fb7bbb77455e8f39df0f8909db7")
+		competingHash := testutils.RevChainhash(t, "67fc757d9ed6d119fc0926ae5c82c1a2cf036ec823257cfaea396e49184ec7ff")
+		chainhash4 := testutils.RevChainhash(t, "3e0b5b218c344110f09bf485bc58de4ea5378e55744185edf9c1dafa40068ecd")
 
 		txBlocks := []*blocktx_api.TransactionBlock{
 			{
@@ -922,7 +922,7 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("clear data", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
 
 		res, err := postgresDB.ClearData(ctx, 14)
 		require.NoError(t, err)
@@ -936,9 +936,9 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("get seen on network txs", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
 
-		txHash := testutils2.RevChainhash(t, "855b2aea1420df52a561fe851297653739677b14c89c0a08e3f70e1942bcb10f")
+		txHash := testutils.RevChainhash(t, "855b2aea1420df52a561fe851297653739677b14c89c0a08e3f70e1942bcb10f")
 		require.NoError(t, err)
 
 		records, err := postgresDB.GetSeenOnNetwork(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), time.Date(2023, 1, 1, 3, 0, 0, 0, time.UTC), 2, 0)
@@ -955,7 +955,7 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("get stats", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils2.LoadFixtures(t, postgresDB.db, "fixtures/get_stats")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/get_stats")
 
 		res, err := postgresDB.GetStats(ctx, time.Date(2023, 1, 1, 1, 0, 0, 0, time.UTC), 10*time.Minute, 20*time.Minute)
 		require.NoError(t, err)

--- a/internal/metamorph/store/postgresql/postgres_test.go
+++ b/internal/metamorph/store/postgresql/postgres_test.go
@@ -432,42 +432,51 @@ func TestPostgresDB(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
 		testutils.LoadFixtures(t, postgresDB.db, "fixtures/update_double_spend")
 
+		timestamp := time.Date(2025, 4, 3, 14, 5, 20, 0, time.UTC)
+
 		updates := []store.UpdateStatus{
 			{
 				Hash:         *testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"), // update expected
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"5678"},
+				Timestamp:    timestamp,
 			},
 			{
 				Hash:         *testutils.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e"), // update expected
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"9999", "8888"},
+				Timestamp:    timestamp,
 			},
 			{
 				Hash:         *testutils.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430"), // update expected
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"1234"},
+				Timestamp:    timestamp,
 			},
 			{
 				Hash:         *testutils.RevChainhash(t, "3e0b5b218c344110f09bf485bc58de4ea5378e55744185edf9c1dafa40068ecd"), // update not expected - status is mined
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"1234"},
+				Timestamp:    timestamp,
 			},
 			{
 				Hash:         *testutils.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f"), // update expected - old status < new status
 				Status:       metamorph_api.Status_REJECTED,
 				CompetingTxs: []string{"1234"},
 				Error:        errors.New("double spend attempted"),
+				Timestamp:    timestamp,
 			},
 			{
 				Hash:         *testutils.RevChainhash(t, "3ce1e0c6cbbbe2118c3f80d2e6899d2d487f319ef0923feb61f3d26335b2225c"), // update not expected - hash non-existent in db
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"1234"},
+				Timestamp:    timestamp,
 			},
 			{
 				Hash:         *testutils.RevChainhash(t, "7e3350ca12a0dd9375540e13637b02e054a3436336e9d6b82fe7f2b23c710002"), // update not expected - hash non-existent in db
 				Status:       metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED,
 				CompetingTxs: []string{"1234"},
+				Timestamp:    timestamp,
 			},
 		}
 		updatedStatuses := 4
@@ -478,18 +487,22 @@ func TestPostgresDB(t *testing.T) {
 
 		require.Equal(t, metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, statusUpdates[0].Status)
 		require.Equal(t, *testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"), *statusUpdates[0].Hash)
-		require.True(t, unorderedEqual([]string{"5678", "1234"}, statusUpdates[0].CompetingTxs))
+		require.Equal(t, []*store.StatusWithTimestamp{{Status: metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, Timestamp: timestamp}}, statusUpdates[0].StatusHistory)
+		require.ElementsMatch(t, []string{"5678", "1234"}, statusUpdates[0].CompetingTxs)
 
 		require.Equal(t, metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, statusUpdates[1].Status)
 		require.Equal(t, *testutils.RevChainhash(t, "21132d32cb5411c058bb4391f24f6a36ed9b810df851d0e36cac514fd03d6b4e"), *statusUpdates[1].Hash)
-		require.True(t, unorderedEqual([]string{"9999", "8888", "1234", "5678"}, statusUpdates[1].CompetingTxs))
+		require.Equal(t, []*store.StatusWithTimestamp{{Status: metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, Timestamp: timestamp}}, statusUpdates[1].StatusHistory)
+		require.ElementsMatch(t, []string{"9999", "8888", "1234", "5678"}, statusUpdates[1].CompetingTxs)
 
 		require.Equal(t, metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, statusUpdates[2].Status)
 		require.Equal(t, *testutils.RevChainhash(t, "b16cea53fc823e146fbb9ae4ad3124f7c273f30562585ad6e4831495d609f430"), *statusUpdates[2].Hash)
+		require.Equal(t, []*store.StatusWithTimestamp{{Status: metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, Timestamp: timestamp}}, statusUpdates[2].StatusHistory)
 		require.Equal(t, []string{"1234"}, statusUpdates[2].CompetingTxs)
 
 		require.Equal(t, metamorph_api.Status_REJECTED, statusUpdates[3].Status)
 		require.Equal(t, *testutils.RevChainhash(t, "7809b730cbe7bb723f299a4e481fb5165f31175876392a54cde85569a18cc75f"), *statusUpdates[3].Hash)
+		require.Equal(t, []*store.StatusWithTimestamp{{Status: metamorph_api.Status_REJECTED, Timestamp: timestamp}}, statusUpdates[3].StatusHistory)
 		require.Equal(t, []string{"1234"}, statusUpdates[3].CompetingTxs)
 		require.Equal(t, "double spend attempted", statusUpdates[3].RejectReason)
 
@@ -975,26 +988,4 @@ func TestPostgresDB(t *testing.T) {
 		require.Equal(t, int64(6), res.StatusMinedTotal)
 		require.Equal(t, int64(2), res.StatusSeenOnNetworkTotal)
 	})
-}
-
-// unorderedEqual checks if two string slices contain
-// the same elements, regardless of order
-func unorderedEqual(sliceOne, sliceTwo []string) bool {
-	if len(sliceOne) != len(sliceTwo) {
-		return false
-	}
-
-	exists := make(map[string]bool)
-
-	for _, value := range sliceOne {
-		exists[value] = true
-	}
-
-	for _, value := range sliceTwo {
-		if !exists[value] {
-			return false
-		}
-	}
-
-	return true
 }

--- a/internal/metamorph/store/postgresql/postgres_test.go
+++ b/internal/metamorph/store/postgresql/postgres_test.go
@@ -405,7 +405,7 @@ func TestPostgresDB(t *testing.T) {
 		}
 		updatedStatuses := 3
 
-		statusUpdates, err := postgresDB.UpdateStatusBulk(ctx, updates)
+		statusUpdates, err := postgresDB.UpdateStatus(ctx, updates)
 		require.NoError(t, err)
 		require.Len(t, statusUpdates, updatedStatuses)
 
@@ -423,7 +423,7 @@ func TestPostgresDB(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, metamorph_api.Status_ACCEPTED_BY_NETWORK, returnedDataRequested.Status)
 
-		statusUpdates, err = postgresDB.UpdateStatusBulk(ctx, updates)
+		statusUpdates, err = postgresDB.UpdateStatus(ctx, updates)
 		require.NoError(t, err)
 		require.Len(t, statusUpdates, 0)
 	})
@@ -667,7 +667,7 @@ func TestPostgresDB(t *testing.T) {
 			},
 		}
 
-		statusUpdates, err := postgresDB.UpdateStatusBulk(ctx, updates)
+		statusUpdates, err := postgresDB.UpdateStatus(ctx, updates)
 		require.NoError(t, err)
 		require.Len(t, statusUpdates, 1)
 
@@ -696,7 +696,7 @@ func TestPostgresDB(t *testing.T) {
 			},
 		}
 
-		statusUpdates, err = postgresDB.UpdateStatusBulk(ctx, updates)
+		statusUpdates, err = postgresDB.UpdateStatus(ctx, updates)
 		require.NoError(t, err)
 		require.Len(t, statusUpdates, 1)
 
@@ -811,7 +811,7 @@ func TestPostgresDB(t *testing.T) {
 			},
 		}
 
-		statusUpdates, err := postgresDB.UpdateStatusHistoryBulk(ctx, updates)
+		statusUpdates, err := postgresDB.UpdateStatusHistory(ctx, updates)
 		require.NoError(t, err)
 		require.Len(t, statusUpdates, 1)
 
@@ -848,7 +848,7 @@ func TestPostgresDB(t *testing.T) {
 			},
 		}
 
-		statusUpdates, err := postgresDB.UpdateStatusHistoryBulk(ctx, updates)
+		statusUpdates, err := postgresDB.UpdateStatusHistory(ctx, updates)
 		require.NoError(t, err)
 		require.Len(t, statusUpdates, 1)
 
@@ -888,7 +888,7 @@ func TestPostgresDB(t *testing.T) {
 			},
 		}
 
-		statusUpdates, err := postgresDB.UpdateStatusHistoryBulk(ctx, updates)
+		statusUpdates, err := postgresDB.UpdateStatusHistory(ctx, updates)
 		require.NoError(t, err)
 		require.Len(t, statusUpdates, 1)
 
@@ -921,7 +921,7 @@ func TestPostgresDB(t *testing.T) {
 			},
 		}
 
-		statusUpdates, err := postgresDB.UpdateStatusHistoryBulk(ctx, updates)
+		statusUpdates, err := postgresDB.UpdateStatusHistory(ctx, updates)
 		require.NoError(t, err)
 		require.Len(t, statusUpdates, 1)
 

--- a/internal/metamorph/store/postgresql/postgres_test.go
+++ b/internal/metamorph/store/postgresql/postgres_test.go
@@ -487,7 +487,10 @@ func TestPostgresDB(t *testing.T) {
 
 		require.Equal(t, metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, statusUpdates[0].Status)
 		require.Equal(t, *testutils.RevChainhash(t, "cd3d2f97dfc0cdb6a07ec4b72df5e1794c9553ff2f62d90ed4add047e8088853"), *statusUpdates[0].Hash)
-		require.Equal(t, []*store.StatusWithTimestamp{{Status: metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, Timestamp: timestamp}}, statusUpdates[0].StatusHistory)
+		require.ElementsMatch(t, []*store.StatusWithTimestamp{
+			{Status: metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, Timestamp: timestamp},
+			{Status: metamorph_api.Status_ANNOUNCED_TO_NETWORK, Timestamp: time.Date(2023, 10, 1, 14, 0, 0, 0, time.UTC)},
+		}, statusUpdates[0].StatusHistory)
 		require.ElementsMatch(t, []string{"5678", "1234"}, statusUpdates[0].CompetingTxs)
 
 		require.Equal(t, metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, statusUpdates[1].Status)

--- a/internal/metamorph/store/store.go
+++ b/internal/metamorph/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/libsv/go-p2p/chaincfg/chainhash"
@@ -12,7 +13,10 @@ import (
 	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
 )
 
-var ErrNotFound = errors.New("key could not be found")
+var (
+	ErrNotFound        = errors.New("key could not be found")
+	ErrUpdateCompeting = fmt.Errorf("failed to updated competing transactions with status %s", metamorph_api.Status_REJECTED.String())
+)
 
 type Data struct {
 	RawTx             []byte

--- a/internal/metamorph/store/store.go
+++ b/internal/metamorph/store/store.go
@@ -75,8 +75,8 @@ type MetamorphStore interface {
 	SetUnlockedByName(ctx context.Context, lockedBy string) (int64, error)
 	GetUnmined(ctx context.Context, since time.Time, limit int64, offset int64) ([]*Data, error)
 	GetSeenOnNetwork(ctx context.Context, since time.Time, until time.Time, limit int64, offset int64) ([]*Data, error)
-	UpdateStatusBulk(ctx context.Context, updates []UpdateStatus) ([]*Data, error)
-	UpdateStatusHistoryBulk(ctx context.Context, updates []UpdateStatus) (res []*Data, err error)
+	UpdateStatus(ctx context.Context, updates []UpdateStatus) ([]*Data, error)
+	UpdateStatusHistory(ctx context.Context, updates []UpdateStatus) (res []*Data, err error)
 	UpdateMined(ctx context.Context, txsBlocks []*blocktx_api.TransactionBlock) ([]*Data, error)
 	UpdateDoubleSpend(ctx context.Context, updates []UpdateStatus) ([]*Data, error)
 	Close(ctx context.Context) error

--- a/test/utils.go
+++ b/test/utils.go
@@ -222,8 +222,8 @@ func respondToCallback(w http.ResponseWriter, success bool) error {
 }
 
 func CreateCallbackServer(t *testing.T) (callbackURL string, token string, callbackReceivedChan chan *TransactionResponse, callbackErrChan chan error, cleanup func()) {
-	callbackReceivedChan = make(chan *TransactionResponse)
-	callbackErrChan = make(chan error)
+	callbackReceivedChan = make(chan *TransactionResponse, 100)
+	callbackErrChan = make(chan error, 100)
 
 	lis, err := net.Listen("tcp", ":9000")
 	require.NoError(t, err)


### PR DESCRIPTION
## Description of Changes

- Update mined and competing txs in separate db transactions
- Check callbacks in double spend e2e test
- Fix update double spend query to include the current status in the status history
- Rename bulk-update db functions as they're all bulk-update functions

## Testing Procedure

- [X] I have added new unit tests
- [X] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
