### PR TITLE
fix(BPAAS-2172): Set locked double spend

### DIFF
--- a/internal/metamorph/store/postgresql/fixtures/set_locked/metamorph.transactions.yaml
+++ b/internal/metamorph/store/postgresql/fixtures/set_locked/metamorph.transactions.yaml
@@ -1,0 +1,20 @@
+- hash: 0x319b5eb9d99084b72002640d1445f49b8c83539260a7e5b2cbb16c1d2954a743
+  locked_by: NONE
+  status: 90
+  stored_at: 2023-10-01 14:00:00
+  last_submitted_at: 2023-10-01 14:00:00
+- hash: 0x12c04cfc5643f1cd25639ad42d6f8f0489557699d92071d7e0a5b940438c4357
+  locked_by: NONE
+  status: 40
+  stored_at: 2023-10-01 14:00:00
+  last_submitted_at: 2023-10-01 14:00:00
+- hash: 0x104d50aba0aa4b7568fcd03c510a8c8e2362c6136768f08a546cb9bb11cf947c
+  locked_by: NONE
+  status: 100
+  stored_at: 2023-10-01 14:00:00
+  last_submitted_at: 2023-10-01 14:00:00
+- hash: 0x78d66c8391ff5e4a65b494e39645facb420b744f77f3f3b83a3aa8573282176e
+  locked_by: NONE
+  status: 50
+  stored_at: 2023-10-01 14:00:00
+  last_submitted_at: 2023-10-01 14:00:00

--- a/internal/metamorph/store/postgresql/postgres.go
+++ b/internal/metamorph/store/postgresql/postgres.go
@@ -544,7 +544,7 @@ func (p *PostgreSQL) SetLocked(ctx context.Context, since time.Time, limit int64
 		);
 	;`
 
-	_, err := p.db.ExecContext(ctx, q, p.hostname, limit, metamorph_api.Status_SEEN_ON_NETWORK, since)
+	_, err := p.db.ExecContext(ctx, q, p.hostname, limit, metamorph_api.Status_DOUBLE_SPEND_ATTEMPTED, since)
 	if err != nil {
 		return err
 	}

--- a/internal/metamorph/store/postgresql/postgres_test.go
+++ b/internal/metamorph/store/postgresql/postgres_test.go
@@ -277,9 +277,9 @@ func TestPostgresDB(t *testing.T) {
 
 	t.Run("set locked by", func(t *testing.T) {
 		defer pruneTables(t, postgresDB.db)
-		testutils.LoadFixtures(t, postgresDB.db, "fixtures/transactions")
+		testutils.LoadFixtures(t, postgresDB.db, "fixtures/set_locked")
 
-		err := postgresDB.SetLocked(ctx, time.Date(2023, 9, 15, 1, 0, 0, 0, time.UTC), 2)
+		err := postgresDB.SetLocked(ctx, time.Date(2023, 9, 15, 1, 0, 0, 0, time.UTC), 3)
 		require.NoError(t, err)
 
 		// locked by NONE
@@ -288,23 +288,29 @@ func TestPostgresDB(t *testing.T) {
 		// locked by NONE
 		expectedHash3 := testutils.RevChainhash(t, "319b5eb9d99084b72002640d1445f49b8c83539260a7e5b2cbb16c1d2954a743")
 
-		// check if previously unlocked tx has b
 		// locked by NONE
-		expectedHash4 := testutils.RevChainhash(t, "78d66c8391ff5e4a65b494e39645facb420b744f77f3f3b83a3aa8573282176e")
+		expectedHash4 := testutils.RevChainhash(t, "104d50aba0aa4b7568fcd03c510a8c8e2362c6136768f08a546cb9bb11cf947c")
+
+		// locked by NONE
+		expectedHash5 := testutils.RevChainhash(t, "78d66c8391ff5e4a65b494e39645facb420b744f77f3f3b83a3aa8573282176e")
 
 		// check if previously unlocked tx has been locked
 		dataReturned, err := postgresDB.Get(ctx, expectedHash2[:])
 		require.NoError(t, err)
-		require.Equal(t, "metamorph-1", dataReturned.LockedBy)
+		assert.Equal(t, "metamorph-1", dataReturned.LockedBy)
 
 		dataReturned, err = postgresDB.Get(ctx, expectedHash3[:])
 		require.NoError(t, err)
-		require.Equal(t, "metamorph-1", dataReturned.LockedBy)
+		assert.Equal(t, "metamorph-1", dataReturned.LockedBy)
 
-		// this unlocked tx remains unlocked as the limit was 2
 		dataReturned, err = postgresDB.Get(ctx, expectedHash4[:])
 		require.NoError(t, err)
-		require.Equal(t, "NONE", dataReturned.LockedBy)
+		assert.Equal(t, "metamorph-1", dataReturned.LockedBy)
+
+		// this unlocked tx remains unlocked as the limit was 2
+		dataReturned, err = postgresDB.Get(ctx, expectedHash5[:])
+		require.NoError(t, err)
+		assert.Equal(t, "NONE", dataReturned.LockedBy)
 	})
 
 	t.Run("set unlocked by name", func(t *testing.T) {


### PR DESCRIPTION
## Description of Changes

Include `DOUBLE_SPEND_ATTEMPTED` status when setting locked transactions to avoid them not being marked as REJECTED in case of restart inbetween https://github.com/bitcoin-sv/arc/issues/900

## Testing Procedure

- [X] I have added new unit tests
- [x] All tests pass locally
- [X] I have tested manually in my local environment

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
