### PR TITLE
refactor(BPAAS-2178): Remove nolint:revive and review in Sonarcloud instead

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -69,7 +69,7 @@ func run() error {
 	return nil
 }
 
-func startServices(arcConfig *config.ArcConfig, logger *slog.Logger, startAPI bool, startMetamorph bool, startBlockTx bool, startK8sWatcher bool, startCallbacker bool) ([]func(), error) { //nolint:revive //complexity is high due to the go func()
+func startServices(arcConfig *config.ArcConfig, logger *slog.Logger, startAPI bool, startMetamorph bool, startBlockTx bool, startK8sWatcher bool, startCallbacker bool) ([]func(), error) {
 	cacheStore, err := cmd.NewCacheStore(arcConfig.Cache)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cache store: %v", err)

--- a/internal/blocktx/processor.go
+++ b/internal/blocktx/processor.go
@@ -251,7 +251,7 @@ func (p *Processor) RegisterTransaction(txHash []byte) {
 	}
 }
 
-func (p *Processor) StartProcessRegisterTxs() { //nolint:revive //complexity is high due to the go func()
+func (p *Processor) StartProcessRegisterTxs() {
 	p.waitGroup.Add(1)
 	txHashes := make([][]byte, 0, p.registerTxsBatchSize)
 

--- a/internal/broadcaster/utxo_consolidator.go
+++ b/internal/broadcaster/utxo_consolidator.go
@@ -44,7 +44,7 @@ func (b *UTXOConsolidator) Wait() {
 	b.wg.Wait()
 }
 
-func (b *UTXOConsolidator) Start(txsRateTxsPerMinute int) error { //nolint:revive //complexity is high due to the go func
+func (b *UTXOConsolidator) Start(txsRateTxsPerMinute int) error {
 	submitBatchesPerMinute := float64(txsRateTxsPerMinute) / float64(b.batchSize)
 
 	submitBatchInterval := time.Duration(millisecondsPerSecond*60/float64(submitBatchesPerMinute)) * time.Millisecond

--- a/internal/callbacker/processor.go
+++ b/internal/callbacker/processor.go
@@ -191,7 +191,7 @@ func (p *Processor) StartCallbackStoreCleanup(interval, olderThanDuration time.D
 }
 
 // DispatchPersistedCallbacks loads and dispatches persisted callbacks with unmapped URLs in intervals
-func (p *Processor) DispatchPersistedCallbacks() { //nolint:revive //complexity is high due to the go func()
+func (p *Processor) DispatchPersistedCallbacks() {
 	const batchSize = 100
 	ctx := context.Background()
 

--- a/internal/metamorph/processor.go
+++ b/internal/metamorph/processor.go
@@ -283,7 +283,7 @@ func (p *Processor) unlockRecords() error {
 	return nil
 }
 
-func (p *Processor) StartProcessMinedCallbacks() { //nolint:revive //complexity is high due to the go func()
+func (p *Processor) StartProcessMinedCallbacks() {
 	p.waitGroup.Add(1)
 	var txsBlocksBuffer []*blocktx_api.TransactionBlock
 	ticker := time.NewTicker(p.processMinedInterval)
@@ -425,7 +425,7 @@ func (p *Processor) StartProcessSubmitted() {
 	}()
 }
 
-func (p *Processor) StartSendStatusUpdate() { //nolint:revive //complexity is high due to the go func()
+func (p *Processor) StartSendStatusUpdate() {
 	p.waitGroup.Add(1)
 	go func() {
 		defer p.waitGroup.Done()

--- a/internal/metamorph/server.go
+++ b/internal/metamorph/server.go
@@ -542,7 +542,7 @@ func (s *Server) ClearData(ctx context.Context, req *metamorph_api.ClearDataRequ
 	return result, nil
 }
 
-func (s *Server) waitForTxStatus(ctx context.Context, returnedStatus *metamorph_api.TransactionStatus, responseChannel chan StatusAndError, txID string, waitForStatus metamorph_api.Status) *metamorph_api.TransactionStatus { //nolint:revive //complexity is high due to the for loop
+func (s *Server) waitForTxStatus(ctx context.Context, returnedStatus *metamorph_api.TransactionStatus, responseChannel chan StatusAndError, txID string, waitForStatus metamorph_api.Status) *metamorph_api.TransactionStatus {
 	ctx, span := tracing.StartTracing(ctx, "waitForTxStatus", s.tracingEnabled, s.tracingAttributes...)
 	var err error
 	defer func() {

--- a/internal/p2p/peer_manager.go
+++ b/internal/p2p/peer_manager.go
@@ -146,7 +146,7 @@ func (m *PeerManager) GetPeersForAnnouncement() []PeerI {
 	return sendToPeers
 }
 
-func (m *PeerManager) startMonitorPeerHealth(peer PeerI) { //nolint:revive //complexity is high due to the go func()
+func (m *PeerManager) startMonitorPeerHealth(peer PeerI) {
 	m.l.Info("Starting peer health monitoring", slog.String("peer", peer.String()))
 	m.execWg.Add(1)
 

--- a/pkg/api/status.go
+++ b/pkg/api/status.go
@@ -40,7 +40,7 @@ func (e *ErrorFields) GetSpanAttributes() []attribute.KeyValue {
 	return attr
 }
 
-func NewErrorFields(status StatusCode, extraInfo string) *ErrorFields { //nolint:revive //complexity is high due to number of cases
+func NewErrorFields(status StatusCode, extraInfo string) *ErrorFields {
 	emptyString := ""
 	errFields := ErrorFields{
 		Status:    int(status),


### PR DESCRIPTION
## Description of Changes

We are remofing nolint:revive and we will review in Sonarcloud instead not to mask other revive issues 

## Testing Procedure

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation
- [] I have updated `CHANGELOG.md` with my changes
