### PR TITLE
fix: create new connection when inserting block transactions

### DIFF
--- a/internal/blocktx/store/postgresql/insert_block_transactions.go
+++ b/internal/blocktx/store/postgresql/insert_block_transactions.go
@@ -27,7 +27,14 @@ func (p *PostgreSQL) InsertBlockTransactions(ctx context.Context, blockID uint64
 		copyRows[pos] = []any{blockID, tx.Hash, tx.MerkleTreeIndex}
 	}
 
-	err = p.conn.Raw(func(driverConn any) error {
+	conn, err := p.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer conn.Close()
+
+	err = conn.Raw(func(driverConn any) error {
 		c, ok := driverConn.(*stdlib.Conn)
 		if !ok {
 			return errors.New("driverConn.(*stdlib.Conn) conversion failed")

--- a/internal/blocktx/store/postgresql/postgres.go
+++ b/internal/blocktx/store/postgresql/postgres.go
@@ -22,7 +22,6 @@ const (
 
 type PostgreSQL struct {
 	db                        *sql.DB
-	conn                      *sql.Conn
 	now                       func() time.Time
 	maxPostgresBulkInsertRows int
 	tracingEnabled            bool
@@ -58,15 +57,8 @@ func New(dbInfo string, idleConns int, maxOpenConns int, opts ...func(postgreSQL
 	db.SetMaxIdleConns(idleConns)
 	db.SetMaxOpenConns(maxOpenConns)
 
-	// get an existing connection from the pool instead of creating a new one
-	conn, err := db.Conn(context.TODO())
-	if err != nil {
-		return nil, errors.Join(store.ErrUnableToGetSQLConnection, err)
-	}
-
 	p := &PostgreSQL{
 		db:                        db,
-		conn:                      conn,
 		now:                       time.Now,
 		maxPostgresBulkInsertRows: maxPostgresBulkInsertRows,
 	}


### PR DESCRIPTION
## Description of Changes

Create new connection when inserting block transactions

## Testing Procedure

- [ ] I have added new unit tests
- [X] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
