### PR TITLE
chore(BPAAS-2141): Change deprecated woc api

### DIFF
--- a/cmd/broadcaster-cli/app/keyset/utxos/table.go
+++ b/cmd/broadcaster-cli/app/keyset/utxos/table.go
@@ -32,7 +32,7 @@ func getUtxosTable(ctx context.Context, logger *slog.Logger, t table.Writer, key
 
 	for _, name := range names {
 		ks := keySets[name]
-		utxos, err := wocClient.GetUTXOsWithRetries(ctx, ks.Script, ks.Address(!isTestnet), 1*time.Second, 5)
+		utxos, err := wocClient.GetUTXOsWithRetries(ctx, ks.Address(!isTestnet), 1*time.Second, 5)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return t

--- a/internal/broadcaster/broadcaster.go
+++ b/internal/broadcaster/broadcaster.go
@@ -2,14 +2,11 @@ package broadcaster
 
 import (
 	"context"
-	"log/slog"
-	"time"
-
-	"github.com/bsv-blockchain/go-sdk/script"
+	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
 	feemodel "github.com/bsv-blockchain/go-sdk/transaction/fee_model"
-
-	"github.com/bitcoin-sv/arc/internal/metamorph/metamorph_api"
+	"log/slog"
+	"time"
 )
 
 const (
@@ -19,8 +16,8 @@ const (
 )
 
 type UtxoClient interface {
-	GetUTXOs(ctx context.Context, lockingScript *script.Script, address string) (sdkTx.UTXOs, error)
-	GetUTXOsWithRetries(ctx context.Context, lockingScript *script.Script, address string, constantBackoff time.Duration, retries uint64) (sdkTx.UTXOs, error)
+	GetUTXOs(ctx context.Context, address string) (sdkTx.UTXOs, error)
+	GetUTXOsWithRetries(ctx context.Context, address string, constantBackoff time.Duration, retries uint64) (sdkTx.UTXOs, error)
 	GetBalance(ctx context.Context, address string) (uint64, uint64, error)
 	GetBalanceWithRetries(ctx context.Context, address string, constantBackoff time.Duration, retries uint64) (uint64, uint64, error)
 	TopUp(ctx context.Context, address string) error

--- a/internal/broadcaster/broadcaster_test.go
+++ b/internal/broadcaster/broadcaster_test.go
@@ -3,6 +3,7 @@ package broadcaster_test
 import (
 	"context"
 	"encoding/hex"
+	"github.com/bsv-blockchain/go-sdk/script"
 	"log/slog"
 	"os"
 	"testing"
@@ -11,7 +12,6 @@ import (
 	"github.com/bitcoin-sv/arc/pkg/api"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
-	"github.com/bsv-blockchain/go-sdk/script"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
 	chaincfg "github.com/bsv-blockchain/go-sdk/transaction/chaincfg"
 	"github.com/stretchr/testify/require"
@@ -30,6 +30,11 @@ func TestBroadcaster(t *testing.T) {
 	txIDbytes, _ = hex.DecodeString("1a2992fa3af9eb7ff6b94dc9e27e44f29a54ab351ee6377455409b0ebbe1f00c")
 	hash2, err := chainhash.NewHash(txIDbytes)
 	require.NoError(t, err)
+	lockingScriptStr := "d9ad6a3aba0b1cc57071409f3ebc229193647ad43f715e496a91427d6e812c60"
+	wocScript, err := hex.DecodeString(lockingScriptStr)
+	require.NoError(t, err)
+	lockingScript := script.Script(wocScript)
+
 	// given
 	mockedUtxoClient := &mocks.UtxoClientMock{
 		GetBalanceFunc: func(_ context.Context, _ string) (uint64, uint64, error) {
@@ -38,34 +43,34 @@ func TestBroadcaster(t *testing.T) {
 		GetBalanceWithRetriesFunc: func(_ context.Context, _ string, _ time.Duration, _ uint64) (uint64, uint64, error) {
 			return 1000, 0, nil
 		},
-		GetUTXOsFunc: func(_ context.Context, lockingScript *script.Script, _ string) (sdkTx.UTXOs, error) {
+		GetUTXOsFunc: func(_ context.Context, _ string) (sdkTx.UTXOs, error) {
 			return sdkTx.UTXOs{
 				{
 					TxID:          hash1,
 					Vout:          0,
-					LockingScript: lockingScript,
+					LockingScript: &lockingScript,
 					Satoshis:      1000,
 				},
 				{
 					TxID:          hash2,
 					Vout:          1,
-					LockingScript: lockingScript,
+					LockingScript: &lockingScript,
 					Satoshis:      1000,
 				},
 			}, nil // Mock response for UTXOs retrieval with multiple UTXOs
 		},
-		GetUTXOsWithRetriesFunc: func(_ context.Context, lockingScript *script.Script, _ string, _ time.Duration, _ uint64) (sdkTx.UTXOs, error) {
+		GetUTXOsWithRetriesFunc: func(_ context.Context, _ string, _ time.Duration, _ uint64) (sdkTx.UTXOs, error) {
 			return sdkTx.UTXOs{
 				{
 					TxID:          hash1,
 					Vout:          0,
-					LockingScript: lockingScript,
+					LockingScript: &lockingScript,
 					Satoshis:      1000,
 				},
 				{
 					TxID:          hash2,
 					Vout:          1,
-					LockingScript: lockingScript,
+					LockingScript: &lockingScript,
 					Satoshis:      1000,
 				},
 			}, nil

--- a/internal/broadcaster/mocks/utxo_client_mock.go
+++ b/internal/broadcaster/mocks/utxo_client_mock.go
@@ -6,7 +6,6 @@ package mocks
 import (
 	"context"
 	"github.com/bitcoin-sv/arc/internal/broadcaster"
-	"github.com/bsv-blockchain/go-sdk/script"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
 	"sync"
 	"time"
@@ -28,10 +27,10 @@ var _ broadcaster.UtxoClient = &UtxoClientMock{}
 //			GetBalanceWithRetriesFunc: func(ctx context.Context, address string, constantBackoff time.Duration, retries uint64) (uint64, uint64, error) {
 //				panic("mock out the GetBalanceWithRetries method")
 //			},
-//			GetUTXOsFunc: func(ctx context.Context, lockingScript *script.Script, address string) (sdkTx.UTXOs, error) {
+//			GetUTXOsFunc: func(ctx context.Context, address string) (sdkTx.UTXOs, error) {
 //				panic("mock out the GetUTXOs method")
 //			},
-//			GetUTXOsWithRetriesFunc: func(ctx context.Context, lockingScript *script.Script, address string, constantBackoff time.Duration, retries uint64) (sdkTx.UTXOs, error) {
+//			GetUTXOsWithRetriesFunc: func(ctx context.Context, address string, constantBackoff time.Duration, retries uint64) (sdkTx.UTXOs, error) {
 //				panic("mock out the GetUTXOsWithRetries method")
 //			},
 //			TopUpFunc: func(ctx context.Context, address string) error {
@@ -51,10 +50,10 @@ type UtxoClientMock struct {
 	GetBalanceWithRetriesFunc func(ctx context.Context, address string, constantBackoff time.Duration, retries uint64) (uint64, uint64, error)
 
 	// GetUTXOsFunc mocks the GetUTXOs method.
-	GetUTXOsFunc func(ctx context.Context, lockingScript *script.Script, address string) (sdkTx.UTXOs, error)
+	GetUTXOsFunc func(ctx context.Context, address string) (sdkTx.UTXOs, error)
 
 	// GetUTXOsWithRetriesFunc mocks the GetUTXOsWithRetries method.
-	GetUTXOsWithRetriesFunc func(ctx context.Context, lockingScript *script.Script, address string, constantBackoff time.Duration, retries uint64) (sdkTx.UTXOs, error)
+	GetUTXOsWithRetriesFunc func(ctx context.Context, address string, constantBackoff time.Duration, retries uint64) (sdkTx.UTXOs, error)
 
 	// TopUpFunc mocks the TopUp method.
 	TopUpFunc func(ctx context.Context, address string) error
@@ -83,8 +82,6 @@ type UtxoClientMock struct {
 		GetUTXOs []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// LockingScript is the lockingScript argument value.
-			LockingScript *script.Script
 			// Address is the address argument value.
 			Address string
 		}
@@ -92,8 +89,6 @@ type UtxoClientMock struct {
 		GetUTXOsWithRetries []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// LockingScript is the lockingScript argument value.
-			LockingScript *script.Script
 			// Address is the address argument value.
 			Address string
 			// ConstantBackoff is the constantBackoff argument value.
@@ -197,23 +192,21 @@ func (mock *UtxoClientMock) GetBalanceWithRetriesCalls() []struct {
 }
 
 // GetUTXOs calls GetUTXOsFunc.
-func (mock *UtxoClientMock) GetUTXOs(ctx context.Context, lockingScript *script.Script, address string) (sdkTx.UTXOs, error) {
+func (mock *UtxoClientMock) GetUTXOs(ctx context.Context, address string) (sdkTx.UTXOs, error) {
 	if mock.GetUTXOsFunc == nil {
 		panic("UtxoClientMock.GetUTXOsFunc: method is nil but UtxoClient.GetUTXOs was just called")
 	}
 	callInfo := struct {
-		Ctx           context.Context
-		LockingScript *script.Script
-		Address       string
+		Ctx     context.Context
+		Address string
 	}{
-		Ctx:           ctx,
-		LockingScript: lockingScript,
-		Address:       address,
+		Ctx:     ctx,
+		Address: address,
 	}
 	mock.lockGetUTXOs.Lock()
 	mock.calls.GetUTXOs = append(mock.calls.GetUTXOs, callInfo)
 	mock.lockGetUTXOs.Unlock()
-	return mock.GetUTXOsFunc(ctx, lockingScript, address)
+	return mock.GetUTXOsFunc(ctx, address)
 }
 
 // GetUTXOsCalls gets all the calls that were made to GetUTXOs.
@@ -221,14 +214,12 @@ func (mock *UtxoClientMock) GetUTXOs(ctx context.Context, lockingScript *script.
 //
 //	len(mockedUtxoClient.GetUTXOsCalls())
 func (mock *UtxoClientMock) GetUTXOsCalls() []struct {
-	Ctx           context.Context
-	LockingScript *script.Script
-	Address       string
+	Ctx     context.Context
+	Address string
 } {
 	var calls []struct {
-		Ctx           context.Context
-		LockingScript *script.Script
-		Address       string
+		Ctx     context.Context
+		Address string
 	}
 	mock.lockGetUTXOs.RLock()
 	calls = mock.calls.GetUTXOs
@@ -237,19 +228,17 @@ func (mock *UtxoClientMock) GetUTXOsCalls() []struct {
 }
 
 // GetUTXOsWithRetries calls GetUTXOsWithRetriesFunc.
-func (mock *UtxoClientMock) GetUTXOsWithRetries(ctx context.Context, lockingScript *script.Script, address string, constantBackoff time.Duration, retries uint64) (sdkTx.UTXOs, error) {
+func (mock *UtxoClientMock) GetUTXOsWithRetries(ctx context.Context, address string, constantBackoff time.Duration, retries uint64) (sdkTx.UTXOs, error) {
 	if mock.GetUTXOsWithRetriesFunc == nil {
 		panic("UtxoClientMock.GetUTXOsWithRetriesFunc: method is nil but UtxoClient.GetUTXOsWithRetries was just called")
 	}
 	callInfo := struct {
 		Ctx             context.Context
-		LockingScript   *script.Script
 		Address         string
 		ConstantBackoff time.Duration
 		Retries         uint64
 	}{
 		Ctx:             ctx,
-		LockingScript:   lockingScript,
 		Address:         address,
 		ConstantBackoff: constantBackoff,
 		Retries:         retries,
@@ -257,7 +246,7 @@ func (mock *UtxoClientMock) GetUTXOsWithRetries(ctx context.Context, lockingScri
 	mock.lockGetUTXOsWithRetries.Lock()
 	mock.calls.GetUTXOsWithRetries = append(mock.calls.GetUTXOsWithRetries, callInfo)
 	mock.lockGetUTXOsWithRetries.Unlock()
-	return mock.GetUTXOsWithRetriesFunc(ctx, lockingScript, address, constantBackoff, retries)
+	return mock.GetUTXOsWithRetriesFunc(ctx, address, constantBackoff, retries)
 }
 
 // GetUTXOsWithRetriesCalls gets all the calls that were made to GetUTXOsWithRetries.
@@ -266,14 +255,12 @@ func (mock *UtxoClientMock) GetUTXOsWithRetries(ctx context.Context, lockingScri
 //	len(mockedUtxoClient.GetUTXOsWithRetriesCalls())
 func (mock *UtxoClientMock) GetUTXOsWithRetriesCalls() []struct {
 	Ctx             context.Context
-	LockingScript   *script.Script
 	Address         string
 	ConstantBackoff time.Duration
 	Retries         uint64
 } {
 	var calls []struct {
 		Ctx             context.Context
-		LockingScript   *script.Script
 		Address         string
 		ConstantBackoff time.Duration
 		Retries         uint64

--- a/internal/broadcaster/rate_broadcaster.go
+++ b/internal/broadcaster/rate_broadcaster.go
@@ -92,7 +92,7 @@ func (b *UTXORateBroadcaster) Start() error {
 	}
 	b.logger.Info("Start broadcasting", slog.String("wait for status", b.waitForStatus.String()), slog.String("op return", b.opReturn), slog.Bool("full status updates", b.fullStatusUpdates), slog.String("callback URL", b.callbackURL), slog.String("callback token", b.callbackToken))
 
-	utxoSet, err := b.utxoClient.GetUTXOsWithRetries(b.ctx, b.ks.Script, b.ks.Address(!b.isTestnet), 1*time.Second, 5)
+	utxoSet, err := b.utxoClient.GetUTXOsWithRetries(b.ctx, b.ks.Address(!b.isTestnet), 1*time.Second, 5)
 	if err != nil {
 		return errors.Join(ErrFailedToGetUTXOs, err)
 	}
@@ -262,10 +262,6 @@ func addRandomDataInputs(b *UTXORateBroadcaster, tx **sdkTx.Transaction, amount 
 		return fmt.Errorf("failed to generate random number: %v", err)
 	}
 	dataSize := randJitter.Int64()
-
-	if err != nil {
-		return fmt.Errorf("failed to generate random number for filling OP_RETURN: %v", err)
-	}
 
 	randomBytes := make([]byte, dataSize)
 	_, err = cRand.Read(randomBytes)

--- a/internal/broadcaster/rate_broadcaster_test.go
+++ b/internal/broadcaster/rate_broadcaster_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"github.com/bsv-blockchain/go-sdk/script"
 	"log/slog"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
-	"github.com/bsv-blockchain/go-sdk/script"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
 	chaincfg "github.com/bsv-blockchain/go-sdk/transaction/chaincfg"
 	"github.com/stretchr/testify/assert"
@@ -102,6 +102,10 @@ func TestRateBroadcasterStart(t *testing.T) {
 	txIDbytes, _ := hex.DecodeString("4a2992fa3af9eb7ff6b94dc9e27e44f29a54ab351ee6377455409b0ebbe1f00c")
 	hash1, err := chainhash.NewHash(txIDbytes)
 	require.NoError(t, err)
+	lockingScriptStr := "d9ad6a3aba0b1cc57071409f3ebc229193647ad43f715e496a91427d6e812c60"
+	wocScript, err := hex.DecodeString(lockingScriptStr)
+	require.NoError(t, err)
+	lockingScript := script.Script(wocScript)
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
@@ -109,7 +113,7 @@ func TestRateBroadcasterStart(t *testing.T) {
 				GetBalanceWithRetriesFunc: func(_ context.Context, _ string, _ time.Duration, _ uint64) (uint64, uint64, error) {
 					return 1000, 0, tc.getBalanceWithRetriesErr
 				},
-				GetUTXOsWithRetriesFunc: func(_ context.Context, lockingScript *script.Script, _ string, _ time.Duration, _ uint64) (sdkTx.UTXOs, error) {
+				GetUTXOsWithRetriesFunc: func(_ context.Context, _ string, _ time.Duration, _ uint64) (sdkTx.UTXOs, error) {
 					if tc.getUTXOsWithRetriesErr != nil {
 						return nil, tc.getUTXOsWithRetriesErr
 					}
@@ -119,7 +123,7 @@ func TestRateBroadcasterStart(t *testing.T) {
 						{
 							TxID:          hash1,
 							Vout:          0,
-							LockingScript: lockingScript,
+							LockingScript: &lockingScript,
 							Satoshis:      1000,
 						},
 					}
@@ -231,6 +235,11 @@ func TestRateBroadcasterStartBroadcast(t *testing.T) {
 	txIDbytes, _ := hex.DecodeString("4a2992fa3af9eb7ff6b94dc9e27e44f29a54ab351ee6377455409b0ebbe1f00c")
 	hash1, err := chainhash.NewHash(txIDbytes)
 	require.NoError(t, err)
+	lockingScriptStr := "d9ad6a3aba0b1cc57071409f3ebc229193647ad43f715e496a91427d6e812c60"
+	wocScript, err := hex.DecodeString(lockingScriptStr)
+	require.NoError(t, err)
+	lockingScript := script.Script(wocScript)
+	require.NoError(t, err)
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
@@ -244,12 +253,12 @@ func TestRateBroadcasterStartBroadcast(t *testing.T) {
 				GetBalanceWithRetriesFunc: func(_ context.Context, _ string, _ time.Duration, _ uint64) (uint64, uint64, error) {
 					return 1000, 0, nil
 				},
-				GetUTXOsWithRetriesFunc: func(_ context.Context, lockingScript *script.Script, _ string, _ time.Duration, _ uint64) (sdkTx.UTXOs, error) {
+				GetUTXOsWithRetriesFunc: func(_ context.Context, _ string, _ time.Duration, _ uint64) (sdkTx.UTXOs, error) {
 					baseUtxo := sdkTx.UTXOs{
 						{
 							TxID:          hash1,
 							Vout:          0,
-							LockingScript: lockingScript,
+							LockingScript: &lockingScript,
 							Satoshis:      1000,
 						},
 					}

--- a/internal/broadcaster/utxo_consolidator.go
+++ b/internal/broadcaster/utxo_consolidator.go
@@ -48,7 +48,7 @@ func (b *UTXOConsolidator) Start(txsRateTxsPerMinute int) error {
 	submitBatchesPerMinute := float64(txsRateTxsPerMinute) / float64(b.batchSize)
 
 	submitBatchInterval := time.Duration(millisecondsPerSecond*60/float64(submitBatchesPerMinute)) * time.Millisecond
-	utxos, err := b.utxoClient.GetUTXOsWithRetries(b.ctx, b.keySet.Script, b.keySet.Address(!b.isTestnet), 1*time.Second, 5)
+	utxos, err := b.utxoClient.GetUTXOsWithRetries(b.ctx, b.keySet.Address(!b.isTestnet), 1*time.Second, 5)
 	if err != nil {
 		return errors.Join(ErrFailedToGetUTXOs, err)
 	}

--- a/internal/broadcaster/utxo_consolidator_test.go
+++ b/internal/broadcaster/utxo_consolidator_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
-	"github.com/bsv-blockchain/go-sdk/script"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
 	chaincfg "github.com/bsv-blockchain/go-sdk/transaction/chaincfg"
 	"github.com/stretchr/testify/require"
@@ -105,7 +104,7 @@ func TestStart(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
 			utxoClient := &mocks.UtxoClientMock{
-				GetUTXOsWithRetriesFunc: func(_ context.Context, _ *script.Script, _ string, _ time.Duration, _ uint64) (sdkTx.UTXOs, error) {
+				GetUTXOsWithRetriesFunc: func(_ context.Context, _ string, _ time.Duration, _ uint64) (sdkTx.UTXOs, error) {
 					return tc.getUTXOsResp, tc.getUTXOsWithRetriesErr
 				},
 			}

--- a/internal/broadcaster/utxo_creator.go
+++ b/internal/broadcaster/utxo_creator.go
@@ -67,7 +67,7 @@ func (b *UTXOCreator) Start(requestedOutputs uint64, requestedSatoshisPerOutput 
 		return errors.Join(ErrRequestedSatoshisTooHigh, fmt.Errorf("requested: %d, balance: %d", requestedOutputsSatoshis, balance))
 	}
 
-	utxos, err := b.utxoClient.GetUTXOsWithRetries(b.ctx, b.keySet.Script, b.keySet.Address(!b.isTestnet), 1*time.Second, 5)
+	utxos, err := b.utxoClient.GetUTXOsWithRetries(b.ctx, b.keySet.Address(!b.isTestnet), 1*time.Second, 5)
 	if err != nil {
 		return errors.Join(ErrFailedToGetUTXOs, err)
 	}

--- a/internal/broadcaster/utxo_creator_test.go
+++ b/internal/broadcaster/utxo_creator_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/bitcoin-sv/arc/pkg/keyset"
 
 	"github.com/bsv-blockchain/go-sdk/chainhash"
-	"github.com/bsv-blockchain/go-sdk/script"
 	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
 	transaction "github.com/bsv-blockchain/go-sdk/transaction/chaincfg"
 	"github.com/stretchr/testify/require"
@@ -75,7 +74,7 @@ func TestUTXOCreator(t *testing.T) {
 
 			mockUtxoClient := &mocks.UtxoClientMock{
 				GetBalanceWithRetriesFunc: tt.getBalanceFunc,
-				GetUTXOsWithRetriesFunc: func(_ context.Context, _ *script.Script, _ string, _ time.Duration, _ uint64) (sdkTx.UTXOs, error) {
+				GetUTXOsWithRetriesFunc: func(_ context.Context, _ string, _ time.Duration, _ uint64) (sdkTx.UTXOs, error) {
 					return tt.getUTXOsResp, nil
 				},
 			}

--- a/pkg/keyset/key_set.go
+++ b/pkg/keyset/key_set.go
@@ -101,7 +101,7 @@ func (k *KeySet) GetUTXOs(mainnet bool) ([]*sdkTx.UTXO, error) {
 	// Get UTXOs from WhatsOnChain
 	woc := woc_client.New(mainnet)
 
-	return woc.GetUTXOs(context.Background(), k.Script, k.Address(mainnet))
+	return woc.GetUTXOs(context.Background(), k.Address(mainnet))
 }
 
 type WocBalance struct {

--- a/pkg/woc_client/woc_client_integration_test.go
+++ b/pkg/woc_client/woc_client_integration_test.go
@@ -1,0 +1,85 @@
+//go:build woc
+
+package woc_client
+
+import (
+	"context"
+	sdkTx "github.com/bsv-blockchain/go-sdk/transaction"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_GetBalanceFromWoC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tt := []struct {
+		name          string
+		address       string
+		responseOk    bool
+		responseBody  any
+		expectedError error
+		expected      sdkTx.UTXOs
+	}{
+		{
+			name:       "response OK",
+			address:    testnetAddr,
+			responseOk: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			sut := New(false, WithURL("https://api.whatsonchain.com/v1/bsv/"))
+
+			// when
+			_, _, err := sut.GetBalance(context.TODO(), tc.address)
+			// then
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func Test_GetUTXOsFromWoC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tt := []struct {
+		name          string
+		address       string
+		responseOk    bool
+		responseBody  any
+		expectedError error
+		expected      sdkTx.UTXOs
+	}{
+		{
+			name:       "response OK",
+			address:    testnetAddr,
+			responseOk: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			sut := New(false, WithURL("https://api.whatsonchain.com/v1/bsv/"))
+			// when
+			_, err := sut.GetUTXOs(context.TODO(), tc.address)
+			// then
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description of Changes

Migrate woc_client endpoints to use the latest (not deprecated) versions of UTXOs and Balance API calls.

## Testing Procedure

- [X] I have added new unit tests
- [X] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
