### PR TITLE
feat(BPAAS-2127): fix stale tx status

### DIFF
--- a/test/submit_05_reorg_test.go
+++ b/test/submit_05_reorg_test.go
@@ -189,6 +189,12 @@ func TestReorg(t *testing.T) {
 			switch status.Txid {
 			// verify that callback for tx2 was received
 			case tx2.TxID().String():
+				if status.TxStatus == StatusMined {
+					require.Equal(t, staleHash, *status.BlockHash)
+				}
+				if status.TxStatus == StatusMinedInStaleBlock {
+					require.Equal(t, tx2BlockHash, *status.BlockHash)
+				}
 			// verify that callback for tx1 was received with status MINED and updated merkle path
 			case tx1.TxID().String():
 				require.Equal(t, StatusMined, status.TxStatus)


### PR DESCRIPTION
## Description of Changes

The problem in the test was the following: we expected that the transaction belonging to the stale chain would remain there. The thing is that a transaction can be part of the both chains - canonical and stale. If it still exists in the pool or is re-broadcasted it can also be mined in a forked chain. 

That's what was happening sometimes - tx from stale block was also included in the canonical chain.

In the end we somehow expected that it would remain in stale chain which is incorrect. Removing that assumption from the test.

## Testing Procedure

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
