### PR TITLE
fix: node connection

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -140,9 +140,10 @@ func run() error {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM, syscall.SIGINT)
 
+	<-signalChan
+
 	logger.Info("Received signal to shutdown")
 
-	<-signalChan
 	appCleanup(logger, shutdownFns)
 
 	return nil

--- a/cmd/arc/services/blocktx.go
+++ b/cmd/arc/services/blocktx.go
@@ -329,7 +329,8 @@ func connectToPeers(l *slog.Logger, network wire.BitcoinNet, msgHandler p2p.Mess
 			opts...)
 		ok := p.Connect()
 		if !ok {
-			return nil, fmt.Errorf("error connecting peer %s", url)
+			l.Warn("Failed to connect to peer", slog.String("url", url))
+			continue
 		}
 
 		peers = append(peers, p)


### PR DESCRIPTION
## Description of Changes

It repeatedly happened that ARC was not starting when just one of multiple nodes were not available.
In this case ARC should skip the unavailable nodes and connect to the available ones

- Skip peers which cannot be connected to but add remaining peers
- Move log after signal is actually received

## Testing Procedure

- [ ] I have added new unit tests
- [X] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
