### PR TITLE
feat(BPAAS-2239): skip beef validation

### DIFF
--- a/internal/api/handler/default.go
+++ b/internal/api/handler/default.go
@@ -416,6 +416,7 @@ func (m *ArcDefaultHandler) postTransactions(ctx echo.Context, txsHex []byte, pa
 			}
 		} else if len(txStatuses) == len(txIDs) {
 			// if found all the transactions found, skip the validation
+			fmt.Println("shota setting true")
 			transactionOptions.SkipTxValidation = true
 
 			// check if processing of the transaction can be skipped
@@ -773,9 +774,10 @@ func (m *ArcDefaultHandler) validateBEEFTransaction(ctx context.Context, beefTx 
 	}()
 
 	if options.SkipTxValidation {
+		fmt.Println("shota skipping validating")
 		return nil
 	}
-
+	fmt.Println("shota validating")
 	feeOpts, scriptOpts := toValidationOpts(options)
 
 	failedTx, err := m.beefValidator.ValidateTransaction(ctx, beefTx, feeOpts, scriptOpts)

--- a/test/submit_04_beef_test.go
+++ b/test/submit_04_beef_test.go
@@ -99,6 +99,7 @@ func TestBeef(t *testing.T) {
 			}
 		}()
 
+		fmt.Println("shota test starting ...")
 		waitForStatusTimeoutSeconds := 30
 
 		// when

--- a/test/submit_04_beef_test.go
+++ b/test/submit_04_beef_test.go
@@ -110,6 +110,13 @@ func TestBeef(t *testing.T) {
 			"X-MaxTimeout":    strconv.Itoa(waitForStatusTimeoutSeconds),
 		}, http.StatusOK)
 
+		resp = postRequest[TransactionResponse](t, arcEndpointV1Tx, createPayload(t, TransactionRequest{RawTx: beef3}), map[string]string{
+			"X-WaitFor":       StatusSeenOnNetwork,
+			"X-CallbackUrl":   callbackURL,
+			"X-CallbackToken": token,
+			"X-MaxTimeout":    strconv.Itoa(waitForStatusTimeoutSeconds),
+		}, http.StatusOK)
+
 		// then
 		require.Equal(t, StatusSeenOnNetwork, resp.TxStatus)
 
@@ -117,6 +124,7 @@ func TestBeef(t *testing.T) {
 
 		time.Sleep(200 * time.Millisecond)
 
+		require.Equal(t, tx3.TxID(), tx2.TxID())
 		statusURL := fmt.Sprintf("%s/%s", arcEndpointV1Tx, tx3.TxID())
 		statusResp := getRequest[TransactionResponse](t, statusURL)
 		require.Equal(t, StatusMined, statusResp.TxStatus)


### PR DESCRIPTION
## Description of Changes

**NOTHING TO MERGE  HERE**

I checked the code and even with beef we still set skipping validation to true. Also checked it in e2e tests and on the second submit validation is skipped. you will see those logs to confirm:

`tests-1       | shota test starting ...`
`api-1         | shota validating`
`api-1         | shota setting true`
`api-1         | shota skipping validating`

## Testing Procedure

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
