### PR TITLE
fix(BPAAS-2310): reduce default store and send intervals

### DIFF
--- a/internal/callbacker/processor.go
+++ b/internal/callbacker/processor.go
@@ -24,9 +24,9 @@ const (
 	singleSendDefault             = 5 * time.Second
 	expirationDefault             = 24 * time.Hour
 	batchSendIntervalDefault      = 5 * time.Second
-	storeCallbacksIntervalDefault = 5 * time.Second
+	storeCallbacksIntervalDefault = 2 * time.Second
 	storeCallbackBatchSizeDefault = 500
-	sendCallbacksInterval         = 5 * time.Second
+	sendCallbacksInterval         = 2 * time.Second
 )
 
 type Processor struct {


### PR DESCRIPTION
## Description of Changes

Reduce default store and send intervals

## Testing Procedure

- [ ] I have added new unit tests
- [x] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated `CHANGELOG.md` with my changes
