### PR TITLE
fix: remove default zmq port

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -197,7 +197,7 @@ func getFillGapsConfig() *FillGapsConfig {
 
 func getUnorphanRecentWrongOrphansConfig() *UnorphanRecentWrongOrphansConfig {
 	return &UnorphanRecentWrongOrphansConfig{
-		Enabled:  true,
+		Enabled:  false,
 		Interval: 5 * time.Minute,
 	}
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -82,7 +82,6 @@ func getMetamorphConfig() *MetamorphConfig {
 					Host: "localhost",
 					Port: &PeerPortConfig{
 						P2P: 18333,
-						ZMQ: 28332,
 					},
 				},
 			},
@@ -113,7 +112,6 @@ func getBlocktxConfig() *BlocktxConfig {
 					Host: "localhost",
 					Port: &PeerPortConfig{
 						P2P: 18333,
-						ZMQ: 28332,
 					},
 				},
 			},

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -112,7 +112,7 @@ blocktx:
     enabled: true
     interval: 15m # time interval to check and fill gaps in processed blocks
   unorphanRecentWrongOrphans:
-    enabled: true
+    enabled: false
     interval: 5m # time interval to check and fix wrong orphan blocks
   maxAllowedBlockHeightMismatch: 3 # maximum number of blocks that can be ahead of current highest block in blocktx, used for merkle roots verification
   p2pReadBufferSize: 8388608 # size of read buffer for p2p messeges

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -66,11 +66,10 @@ metamorph:
       - host: node1
         port:
           p2p: 18333
-          zmq: 28332
+        zmq: 28332
       - host: node2
         port:
           p2p: 18333
-          zmq: 28332
 
 blocktx:
   listenAddr: 0.0.0.0:8011
@@ -106,11 +105,9 @@ blocktx:
       - host: node1
         port:
           p2p: 18333
-          zmq: 28332
       - host: node2
         port:
           p2p: 18333
-          zmq: 28332
 
 api:
   address: 0.0.0.0:9090

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -94,7 +94,7 @@ blocktx:
     enabled: true
     interval: 1s
   unorphanRecentWrongOrphans:
-      enabled: true
+      enabled: false
       interval: 1s
   maxAllowedBlockHeightMismatch: 3
   p2pReadBufferSize: 8388608

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -66,7 +66,7 @@ metamorph:
       - host: node1
         port:
           p2p: 18333
-        zmq: 28332
+          zmq: 28332
       - host: node2
         port:
           p2p: 18333

--- a/test/config/config_mcast.yaml
+++ b/test/config/config_mcast.yaml
@@ -71,7 +71,6 @@ metamorph:
       - host: node2
         port:
           p2p: 18333
-          zmq: 28332
     mcast:
       tx:
         address: "[ff05::1]:9999"
@@ -112,11 +111,9 @@ blocktx:
       - host: node1
         port:
           p2p: 18333
-          zmq: 28332
       - host: node2
         port:
           p2p: 18333
-          zmq: 28332
     mcast:
       block:
         address: "[ff05::3]:9979"

--- a/test/config/config_mcast.yaml
+++ b/test/config/config_mcast.yaml
@@ -100,7 +100,7 @@ blocktx:
     enabled: true
     interval: 120s
   unorphanRecentWrongOrphans:
-    enabled: true
+    enabled: false
     interval: 120s
   maxAllowedBlockHeightMismatch: 3
   p2pReadBufferSize: 8388608


### PR DESCRIPTION
## Description of Changes

No ZMQ by default

## Testing Procedure

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
